### PR TITLE
Allow for custom filter ordering in test context

### DIFF
--- a/api/filters/authn/authn_test.go
+++ b/api/filters/authn/authn_test.go
@@ -228,7 +228,6 @@ var _ = Describe("Authn", func() {
 
 	Describe("Authentication Required Middleware", func() {
 		var (
-			fakeHandler         *webfakes.FakeHandler
 			authnRequiredFilter *RequiredAuthnFilter
 		)
 
@@ -237,7 +236,6 @@ var _ = Describe("Authn", func() {
 		}
 
 		BeforeEach(func() {
-			fakeHandler = &webfakes.FakeHandler{}
 			authnRequiredFilter = NewRequiredAuthnFilter()
 		})
 

--- a/api/filters/authn/required.go
+++ b/api/filters/authn/required.go
@@ -5,6 +5,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const RequiredAuthenticationFilterName = "RequiredAuthenticationFilter"
+
 // RequiredAuthnFilter type verifies that authentication has been performed for APIs that are secured
 type RequiredAuthnFilter struct {
 }
@@ -16,7 +18,7 @@ func NewRequiredAuthnFilter() *RequiredAuthnFilter {
 
 // Name implements the web.Filter interface and returns the identifier of the filter
 func (raf *RequiredAuthnFilter) Name() string {
-	return "RequiredAuthenticationFilter"
+	return RequiredAuthenticationFilterName
 }
 
 // Run implements web.Filter and represents the authentication middleware function that verifies the user is

--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -63,7 +63,7 @@ func SendRequest(doRequest DoRequestFunc, method, url string, params map[string]
 func BodyToBytes(closer io.ReadCloser) ([]byte, error) {
 	defer func() {
 		if err := closer.Close(); err != nil {
-			logrus.Errorf("ReadCloser couldn't be closed", err)
+			logrus.Errorf("ReadCloser couldn't be closed: %v", err)
 		}
 	}()
 

--- a/pkg/web/api.go
+++ b/pkg/web/api.go
@@ -34,7 +34,7 @@ type API struct {
 	Filters []Filter
 }
 
-// pluginSegment represents one piece of a web.invalidPlugin. Each web.invalidPlugin is decomposed into as many plugin segments as
+// pluginSegment represents one piece of a web.Plugin. Each web.Plugin is decomposed into as many plugin segments as
 // the count of OSB operations it provides. Each pluginSegment is treated as a web.Filter.
 type pluginSegment struct {
 	NameValue          string
@@ -84,28 +84,32 @@ func (api *API) RegisterFilters(filters ...Filter) {
 	api.Filters = append(api.Filters, filters...)
 }
 
-// RegisterFilterBefore registers the specified filter before the one with the given name.
+// RegisterFiltersBefore registers the specified filters before the one with the given name.
 // If for some routes, the filter with the given name does not match the routes of the provided filter, then
-// the filter will be registered at the place at which the filter with this name would have been, had it been
+// the filters will be registered at the place at which the filter with this name would have been, had it been
 // configured to match route.
-func (api *API) RegisterFilterBefore(beforeFilterName string, filter Filter) {
-	logrus.Debugf("Registering filter %s before %s", filter.Name(), beforeFilterName)
-	api.validateFilters(filter)
-	api.registerFilterRelatively(beforeFilterName, filter, func(beforeFilterPosition int) int {
-		return beforeFilterPosition
-	})
+func (api *API) RegisterFiltersBefore(beforeFilterName string, filters ...Filter) {
+	for _, filter := range filters {
+		logrus.Debugf("Registering filter %s before %s", filter.Name(), beforeFilterName)
+		api.validateFilters(filter)
+		api.registerFilterRelatively(beforeFilterName, filter, func(beforeFilterPosition int) int {
+			return beforeFilterPosition
+		})
+	}
 }
 
-// RegisterFilterAfter registers the specified filter after the one with the given name.
+// RegisterFiltersAfter registers the specified filter after the one with the given name.
 // If for some routes, the filter with the given name does not match the routes of the provided filter, then
 // the filter will be registered after the place at which the filter with this name would have been, had it been
 // configured to match route.
-func (api *API) RegisterFilterAfter(afterFilterName string, filter Filter) {
-	logrus.Debugf("Registering filter %s after %s", filter.Name(), afterFilterName)
-	api.validateFilters(filter)
-	api.registerFilterRelatively(afterFilterName, filter, func(filterPosition int) int {
-		return filterPosition + 1
-	})
+func (api *API) RegisterFiltersAfter(afterFilterName string, filters ...Filter) {
+	for i, filter := range filters {
+		logrus.Debugf("Registering filter %s after %s", filter.Name(), afterFilterName)
+		api.validateFilters(filter)
+		api.registerFilterRelatively(afterFilterName, filter, func(filterPosition int) int {
+			return filterPosition + 1 + i
+		})
+	}
 }
 
 // ReplaceFilter registers the given filter in the place of the filter with the given name.
@@ -147,7 +151,7 @@ func (api *API) validateFilters(filters ...Filter) {
 		logrus.Panicf("Filters %q are already registered", commonFilterNames)
 	}
 	filterNamesWithColon := slice.StringsContaining(newFilterNames, ":")
-	if  len(filterNamesWithColon) > 0 {
+	if len(filterNamesWithColon) > 0 {
 		logrus.Panicf("Cannot register filters with : in their names. Invalid filter names: %q", filterNamesWithColon)
 	}
 }

--- a/pkg/web/api_test.go
+++ b/pkg/web/api_test.go
@@ -17,7 +17,7 @@
 package web_test
 
 import (
-		"github.com/Peripli/service-manager/pkg/web"
+	"github.com/Peripli/service-manager/pkg/web"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -100,21 +100,29 @@ var _ = Describe("API", func() {
 		Context("When filter with such name does not exist", func() {
 			It("Panics", func() {
 				replaceFilter := func() {
-					api.RegisterFilterBefore("some-filter", &testFilter{"testFilter"})
+					api.RegisterFiltersBefore("some-filter", &testFilter{"testFilter"})
 				}
 				Expect(replaceFilter).To(Panic())
 			})
 		})
 
 		Context("When filter with such name exists", func() {
-			It("Adds the filter before it", func() {
-				filter1 := &testFilter{"testFilter"}
+			It("Adds a filter before it", func() {
+				filter1 := &testFilter{"testFilter1"}
 				filter2 := &testFilter{"testFilter2"}
 				filter3 := &testFilter{"testFilter3"}
 				api.RegisterFilters(filter1, filter2)
-				api.RegisterFilterBefore(filter2.Name(), filter3)
-				names := filterNames()
-				Expect(names).To(Equal([]string{filter1.Name(), filter3.Name(), filter2.Name()}))
+				api.RegisterFiltersBefore(filter2.Name(), filter3)
+				Expect(filterNames()).To(Equal([]string{filter1.Name(), filter3.Name(), filter2.Name()}))
+			})
+
+			It("Adds multiple filters before it", func() {
+				filter1 := &testFilter{"testFilter1"}
+				filter2 := &testFilter{"testFilter2"}
+				filter3 := &testFilter{"testFilter3"}
+				api.RegisterFilters(filter1)
+				api.RegisterFiltersBefore(filter1.Name(), filter2, filter3)
+				Expect(filterNames()).To(Equal([]string{filter2.Name(), filter3.Name(), filter1.Name()}))
 			})
 		})
 	})
@@ -123,19 +131,29 @@ var _ = Describe("API", func() {
 		Context("When filter with such name does not exist", func() {
 			It("Panics", func() {
 				replaceFilter := func() {
-					api.RegisterFilterAfter("some-filter", &testFilter{"testFilter"})
+					api.RegisterFiltersAfter("some-filter", &testFilter{"testFilter"})
 				}
 				Expect(replaceFilter).To(Panic())
 			})
 		})
 		Context("When filter with such name exists", func() {
-			It("Adds the filter before it", func() {
-				filter := &testFilter{"testFilter"}
-				newFilter := &testFilter{"testFilter2"}
-				api.RegisterFilters(filter)
-				api.RegisterFilterAfter(filter.Name(), newFilter)
-				names := filterNames()
-				Expect(names).To(Equal([]string{filter.Name(), newFilter.Name()}))
+			It("Adds a filter after it", func() {
+				filter1 := &testFilter{"testFilter1"}
+				filter2 := &testFilter{"testFilter2"}
+				filter3 := &testFilter{"testFilter3"}
+				api.RegisterFilters(filter1, filter2)
+				api.RegisterFiltersAfter(filter1.Name(), filter3)
+				Expect(filterNames()).To(Equal([]string{filter1.Name(), filter3.Name(), filter2.Name()}))
+			})
+
+			It("Adds multiple filters after it", func() {
+				filter1 := &testFilter{"testFilter1"}
+				filter2 := &testFilter{"testFilter2"}
+				filter3 := &testFilter{"testFilter3"}
+				filter4 := &testFilter{"testFilter4"}
+				api.RegisterFilters(filter1, filter2)
+				api.RegisterFiltersAfter(filter1.Name(), filter3, filter4)
+				Expect(filterNames()).To(Equal([]string{filter1.Name(), filter3.Name(), filter4.Name(), filter2.Name()}))
 			})
 		})
 	})

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -561,7 +561,6 @@ var _ = Describe("Service Manager Broker API", func() {
 
 			Context("when unmodifiable fields are provided request body", func() {
 				var (
-					err                error
 					unmarshaledCatalog common.Object
 				)
 
@@ -579,7 +578,7 @@ var _ = Describe("Service Manager Broker API", func() {
 					}
 
 					unmarshaledCatalog = common.Object{}
-					err = json.Unmarshal([]byte(common.Catalog), &unmarshaledCatalog)
+					json.Unmarshal([]byte(common.Catalog), &unmarshaledCatalog)
 				})
 
 				It("should not change them", func() {

--- a/test/common/broker.go
+++ b/test/common/broker.go
@@ -1,0 +1,73 @@
+package common
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gavv/httpexpect"
+	. "github.com/onsi/ginkgo"
+)
+
+type Broker struct {
+	StatusCode     int
+	ResponseBody   []byte
+	Request        *http.Request
+	RequestBody    *httpexpect.Value
+	RawRequestBody []byte
+	OSBURL         string
+	Server         *httptest.Server
+	ID             string
+}
+
+const serviceCatalog = `{
+	"services": [{
+		"id": "1234",
+		"name": "service1",
+		"description": "sample-test",
+		"bindable": true,
+		"plans": [{
+			"id": "plan-id",
+			"name": "plan-name",
+			"description": "plan-desc"
+		}]
+	}]
+}`
+
+func (b *Broker) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	b.Request = req
+	responseBody := b.ResponseBody
+	switch req.Method {
+	case http.MethodPatch, http.MethodPost, http.MethodPut:
+		var err error
+		b.RawRequestBody, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			panic(err)
+		}
+		var reqData interface{}
+		err = json.Unmarshal(b.RawRequestBody, &reqData)
+		if err != nil {
+			panic(err)
+		}
+		b.RequestBody = httpexpect.NewValue(GinkgoT(), reqData)
+
+	case http.MethodGet:
+		if responseBody == nil && req.URL.Path == "/v2/catalog" {
+			responseBody = []byte(serviceCatalog)
+		}
+	}
+
+	code := b.StatusCode
+	if code == 0 {
+		code = http.StatusOK
+	}
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(code)
+
+	rw.Write(responseBody)
+}
+
+func (b *Broker) Called() bool {
+	return b.Request != nil
+}

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -30,11 +30,8 @@ import (
 )
 
 type ContextParams struct {
-	AdditionalFilters     []web.Filter
-	AdditionalPlugins     []web.Plugin
-	AdditionalControllers []web.Controller
-
 	Environment        env.Environment
+	RegisterExtensions func(api *web.API)
 	DefaultTokenClaims map[string]interface{}
 }
 
@@ -52,9 +49,9 @@ func buildSM(params *ContextParams, issuerURL string) *httptest.Server {
 
 	ctx, _ := context.WithCancel(context.Background())
 	smanagerBuilder := sm.New(ctx, params.Environment)
-	smanagerBuilder.RegisterControllers(params.AdditionalControllers...)
-	smanagerBuilder.RegisterFilters(params.AdditionalFilters...)
-	smanagerBuilder.RegisterPlugins(params.AdditionalPlugins...)
+	if params.RegisterExtensions != nil {
+		params.RegisterExtensions(smanagerBuilder.API)
+	}
 	serviceManager := smanagerBuilder.Build()
 	return httptest.NewServer(serviceManager.Server.Router)
 }

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -18,9 +18,6 @@ package common
 
 import (
 	"context"
-	"encoding/json"
-	"io/ioutil"
-	"net/http"
 	"net/http/httptest"
 
 	. "github.com/onsi/ginkgo"
@@ -31,20 +28,6 @@ import (
 	"github.com/Peripli/service-manager/pkg/web"
 	"github.com/gavv/httpexpect"
 )
-
-var serviceCatalog = `{
-	"services": [{
-		"id": "1234",
-		"name": "service1",
-		"description": "sample-test",
-		"bindable": true,
-		"plans": [{
-			"id": "plan-id",
-			"name": "plan-name",
-			"description": "plan-desc"
-		}]
-	}]
-}`
 
 type ContextParams struct {
 	AdditionalFilters     []web.Filter
@@ -168,52 +151,4 @@ func (ctx *TestContext) Cleanup() {
 		ctx.smServer.Close()
 	}
 	ctx.OAuthServer.Close()
-}
-
-type Broker struct {
-	StatusCode     int
-	ResponseBody   []byte
-	Request        *http.Request
-	RequestBody    *httpexpect.Value
-	RawRequestBody []byte
-	OSBURL         string
-	Server         *httptest.Server
-	ID             string
-}
-
-func (b *Broker) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	b.Request = req
-	responseBody := b.ResponseBody
-	switch req.Method {
-	case http.MethodPatch, http.MethodPost, http.MethodPut:
-		var err error
-		b.RawRequestBody, err = ioutil.ReadAll(req.Body)
-		if err != nil {
-			panic(err)
-		}
-		var reqData interface{}
-		err = json.Unmarshal(b.RawRequestBody, &reqData)
-		if err != nil {
-			panic(err)
-		}
-		b.RequestBody = httpexpect.NewValue(GinkgoT(), reqData)
-
-	case http.MethodGet:
-		if responseBody == nil && req.URL.Path == "/v2/catalog" {
-			responseBody = []byte(serviceCatalog)
-		}
-	}
-
-	code := b.StatusCode
-	if code == 0 {
-		code = http.StatusOK
-	}
-	rw.Header().Set("Content-Type", "application/json")
-	rw.WriteHeader(code)
-
-	rw.Write(responseBody)
-}
-
-func (b *Broker) Called() bool {
-	return b.Request != nil
 }

--- a/test/filter_test/filter_test.go
+++ b/test/filter_test/filter_test.go
@@ -27,7 +27,11 @@ var _ = Describe("Service Manager Filters", func() {
 	var order string
 
 	JustBeforeEach(func() {
-		ctx = common.NewTestContext(&common.ContextParams{AdditionalFilters: testFilters})
+		ctx = common.NewTestContext(&common.ContextParams{
+			RegisterExtensions: func(api *web.API) {
+				api.RegisterFilters(testFilters...)
+			},
+		})
 		testBroker = ctx.RegisterBroker("broker1", nil)
 		order = ""
 	})

--- a/test/plugin_test/plugin_test.go
+++ b/test/plugin_test/plugin_test.go
@@ -35,7 +35,9 @@ var _ = Describe("Service Manager Plugins", func() {
 	Describe("Partial plugin", func() {
 		BeforeEach(func() {
 			ctx = common.NewTestContext(&common.ContextParams{
-				AdditionalPlugins: []web.Plugin{&PartialPlugin{}},
+				RegisterExtensions: func(api *web.API) {
+					api.RegisterPlugins(&PartialPlugin{})
+				},
 			})
 			testBroker = ctx.RegisterBroker("broker1", nil)
 
@@ -63,7 +65,9 @@ var _ = Describe("Service Manager Plugins", func() {
 
 		JustBeforeEach(func() {
 			ctx = common.NewTestContext(&common.ContextParams{
-				AdditionalPlugins: []web.Plugin{testPlugin},
+				RegisterExtensions: func(api *web.API) {
+					api.RegisterPlugins(testPlugin)
+				},
 			})
 			testBroker = ctx.RegisterBroker("broker1", nil)
 		})


### PR DESCRIPTION
Fix for go1.11
Allow for custom filter ordering in test context
Allow to insert multiple filters