### PR TITLE
Respect PORT when running in CF

### DIFF
--- a/cf/env_test.go
+++ b/cf/env_test.go
@@ -95,7 +95,7 @@ var _ = Describe("CF Env", func() {
 			It("returns no error", func() {
 				Expect(os.Unsetenv("VCAP_APPLICATION")).ShouldNot(HaveOccurred())
 
-				Expect(SetEnvValues(env)).ShouldNot(HaveOccurred())
+				Expect(SetCFOverrides(env)).ShouldNot(HaveOccurred())
 				Expect(env.Get("store.uri")).Should(BeNil())
 			})
 		})
@@ -105,7 +105,7 @@ var _ = Describe("CF Env", func() {
 				It("returns no error", func() {
 					Expect(os.Unsetenv("STORAGE_NAME")).ShouldNot(HaveOccurred())
 
-					Expect(SetEnvValues(env)).ShouldNot(HaveOccurred())
+					Expect(SetCFOverrides(env)).ShouldNot(HaveOccurred())
 					Expect(env.Get("storage.name")).Should(BeNil())
 					Expect(env.Get("storage.uri")).Should(BeNil())
 
@@ -116,8 +116,8 @@ var _ = Describe("CF Env", func() {
 				It("returns error", func() {
 					Expect(os.Setenv("STORAGE_NAME", "missing")).ShouldNot(HaveOccurred())
 
-					err := SetEnvValues(env)
-					Expect(SetEnvValues(env)).Should(HaveOccurred())
+					err := SetCFOverrides(env)
+					Expect(SetCFOverrides(env)).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("could not find service with name"))
 				})
 			})
@@ -126,7 +126,7 @@ var _ = Describe("CF Env", func() {
 				It("returns error", func() {
 					Expect(os.Setenv("VCAP_SERVICES", "Invalid")).ShouldNot(HaveOccurred())
 
-					Expect(SetEnvValues(env)).Should(HaveOccurred())
+					Expect(SetCFOverrides(env)).Should(HaveOccurred())
 				})
 			})
 
@@ -134,12 +134,12 @@ var _ = Describe("CF Env", func() {
 				It("returns error", func() {
 					Expect(os.Unsetenv("VCAP_SERVICES")).ShouldNot(HaveOccurred())
 
-					Expect(SetEnvValues(env)).Should(HaveOccurred())
+					Expect(SetCFOverrides(env)).Should(HaveOccurred())
 				})
 			})
 
 			It("sets the storage.uri if successful", func() {
-				Expect(SetEnvValues(env)).ShouldNot(HaveOccurred())
+				Expect(SetCFOverrides(env)).ShouldNot(HaveOccurred())
 
 				Expect(env.Get("storage.uri")).ShouldNot(BeEmpty())
 			})

--- a/config/config.go
+++ b/config/config.go
@@ -55,7 +55,6 @@ type File struct {
 func DefaultSettings() *Settings {
 	config := &Settings{
 		Server: server.Settings{
-			Host:            "127.0.0.1",
 			Port:            8080,
 			RequestTimeout:  time.Millisecond * time.Duration(3000),
 			ShutdownTimeout: time.Millisecond * time.Duration(3000),

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	if err != nil {
 		panic(fmt.Sprintf("error loading environment: %s", err))
 	}
-	if err := cf.SetEnvValues(env); err != nil {
+	if err := cf.SetCFOverrides(env); err != nil {
 		panic(fmt.Sprintf("error setting CF environment values: %s", err))
 	}
 	cfg, err := config.New(env)

--- a/server/server.go
+++ b/server/server.go
@@ -33,7 +33,6 @@ import (
 
 // Settings type to be loaded from the environment
 type Settings struct {
-	Host            string
 	Port            int
 	RequestTimeout  time.Duration
 	ShutdownTimeout time.Duration
@@ -63,7 +62,7 @@ func New(api rest.API, config Settings) (*Server, error) {
 func (s *Server) Run(ctx context.Context) {
 	handler := &http.Server{
 		Handler:      s.Router,
-		Addr:         s.Config.Host + ":" + strconv.Itoa(s.Config.Port),
+		Addr:         ":" + strconv.Itoa(s.Config.Port),
 		WriteTimeout: s.Config.RequestTimeout,
 		ReadTimeout:  s.Config.RequestTimeout,
 	}


### PR DESCRIPTION
Currently SM does not respect CF's PORT env variable and instead starts the process on a port of its own desire (defaults to 8080, picked up from application.yml). If CF picks a different port for the SM process, this leads to CF health check failure. 

This seems to have appeared after switching from running a docker container to using the go buildpack.