### PR TITLE
Adapt docu with missing information after following guide

### DIFF
--- a/docs/install/cf-proxy.md
+++ b/docs/install/cf-proxy.md
@@ -19,7 +19,7 @@ Clone the [service-broker-proxy-cf](https://github.com/Peripli/service-broker-pr
 git clone https://github.com/Peripli/service-broker-proxy-cf.git && cd service-broker-proxy-cf
 ```
 
-**Note:** Do not use `go get`. Instead use git to clone the repository.
+**Note:** Do not use `go get`. Instead use git to clone the repository, but within `$GOPATH/src` to allow `dep ensure`.
 
 ## Install dependencies
 

--- a/docs/install/cf-proxy.md
+++ b/docs/install/cf-proxy.md
@@ -51,7 +51,7 @@ ID                                    Name  Type  Description  Created          
 
 In the [service-broker-proxy-cf](https://github.com/Peripli/service-broker-proxy-cf) repository you need to replace in the `manifest.yml` the following things:
 
-* Administrative credentials for CF with env variables `CF_CLIENT_USERNAME`, `CF_CLIENT_PASSWORD` and `CF_CLIENT_APIADDRESS.
+* Administrative credentials for CF with env variables `CF_CLIENT_USERNAME` and `CF_CLIENT_PASSWORD`.
 * Service-Manager URL using the `SM_URL` env variable.
 * Credentials for Service Manager with env variables `SM_USER` and `SM_PASSWORD`. These are the credentials obtained by the `smctl register-platform` command
 

--- a/docs/install/cf-proxy.md
+++ b/docs/install/cf-proxy.md
@@ -52,6 +52,7 @@ ID                                    Name  Type  Description  Created          
 In the [service-broker-proxy-cf](https://github.com/Peripli/service-broker-proxy-cf) repository you need to replace in the `manifest.yml` the following things:
 
 * Administrative credentials for CF with env variables `CF_CLIENT_USERNAME` and `CF_CLIENT_PASSWORD`.
+* Optional: adapt env variable `CF_CLIENT_APIADDRESS`.
 * Service-Manager URL using the `SM_URL` env variable.
 * Credentials for Service Manager with env variables `SM_USER` and `SM_PASSWORD`. These are the credentials obtained by the `smctl register-platform` command
 

--- a/docs/install/cf-proxy.md
+++ b/docs/install/cf-proxy.md
@@ -16,10 +16,10 @@
 Clone the [service-broker-proxy-cf](https://github.com/Peripli/service-broker-proxy-cf) git repository.
 
 ```console
-git clone https://github.com/Peripli/service-broker-proxy-cf.git && cd service-broker-proxy-cf
+$ git clone https://github.com/Peripli/service-broker-proxy-cf.git $GOPATH/src/github.com/Peripli/service-broker-proxy-cf && cd $GOPATH/src/github.com/Peripli/service-broker-proxy-cf
 ```
 
-**Note:** Do not use `go get`. Instead use git to clone the repository, but within `$GOPATH/src` to allow `dep ensure`.
+**Note:** Do not use `go get`. Instead use git to clone the repository.
 
 ## Install dependencies
 

--- a/docs/install/k8s-proxy.md
+++ b/docs/install/k8s-proxy.md
@@ -51,7 +51,7 @@ The service-broker-proxy-k8s is installed via a helm chart located in the [servi
 Navigate to the root of the cloned repository and execute:
 
 ```console
-helm install charts/service-broker-proxy --name service-broker-proxy --namespace service-broker-proxy --set config.sm.url=<SM_URL> --set sm.user=<SM_USER> --set sm.password=<SM_PASSWORD>
+helm install charts/service-broker-proxy-k8s --name service-broker-proxy --namespace service-broker-proxy --set config.sm.url=<SM_URL> --set sm.user=<SM_USER> --set sm.password=<SM_PASSWORD>
 ```
 
 **Note:** Make sure you substitute `<SM_URL>` with the Service Manager URL, `<SM_USER>` and `<SM_PASSWORD>` with the credentials issued from Service Manager when this platform was registered there.

--- a/docs/install/k8s-proxy.md
+++ b/docs/install/k8s-proxy.md
@@ -15,7 +15,7 @@
 Clone the [service-broker-proxy-k8s](https://github.com/Peripli/service-broker-proxy-k8s) git repository.
 
 ```console
-git clone https://github.com/Peripli/service-broker-proxy-k8s.git && cd service-broker-proxy-k8s
+$ git clone https://github.com/Peripli/service-broker-proxy-k8s.git $GOPATH/src/github.com/Peripli/service-broker-proxy-k8s && cd $GOPATH/src/github.com/Peripli/service-broker-proxy-k8s
 ```
 
 **Note:** Do not use `go get`. Instead use git to clone the repository.


### PR DESCRIPTION
Make it clearer to follow the installation guide to install service manager proxy to k8s and cf.
