### PR TITLE
Fix setting correlation id header

### DIFF
--- a/api/filters/logging_test.go
+++ b/api/filters/logging_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Logging Filter", func() {
 		Context("When one is provided in header", func() {
 			It("Uses it for logger", func() {
 				expectedCorrelationId := "correlationId"
-				request.Header["X-Correlation-ID"] = []string{expectedCorrelationId}
+				request.Header.Set("X-Correlation-ID", expectedCorrelationId)
 				loggingFilter.Run(request, handler)
 				logger := log.C(request.Context())
 				correlationId := logger.Data[log.FieldCorrelationID].(string)

--- a/pkg/log/request.go
+++ b/pkg/log/request.go
@@ -24,7 +24,7 @@ import (
 )
 
 // CorrelationIDHeaders are the headers whose values will be taken as a correlation id for incoming requests
-var CorrelationIDHeaders = []string{"X-Correlation-ID", "X-CorrelationID", "X-ForRequest-ID"}
+var CorrelationIDHeaders = []string{"X-Correlation-ID", "X-CorrelationID", "X-ForRequest-ID", "X-Request-ID"}
 
 // CorrelationIDForRequest returns checks the http headers for any of the supported correlation id headers.
 // The first that matches is taken as the correlation id. If none exists a new one is generated.
@@ -38,7 +38,7 @@ func CorrelationIDForRequest(request *http.Request) string {
 	uuids, err := uuid.NewV4()
 	if err == nil {
 		newCorrelationID = uuids.String()
-		request.Header.Set(CorrelationIDHeaders[0], newCorrelationID)
+		request.Header[CorrelationIDHeaders[0]] = []string{newCorrelationID} // case-sensitive, do not use canonical set
 	}
 	return newCorrelationID
 }

--- a/pkg/log/request.go
+++ b/pkg/log/request.go
@@ -30,7 +30,7 @@ var CorrelationIDHeaders = []string{"X-Correlation-ID", "X-CorrelationID", "X-Fo
 // The first that matches is taken as the correlation id. If none exists a new one is generated.
 func CorrelationIDForRequest(request *http.Request) string {
 	for key, val := range request.Header {
-		if slice.StringsAnyEquals(CorrelationIDHeaders, key) {
+		if slice.StringsAnyEqualsIgnoreCase(CorrelationIDHeaders, key) {
 			return val[0]
 		}
 	}
@@ -38,7 +38,7 @@ func CorrelationIDForRequest(request *http.Request) string {
 	uuids, err := uuid.NewV4()
 	if err == nil {
 		newCorrelationID = uuids.String()
-		request.Header[CorrelationIDHeaders[0]] = []string{newCorrelationID} // case-sensitive, do not use canonical set
+		request.Header.Set(CorrelationIDHeaders[0], newCorrelationID)
 	}
 	return newCorrelationID
 }

--- a/pkg/log/request.go
+++ b/pkg/log/request.go
@@ -19,7 +19,6 @@ package log
 import (
 	"net/http"
 
-	"github.com/Peripli/service-manager/pkg/util/slice"
 	"github.com/gofrs/uuid"
 )
 
@@ -29,9 +28,10 @@ var CorrelationIDHeaders = []string{"X-Correlation-ID", "X-CorrelationID", "X-Fo
 // CorrelationIDForRequest returns checks the http headers for any of the supported correlation id headers.
 // The first that matches is taken as the correlation id. If none exists a new one is generated.
 func CorrelationIDForRequest(request *http.Request) string {
-	for key, val := range request.Header {
-		if slice.StringsAnyEqualsIgnoreCase(CorrelationIDHeaders, key) {
-			return val[0]
+	for _, header := range CorrelationIDHeaders {
+		headerValue := request.Header.Get(header)
+		if headerValue != "" {
+			return headerValue
 		}
 	}
 	newCorrelationID := ""

--- a/pkg/util/slice/strings.go
+++ b/pkg/util/slice/strings.go
@@ -63,3 +63,13 @@ func StringsAnyEquals(stringSlice []string, str string) bool {
 	}
 	return false
 }
+
+// StringsAnyEqualsIgnoreCase returns true if any of the strings in the slice equal the given string ignoring the case.
+func StringsAnyEqualsIgnoreCase(stringSlice []string, str string) bool {
+	for _, v := range stringSlice {
+		if strings.EqualFold(v, str) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/slice/strings.go
+++ b/pkg/util/slice/strings.go
@@ -18,8 +18,6 @@ package slice
 
 import "strings"
 
-type stringPredicate func(next string) bool
-
 // StringsIntersection returns the common elements in two string slices.
 func StringsIntersection(str1, str2 []string) []string {
 	var intersection []string
@@ -37,33 +35,31 @@ func StringsIntersection(str1, str2 []string) []string {
 
 // StringsContaining returns a slice of the strings containing the specified string.
 func StringsContaining(stringSlice []string, str string) []string {
-	return filter(stringSlice, func(next string) bool {
-		return strings.Contains(next, str)
-	})
-}
-
-// StringsAnyPrefix returns true if any of the strings in the slice have the given prefix.
-func StringsAnyPrefix(stringSlice []string, prefix string) bool {
-	stringsWithPrefix := filter(stringSlice, func(next string) bool {
-		return strings.HasPrefix(next, prefix)
-	})
-	return len(stringsWithPrefix) > 0
-}
-
-// StringsAnyEquals returns true if any of the strings in the slice equal the given string.
-func StringsAnyEquals(stringSlice []string, str string) bool {
-	equalStrings := filter(stringSlice, func(next string) bool {
-		return next == str
-	})
-	return len(equalStrings) > 0
-}
-
-func filter(stringSlice []string, predicate stringPredicate) []string {
 	var result []string
 	for _, v := range stringSlice {
-		if predicate(v) {
+		if strings.Contains(v, str) {
 			result = append(result, v)
 		}
 	}
 	return result
+}
+
+// StringsAnyPrefix returns true if any of the strings in the slice have the given prefix.
+func StringsAnyPrefix(stringSlice []string, prefix string) bool {
+	for _, v := range stringSlice {
+		if strings.HasPrefix(v, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// StringsAnyEquals returns true if any of the strings in the slice equal the given string.
+func StringsAnyEquals(stringSlice []string, str string) bool {
+	for _, v := range stringSlice {
+		if v == str {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/util/slice/strings.go
+++ b/pkg/util/slice/strings.go
@@ -58,14 +58,6 @@ func StringsAnyEquals(stringSlice []string, str string) bool {
 	return len(equalStrings) > 0
 }
 
-// StringsAnyEqualsIgnoreCase returns true if any of the strings in the slice equal the given string ignoring the case.
-func StringsAnyEqualsIgnoreCase(stringSlice []string, str string) bool {
-	equalIgnoreCase := filter(stringSlice, func(next string) bool {
-		return strings.EqualFold(next, str)
-	})
-	return len(equalIgnoreCase) > 0
-}
-
 func filter(stringSlice []string, predicate stringPredicate) []string {
 	var result []string
 	for _, v := range stringSlice {

--- a/pkg/util/slice/strings.go
+++ b/pkg/util/slice/strings.go
@@ -18,6 +18,8 @@ package slice
 
 import "strings"
 
+type stringPredicate func(next string) bool
+
 // StringsIntersection returns the common elements in two string slices.
 func StringsIntersection(str1, str2 []string) []string {
 	var intersection []string
@@ -35,41 +37,41 @@ func StringsIntersection(str1, str2 []string) []string {
 
 // StringsContaining returns a slice of the strings containing the specified string.
 func StringsContaining(stringSlice []string, str string) []string {
-	var result []string
-	for _, v := range stringSlice {
-		if strings.Contains(v, str) {
-			result = append(result, v)
-		}
-	}
-	return result
+	return filter(stringSlice, func(next string) bool {
+		return strings.Contains(next, str)
+	})
 }
 
 // StringsAnyPrefix returns true if any of the strings in the slice have the given prefix.
 func StringsAnyPrefix(stringSlice []string, prefix string) bool {
-	for _, v := range stringSlice {
-		if strings.HasPrefix(v, prefix) {
-			return true
-		}
-	}
-	return false
+	stringsWithPrefix := filter(stringSlice, func(next string) bool {
+		return strings.HasPrefix(next, prefix)
+	})
+	return len(stringsWithPrefix) > 0
 }
 
 // StringsAnyEquals returns true if any of the strings in the slice equal the given string.
 func StringsAnyEquals(stringSlice []string, str string) bool {
-	for _, v := range stringSlice {
-		if v == str {
-			return true
-		}
-	}
-	return false
+	equalStrings := filter(stringSlice, func(next string) bool {
+		return next == str
+	})
+	return len(equalStrings) > 0
 }
 
 // StringsAnyEqualsIgnoreCase returns true if any of the strings in the slice equal the given string ignoring the case.
 func StringsAnyEqualsIgnoreCase(stringSlice []string, str string) bool {
+	equalIgnoreCase := filter(stringSlice, func(next string) bool {
+		return strings.EqualFold(next, str)
+	})
+	return len(equalIgnoreCase) > 0
+}
+
+func filter(stringSlice []string, predicate stringPredicate) []string {
+	var result []string
 	for _, v := range stringSlice {
-		if strings.EqualFold(v, str) {
-			return true
+		if predicate(v) {
+			result = append(result, v)
 		}
 	}
-	return false
+	return result
 }


### PR DESCRIPTION
X-Request-ID is also taken as a correlation id - https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Common_non-standard_request_fields 

golang's `Header.Set` uses [CanonicalMIMEHeader](https://golang.org/pkg/net/textproto/#CanonicalMIMEHeaderKey) which changes the capitalisation of ID. Also per https://tools.ietf.org/html/rfc7230#section-3.2 header keys are case-insensitive.