### PR TITLE
Trim broker URL before persisting

### DIFF
--- a/api/broker/broker_controller.go
+++ b/api/broker/broker_controller.go
@@ -32,7 +32,6 @@ import (
 	"github.com/Peripli/service-manager/storage"
 	"github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
-	"path/filepath"
 )
 
 const (
@@ -67,7 +66,7 @@ func (c *Controller) createBroker(request *web.Request) (*web.Response, error) {
 	currentTime := time.Now().UTC()
 	broker.CreatedAt = currentTime
 	broker.UpdatedAt = currentTime
-	broker.BrokerURL = filepath.Clean(broker.BrokerURL)
+	broker.BrokerURL = strings.TrimRight(broker.BrokerURL, "/")
 
 	catalog, err := c.getBrokerCatalog(broker)
 	if err != nil {

--- a/api/broker/broker_controller.go
+++ b/api/broker/broker_controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/Peripli/service-manager/storage"
 	"github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
+	"path/filepath"
 )
 
 const (
@@ -66,6 +67,7 @@ func (c *Controller) createBroker(request *web.Request) (*web.Response, error) {
 	currentTime := time.Now().UTC()
 	broker.CreatedAt = currentTime
 	broker.UpdatedAt = currentTime
+	broker.BrokerURL = filepath.Clean(broker.BrokerURL)
 
 	catalog, err := c.getBrokerCatalog(broker)
 	if err != nil {

--- a/api/broker/broker_controller.go
+++ b/api/broker/broker_controller.go
@@ -66,6 +66,7 @@ func (c *Controller) createBroker(request *web.Request) (*web.Response, error) {
 	currentTime := time.Now().UTC()
 	broker.CreatedAt = currentTime
 	broker.UpdatedAt = currentTime
+
 	broker.BrokerURL = strings.TrimRight(broker.BrokerURL, "/")
 
 	catalog, err := c.getBrokerCatalog(broker)


### PR DESCRIPTION
# Trim broker URL before persisting

This pull request suggests trimming broker URLs and thus removing any trailing forward slashes before persisting any broker.

The need for this PR arises from the fact that in a Kubernetes environment (possibly in other platforms in the future as well) the Service Catalog fails to retrieve broker catalogs for brokers that have a URL with trailing forward slashes("/").
