### PR TITLE
[BUG FIX] Safe environment configuration

### DIFF
--- a/env/env.go
+++ b/env/env.go
@@ -19,10 +19,12 @@ package env
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/Peripli/service-manager/server"
 	"github.com/fatih/structs"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -49,12 +51,20 @@ func New(file *ConfigFile, envPrefix string) server.Environment {
 }
 
 func (v *viperEnv) Load() error {
-	v.Viper.AddConfigPath(v.configFile.Path)
-	v.Viper.SetConfigName(v.configFile.Name)
-	v.Viper.SetConfigType(v.configFile.Format)
 	v.Viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.Viper.SetEnvPrefix(v.envPrefix)
 	v.Viper.AutomaticEnv()
+
+	configFilePath := v.configFile.Path + "/" + v.configFile.Name + "." + v.configFile.Format
+	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
+		logrus.WithError(err).Error("Configuration file missing: ", configFilePath)
+		return nil
+	}
+
+	v.Viper.AddConfigPath(v.configFile.Path)
+	v.Viper.SetConfigName(v.configFile.Name)
+	v.Viper.SetConfigType(v.configFile.Format)
+
 	if err := v.Viper.ReadInConfig(); err != nil {
 		return fmt.Errorf("could not read configuration file: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func handleInterrupts(ctx context.Context, cancelFunc context.CancelFunc) {
 }
 
 func initFlags() map[string]interface{} {
-	configFileLocation := flag.String("config_location", ".", "Location of the application.yaml file")
+	configFileLocation := flag.String("config_location", ".", "Location of the application.yml file")
 	flag.Parse()
 	return map[string]interface{}{"config_location": *configFileLocation}
 }

--- a/server/config.go
+++ b/server/config.go
@@ -89,7 +89,11 @@ func NewConfiguration(env Environment) (*Config, error) {
 		return nil, err
 	}
 
-	configSettings := &Settings{}
+	configSettings := &Settings{
+		Server: &AppSettings{},
+		Db:     &DbSettings{},
+		Log:    &LogSettings{},
+	}
 	if err := env.Unmarshal(configSettings); err != nil {
 		return nil, err
 	}

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -1,7 +1,7 @@
 server:
   port: 1234
 db:
-  uri: postgres://postgres@localhost:5432/postgres?sslmode=disable
+  uri: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
 log:
   level: debug
 token_issuer_url: https://example.com


### PR DESCRIPTION
# Safe environment configuration

Currently if any of the expected environment variables is omitted from the **application.yml** file, or if this file doesn't exist at all, the application startup will crash.

This PR suggests changes for ensuring safe loading of the environment configuration even if **application.yml** is not configured properly or is missing.