### PR TITLE
Fix: wrong path when broker has a url path suffix

### DIFF
--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -76,7 +76,7 @@ func (c *Controller) handler(request *web.Request) (*web.Response, error) {
 	if m == nil || len(m) < 2 {
 		return nil, fmt.Errorf("could not get OSB path from URL %s", request.URL.Path)
 	}
-	modifiedRequest.URL.Path = m[1]
+	modifiedRequest.URL.Path = target.Path + m[1]
 
 	logrus.Debugf("Forwarding OSB request to %s", modifiedRequest.URL)
 	recorder := httptest.NewRecorder()

--- a/test/osb_test/osb_test.go
+++ b/test/osb_test/osb_test.go
@@ -17,16 +17,17 @@ package osb_test
 
 import (
 	"net/http"
+
 	"github.com/Peripli/service-manager/test/common"
 	"github.com/gavv/httpexpect"
 
-	. "github.com/onsi/ginkgo"
-	"testing"
 	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
 )
 
 type object = common.Object
-
 
 // TestOSB tests for OSB API
 func TestOSB(t *testing.T) {
@@ -220,14 +221,38 @@ var _ = Describe("Service Manager OSB API", func() {
 		}
 
 		Context("For service instance", func() {
-			It("should return state", func(){
-				assertLastOperationHasState(validBroker.OSBURL+ "/v2/service_instances/iid/last_operation")
+			It("should return state", func() {
+				assertLastOperationHasState(validBroker.OSBURL + "/v2/service_instances/iid/last_operation")
 			})
 		})
 
 		Context("For service binding", func() {
 			It("should return state", func() {
-				assertLastOperationHasState(validBroker.OSBURL+ "/v2/service_instances/iid/service_bindings/bid/last_operation")
+				assertLastOperationHasState(validBroker.OSBURL + "/v2/service_instances/iid/service_bindings/bid/last_operation")
+			})
+		})
+	})
+
+	Describe("Prefixed broker path", func() {
+
+		Describe("Catalog", func() {
+
+			BeforeEach(func() {
+				ctx = common.NewTestContextFromAPIs()
+				validBroker = ctx.RegisterBroker("broker1", common.SetupFakeServiceBrokerServerWithPrefix("broker1", "/sm"))
+			})
+
+			AfterEach(func() {
+				ctx.Cleanup()
+			})
+
+			Context("when call to working broker", func() {
+				It("should get catalog", func() {
+					resp := ctx.SMWithBasic.GET(validBroker.OSBURL+"/v2/catalog").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+						Expect().Status(http.StatusOK).JSON().Object()
+
+					resp.ContainsKey("services")
+				})
 			})
 		})
 	})


### PR DESCRIPTION
## Motivation
*When a broker is registered with path suffix. For example: http://broker.com/sm.
Normally calls should go to http://broker.com/sm/v2/catalog for getting the catalog.*

- [x] Initial implementation
- [x] Unit tests
