### PR TITLE
Trim bearer prefix no matter the case

### DIFF
--- a/api/filters/authn/oauth/authenticator.go
+++ b/api/filters/authn/oauth/authenticator.go
@@ -96,13 +96,13 @@ func newOIDCConfig(options *options) *goidc.Config {
 // Authenticate returns information about the user by obtaining it from the bearer token, or an error if security is unsuccessful
 func (a *oauthAuthenticator) Authenticate(request *http.Request) (*web.User, security.Decision, error) {
 	authorizationHeader := request.Header.Get("Authorization")
-	if authorizationHeader == "" || !strings.HasPrefix(strings.ToLower(authorizationHeader), "bearer") {
+	if authorizationHeader == "" || !strings.HasPrefix(strings.ToLower(authorizationHeader), "bearer ") {
 		return nil, security.Abstain, nil
 	}
 	if a.Verifier == nil {
 		return nil, security.Abstain, errors.New("authenticator is not configured")
 	}
-	token := strings.TrimPrefix(authorizationHeader, "Bearer ")
+	token := authorizationHeader[len("Bearer ")-1:]
 	if token == "" {
 		return nil, security.Deny, nil
 	}

--- a/api/filters/authn/oauth/authenticator.go
+++ b/api/filters/authn/oauth/authenticator.go
@@ -102,7 +102,7 @@ func (a *oauthAuthenticator) Authenticate(request *http.Request) (*web.User, sec
 	if a.Verifier == nil {
 		return nil, security.Abstain, errors.New("authenticator is not configured")
 	}
-	token := authorizationHeader[len("Bearer ")-1:]
+	token := strings.TrimSpace(authorizationHeader[len("Bearer "):])
 	if token == "" {
 		return nil, security.Deny, nil
 	}


### PR DESCRIPTION
## Motivation
if Authorization header is passed and bearer token is used, it should not matter in what case is the key word "bearer" 

## Pull Request status

* [x] Initial implementation