### PR TITLE
Limit request body size and header size with configuration

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -2,14 +2,15 @@ server:
   request_timeout: 4000ms
   shutdown_timeout: 4000ms
   port: 8080
+  # max_body_bytes: 4000
+  # max_header_bytes: 1000
 log:
   level: debug
   format: text
 storage:
+#  name: sm-postgres
   uri: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
   encryption_key: ejHjRNHbS0NaqARSRvnweVV9zcmhQEa8
-# storage:
-#  name: sm-postgres
 api:
   token_issuer_url: http://localhost:8080/uaa
   client_id: sm


### PR DESCRIPTION
## Motivation
SM should be able to configure the maximum body request size and header sizes

## Pull Request status

* [x] Limit the incoming request body size
* [x] Limit the incoming request headers size
* [ ] Limit the response body size from brokers
* [ ] Unit tests

Currently there is no easy way to test request headers size, as this requires to start real http.Server, rather than a httptest.Server. Tested it with Postman and it rejects request with large header values.