### PR TITLE
Remove redundant Server validation

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -103,9 +103,6 @@ func registerControllers(API *web.API, router *mux.Router) {
 
 // Run starts the server awaiting for incoming requests
 func (s *Server) Run(ctx context.Context) {
-	if err := s.Config.Validate(); err != nil {
-		panic(fmt.Sprintf("invalid server config: %s", err))
-	}
 	handler := &http.Server{
 		Handler:      s.Router,
 		Addr:         s.Config.Host + ":" + strconv.Itoa(s.Config.Port),


### PR DESCRIPTION
Validation is redundant. The check has already been made here: [pkg/sm/sm.go][1]

[1]: https://github.com/Peripli/service-manager/blob/master/pkg/sm/sm.go#L83