### PR TITLE
Minor refactoring and fix typos

### DIFF
--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -79,7 +79,7 @@ type Pinger interface {
 // PingFunc is an adapter that allows to use regular functions as Pinger
 type PingFunc func() error
 
-// Run allows PingFunc to act as a Pinger
+// Ping allows PingFunc to act as a Pinger
 func (mf PingFunc) Ping() error {
 	return mf()
 }

--- a/storage/postgres/service_offering.go
+++ b/storage/postgres/service_offering.go
@@ -43,29 +43,11 @@ func (sos *serviceOfferingStorage) Get(ctx context.Context, id string) (*types.S
 }
 
 func (sos *serviceOfferingStorage) List(ctx context.Context) ([]*types.ServiceOffering, error) {
-	var serviceOfferings []ServiceOffering
-	err := list(ctx, sos.db, serviceOfferingTable, map[string]string{}, &serviceOfferings)
-	if err != nil || len(serviceOfferings) == 0 {
-		return []*types.ServiceOffering{}, err
-	}
-	serviceOfferingDTOs := make([]*types.ServiceOffering, 0, len(serviceOfferings))
-	for _, so := range serviceOfferings {
-		serviceOfferingDTOs = append(serviceOfferingDTOs, so.ToDTO())
-	}
-	return serviceOfferingDTOs, nil
+	return sos.list(ctx, map[string]string{})
 }
 
 func (sos *serviceOfferingStorage) ListByCatalogName(ctx context.Context, name string) ([]*types.ServiceOffering, error) {
-	var serviceOfferings []ServiceOffering
-	err := list(ctx, sos.db, serviceOfferingTable, map[string]string{"catalog_name": name}, &serviceOfferings)
-	if err != nil || len(serviceOfferings) == 0 {
-		return []*types.ServiceOffering{}, err
-	}
-	serviceOfferingDTOs := make([]*types.ServiceOffering, 0, len(serviceOfferings))
-	for _, so := range serviceOfferings {
-		serviceOfferingDTOs = append(serviceOfferingDTOs, so.ToDTO())
-	}
-	return serviceOfferingDTOs, nil
+	return sos.list(ctx, map[string]string{"catalog_name": name})
 }
 
 func (sos *serviceOfferingStorage) ListWithServicePlansByBrokerID(ctx context.Context, brokerID string) ([]*types.ServiceOffering, error) {
@@ -136,4 +118,17 @@ func (sos *serviceOfferingStorage) Update(ctx context.Context, serviceOffering *
 	so.FromDTO(serviceOffering)
 	return update(ctx, sos.db, serviceOfferingTable, so)
 
+}
+
+func (sos *serviceOfferingStorage) list(ctx context.Context, filter map[string]string) ([]*types.ServiceOffering, error) {
+	var serviceOfferings []ServiceOffering
+	err := list(ctx, sos.db, serviceOfferingTable, filter, &serviceOfferings)
+	if err != nil || len(serviceOfferings) == 0 {
+		return []*types.ServiceOffering{}, err
+	}
+	serviceOfferingDTOs := make([]*types.ServiceOffering, 0, len(serviceOfferings))
+	for _, so := range serviceOfferings {
+		serviceOfferingDTOs = append(serviceOfferingDTOs, so.ToDTO())
+	}
+	return serviceOfferingDTOs, nil
 }

--- a/storage/postgres/service_plan.go
+++ b/storage/postgres/service_plan.go
@@ -41,29 +41,11 @@ func (sps *servicePlanStorage) Get(ctx context.Context, id string) (*types.Servi
 }
 
 func (sps *servicePlanStorage) List(ctx context.Context) ([]*types.ServicePlan, error) {
-	var plans []ServicePlan
-	err := list(ctx, sps.db, servicePlanTable, map[string]string{}, &plans)
-	if err != nil || len(plans) == 0 {
-		return []*types.ServicePlan{}, err
-	}
-	servicePlans := make([]*types.ServicePlan, 0, len(plans))
-	for _, plan := range plans {
-		servicePlans = append(servicePlans, plan.ToDTO())
-	}
-	return servicePlans, nil
+	return sps.list(ctx, map[string]string{})
 }
 
 func (sps *servicePlanStorage) ListByCatalogName(ctx context.Context, name string) ([]*types.ServicePlan, error) {
-	var plans []ServicePlan
-	err := list(ctx, sps.db, servicePlanTable, map[string]string{"catalog_name": name}, &plans)
-	if err != nil || len(plans) == 0 {
-		return []*types.ServicePlan{}, err
-	}
-	servicePlans := make([]*types.ServicePlan, 0, len(plans))
-	for _, plan := range plans {
-		servicePlans = append(servicePlans, plan.ToDTO())
-	}
-	return servicePlans, nil
+	return sps.list(ctx, map[string]string{"catalog_name": name})
 }
 
 func (sps *servicePlanStorage) Delete(ctx context.Context, id string) error {
@@ -74,4 +56,17 @@ func (sps *servicePlanStorage) Update(ctx context.Context, servicePlan *types.Se
 	plan := &ServicePlan{}
 	plan.FromDTO(servicePlan)
 	return update(ctx, sps.db, servicePlanTable, plan)
+}
+
+func (sps *servicePlanStorage) list(ctx context.Context, filter map[string]string) ([]*types.ServicePlan, error) {
+	var plans []ServicePlan
+	err := list(ctx, sps.db, servicePlanTable, filter, &plans)
+	if err != nil || len(plans) == 0 {
+		return []*types.ServicePlan{}, err
+	}
+	servicePlans := make([]*types.ServicePlan, 0, len(plans))
+	for _, plan := range plans {
+		servicePlans = append(servicePlans, plan.ToDTO())
+	}
+	return servicePlans, nil
 }

--- a/storage/postgres/storage_state_test.go
+++ b/storage/postgres/storage_state_test.go
@@ -28,7 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Postgres Storageƒ State", func() {
+var _ = Describe("Postgres Storage State", func() {
 
 	var (
 		mockDB *sql.DB


### PR DESCRIPTION
# Minor refactoring and fix typos

### Motive:

Refactors some duplicate code in __storage/postgres/service_offerings.go__ and __storage/postgres/service_plans.go__, and also fixes some typos.