### PR TITLE
Filter blacklisting

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -40,6 +40,12 @@ type Security struct {
 	EncryptionKey string `mapstructure:"encryption_key"`
 }
 
+// Filters is the configuration used for filter settings
+type Filters struct {
+	// Blacklist holds the names of filters to be excluded
+	Blacklist []string `mapstructure:"blacklist"`
+}
+
 // Validate validates the API Security settings
 func (s *Security) Validate() error {
 	if len(s.EncryptionKey) != 32 {
@@ -54,6 +60,7 @@ type Settings struct {
 	ClientID          string   `mapstructure:"client_id"`
 	Security          Security `mapstructure:"security"`
 	SkipSSLValidation bool     `mapstructure:"skip_ssl_validation"`
+	Filters           Filters  `mapstructure:"filters"`
 }
 
 // Validate validates the API settings

--- a/application.yml
+++ b/application.yml
@@ -15,4 +15,6 @@ api:
   security:
     encryption_key: ejHjRNHbS0NaqARSRvnweVV9zcmhQEa8
   skip_ssl_validation: false
+  filters:
+    blacklist: []
 

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,9 @@ func DefaultSettings() *Settings {
 				EncryptionKey: "",
 			},
 			SkipSSLValidation: false,
+			Filters: api.Filters{
+				Blacklist: []string{},
+			},
 		},
 	}
 	return config

--- a/pkg/web/matcher.go
+++ b/pkg/web/matcher.go
@@ -35,7 +35,7 @@ func Methods(methods ...string) Matcher {
 			return false, errEmptyHTTPMethods
 		}
 		method := endpoint.Method
-		return matchInArray(methods, method), nil
+		return MatchInArray(methods, method), nil
 	})
 }
 
@@ -61,7 +61,7 @@ func Path(patterns ...string) Matcher {
 
 }
 
-func matchInArray(arr []string, value string) bool {
+func MatchInArray(arr []string, value string) bool {
 	for _, v := range arr {
 		if v == value {
 			return true

--- a/pkg/web/matcher.go
+++ b/pkg/web/matcher.go
@@ -61,6 +61,7 @@ func Path(patterns ...string) Matcher {
 
 }
 
+// MatchInArray returns true if the given array contains the provided string value
 func MatchInArray(arr []string, value string) bool {
 	for _, v := range arr {
 		if v == value {

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -13,3 +13,5 @@ api:
   skip_ssl_validation: false
   security:
     encryption_key: ejHjRNHbS0NaqARSRvnweVV9zcmhQEa8
+   filters:
+      blacklist: []

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -13,5 +13,5 @@ api:
   skip_ssl_validation: false
   security:
     encryption_key: ejHjRNHbS0NaqARSRvnweVV9zcmhQEa8
-   filters:
-      blacklist: []
+  filters:
+    blacklist: []

--- a/test/sm/sm_test.go
+++ b/test/sm/sm_test.go
@@ -32,10 +32,15 @@ import (
 
 	"errors"
 
+	"github.com/Peripli/service-manager/api"
 	"github.com/Peripli/service-manager/api/healthcheck"
+	"github.com/Peripli/service-manager/config"
+	"github.com/Peripli/service-manager/pkg/env"
 	"github.com/Peripli/service-manager/pkg/env/envfakes"
 	"github.com/Peripli/service-manager/pkg/sm"
 	"github.com/Peripli/service-manager/pkg/web"
+	"github.com/Peripli/service-manager/security/securityfakes"
+	"github.com/Peripli/service-manager/storage/storagefakes"
 	"github.com/Peripli/service-manager/test/common"
 )
 
@@ -49,6 +54,8 @@ var _ = Describe("SM", func() {
 		serviceManagerServer *httptest.Server
 		ctx                  context.Context
 		cancel               context.CancelFunc
+		defaultSMEnvironment env.Environment
+		defaultSMFilters     []web.Filter
 	)
 
 	BeforeSuite(func() {
@@ -56,6 +63,8 @@ var _ = Describe("SM", func() {
 		ctx, cancel = context.WithCancel(context.Background())
 		os.Chdir("../..")
 		os.Setenv("FILE_LOCATION", "test/common")
+
+		defaultSMFilters = retrieveDefaultSMFilters()
 	})
 
 	AfterSuite(func() {
@@ -65,6 +74,7 @@ var _ = Describe("SM", func() {
 
 	BeforeEach(func() {
 		os.Setenv("API_TOKEN_ISSUER_URL", common.SetupFakeOAuthServer().URL)
+		defaultSMEnvironment = sm.DefaultEnv()
 	})
 
 	AfterEach(func() {
@@ -125,6 +135,66 @@ var _ = Describe("SM", func() {
 			})
 		})
 
+		Context("When no filter are blacklisted", func() {
+			It("should return working service manager with all default filters registered", func() {
+				smanager := sm.New(ctx, cancel, sm.DefaultEnv())
+				actualFiltersRegistered := smanager.API.Filters
+
+				Expect(len(actualFiltersRegistered)).To(Equal(len(defaultSMFilters)))
+				verifyServiceManagerStartsSuccessFully(httptest.NewServer(smanager.Build().Server.Router))
+			})
+		})
+
+		Context("When an invalid filter is blacklisted", func() {
+			It("should return working service manager with all default filters registered", func() {
+				filterToExclude := "abc"
+				defaultSMEnvironment.Set("api.filters.blacklist", []string{filterToExclude})
+
+				smanager := sm.New(ctx, cancel, defaultSMEnvironment)
+				actualFiltersRegistered := smanager.API.Filters
+
+				Expect(len(actualFiltersRegistered)).To(Equal(len(defaultSMFilters)))
+				for _, filter := range actualFiltersRegistered {
+					Expect(filter.Name()).ShouldNot(Equal(filterToExclude))
+				}
+				verifyServiceManagerStartsSuccessFully(httptest.NewServer(smanager.Build().Server.Router))
+			})
+		})
+
+		Context("When a valid filter is blacklisted", func() {
+			It("should return working service manager with all default filters registered except for the blacklisted one", func() {
+				filterToExclude := defaultSMFilters[0]
+
+				defaultSMEnvironment.Set("api.filters.blacklist", []string{filterToExclude.Name()})
+				smanager := sm.New(ctx, cancel, defaultSMEnvironment)
+
+				actualFiltersRegistered := smanager.API.Filters
+
+				Expect(len(actualFiltersRegistered)).Should(BeNumerically("<", len(defaultSMFilters)))
+				for _, filter := range actualFiltersRegistered {
+					Expect(filter.Name()).ShouldNot(Equal(filterToExclude))
+				}
+				verifyServiceManagerStartsSuccessFully(httptest.NewServer(smanager.Build().Server.Router))
+			})
+		})
+
+		Context("When all default filters are blacklisted", func() {
+			It("should return working service manager no filters registered", func() {
+				filtersToExclude := make([]string, len(defaultSMFilters))
+				for i, filter := range defaultSMFilters {
+					filtersToExclude[i] = filter.Name()
+				}
+
+				defaultSMEnvironment.Set("api.filters.blacklist", filtersToExclude)
+				smanager := sm.New(ctx, cancel, defaultSMEnvironment)
+
+				actualFiltersRegistered := smanager.API.Filters
+
+				Expect(len(actualFiltersRegistered)).To(Equal(0))
+				verifyServiceManagerStartsSuccessFully(httptest.NewServer(smanager.Build().Server.Router))
+			})
+		})
+
 		Context("when additional filter is registered", func() {
 			It("should return working service manager with a new filter", func() {
 				smanager := sm.New(ctx, cancel, sm.DefaultEnv())
@@ -153,6 +223,18 @@ var _ = Describe("SM", func() {
 		})
 	})
 })
+
+func retrieveDefaultSMFilters() []web.Filter {
+	mockOauthServer := common.SetupFakeOAuthServer()
+	defaultAPISettings := config.DefaultSettings().API
+	defaultAPISettings.TokenIssuerURL = mockOauthServer.URL
+	defaultAPISettings.ClientID = "cf"
+
+	defaultAPI, _ := api.New(context.Background(), &storagefakes.FakeStorage{}, defaultAPISettings, &securityfakes.FakeEncrypter{})
+
+	mockOauthServer.Close()
+	return defaultAPI.Filters
+}
 
 func verifyServiceManagerStartsSuccessFully(serviceManagerServer *httptest.Server) *httpexpect.Expect {
 	SM := httpexpect.New(GinkgoT(), serviceManagerServer.URL)

--- a/test/sm/sm_test.go
+++ b/test/sm/sm_test.go
@@ -135,7 +135,7 @@ var _ = Describe("SM", func() {
 			})
 		})
 
-		Context("When no filter are blacklisted", func() {
+		Context("When no filters are blacklisted", func() {
 			It("should return working service manager with all default filters registered", func() {
 				smanager := sm.New(ctx, cancel, sm.DefaultEnv())
 				actualFiltersRegistered := smanager.API.Filters
@@ -161,7 +161,7 @@ var _ = Describe("SM", func() {
 			})
 		})
 
-		Context("When a valid filter is blacklisted", func() {
+		Context("When a valid default filter is blacklisted", func() {
 			It("should return working service manager with all default filters registered except for the blacklisted one", func() {
 				filterToExclude := defaultSMFilters[0]
 


### PR DESCRIPTION
# Filter blacklisting

## Motivation
This PR proposes adding a filter blacklist which is used to exclude filters by name when the Service Manager is being setup.

This would ease local development and allow for more flexibility.

#### Pull Request status

- [x] Initial implementation
- [x] Fix old tests
- [x] Unit tests
