### PR TITLE
fix creation of reverse proxy

### DIFF
--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -17,14 +17,15 @@
 package osb
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
-	"net/http/httputil"
 	"net/url"
 	"regexp"
+
+	"net/http/httputil"
+
+	"net/http/httptest"
 
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/pkg/util"
@@ -51,47 +52,44 @@ func (c *Controller) handler(request *web.Request) (*web.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	target, _ := url.Parse(broker.BrokerURL)
 
-	reverseProxy := httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.Host = target.Host
-		},
+	target, err := url.Parse(broker.BrokerURL)
+	if err != nil {
+		return nil, err
 	}
 
 	username, password := broker.Credentials.Basic.Username, broker.Credentials.Basic.Password
-
-	modifiedRequest := request.Request.WithContext(request.Context())
 	plaintextPassword, err := c.Encrypter.Decrypt([]byte(password))
 	if err != nil {
 		return nil, err
 	}
-	modifiedRequest.SetBasicAuth(username, string(plaintextPassword))
-	modifiedRequest.URL.Scheme = target.Scheme
-	modifiedRequest.URL.Host = target.Host
-	modifiedRequest.Body = ioutil.NopCloser(bytes.NewReader(request.Body))
-	modifiedRequest.ContentLength = int64(len(request.Body))
 
 	m := osbPathPattern.FindStringSubmatch(request.URL.Path)
 	if m == nil || len(m) < 2 {
 		return nil, fmt.Errorf("could not get OSB path from URL %s", request.URL.Path)
 	}
-	modifiedRequest.URL.Path = target.Path + m[1]
+
+	modifiedRequest := request.Request.WithContext(request.Context())
+	modifiedRequest.SetBasicAuth(username, string(plaintextPassword))
+	modifiedRequest.Host = target.Host
+	modifiedRequest.URL.Path = m[1]
 
 	logrus.Debugf("Forwarding OSB request to %s", modifiedRequest.URL)
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
 	recorder := httptest.NewRecorder()
-	reverseProxy.ServeHTTP(recorder, modifiedRequest)
+
+	proxy.ServeHTTP(recorder, modifiedRequest)
 
 	body, err := ioutil.ReadAll(recorder.Body)
 	if err != nil {
 		return nil, err
 	}
 
-	headers := recorder.HeaderMap
 	resp := &web.Response{
 		StatusCode: recorder.Code,
 		Body:       body,
-		Header:     headers,
+		Header:     recorder.HeaderMap,
 	}
 	logrus.Debugf("Service broker replied with status %d", resp.StatusCode)
 	return resp, nil


### PR DESCRIPTION
Reverse proxy creation reuses the httputil.NewSingleReverseProxy method's director to handle additional slashes