### PR TITLE
Use vendor-only on dep install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
 
 before_install:
   - go get -u github.com/golang/dep/cmd/dep
-  - dep ensure
+  - dep ensure --vendor-only -v
 
 install:
   - go get github.com/alecthomas/gometalinter


### PR DESCRIPTION
## Motivation
The build should be faster.

## Approach
Adding --vendor-only to speedup the dependency installation.

#### Pull Request status
- [n/a] Initial implementation
- [n/a] Refactoring
- [n/a] Unit tests
- [n/a] Integration tests

## Third-party code
N/A
