### PR TITLE
Improve logging during API tests execution

### DIFF
--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -19,6 +19,7 @@ package log
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 
@@ -53,6 +54,7 @@ const (
 type Settings struct {
 	Level  string
 	Format string
+	Output io.Writer `mapstructure:"-"`
 }
 
 // DefaultSettings returns default values for Log settings
@@ -60,6 +62,7 @@ func DefaultSettings() *Settings {
 	return &Settings{
 		Level:  "debug",
 		Format: "text",
+		Output: os.Stdout,
 	}
 }
 
@@ -70,6 +73,9 @@ func (s *Settings) Validate() error {
 	}
 	if len(s.Format) == 0 {
 		return fmt.Errorf("validate Settings: LogFormat missing")
+	}
+	if s.Output == nil {
+		return fmt.Errorf("validate Settings: LogOutput missing")
 	}
 	return nil
 }
@@ -88,7 +94,7 @@ func Configure(ctx context.Context, settings *Settings) context.Context {
 		logger := &logrus.Logger{
 			Formatter: formatter,
 			Level:     level,
-			Out:       os.Stdout,
+			Out:       settings.Output,
 			Hooks:     make(logrus.LevelHooks),
 		}
 		hook := filename.NewHook()
@@ -125,7 +131,7 @@ func RegisterFormatter(name string, formatter logrus.Formatter) error {
 	regMutex.Lock()
 	defer regMutex.Unlock()
 	if _, exists := supportedFormatters[name]; exists {
-		return fmt.Errorf("Formatter with name %s is already registered", name)
+		return fmt.Errorf("formatter with name %s is already registered", name)
 	}
 	supportedFormatters[name] = formatter
 	return nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -129,7 +129,7 @@ func (s *Server) Run(ctx context.Context) {
 func startServer(ctx context.Context, server *http.Server, shutdownTimeout time.Duration) {
 	go gracefulShutdown(ctx, server, shutdownTimeout)
 
-	log.C(ctx).Infof("Listening on %s", server.Addr)
+	log.C(ctx).Infof("Server listening on %s...", server.Addr)
 
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.C(ctx).Fatal(err)

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -95,6 +95,7 @@ func New(ctx context.Context, cancel context.CancelFunc, env env.Environment) *S
 	util.HandleInterrupts(ctx, cancel)
 
 	// setup smStorage
+	log.C(ctx).Info("Setting up Service Manager storage...")
 	smStorage, err := storage.Use(ctx, postgres.Storage, cfg.Storage)
 	if err != nil {
 		panic(fmt.Sprintf("error using smStorage: %s", err))
@@ -110,6 +111,7 @@ func New(ctx context.Context, cancel context.CancelFunc, env env.Environment) *S
 	}
 
 	// setup core api
+	log.C(ctx).Info("Setting up Service Manager core API...")
 	API, err := api.New(ctx, smStorage, cfg.API, encrypter)
 	if err != nil {
 		panic(fmt.Sprintf("error creating core api: %s", err))
@@ -146,6 +148,7 @@ func (smb *ServiceManagerBuilder) installHealth() {
 
 // Run starts the Service Manager
 func (sm *ServiceManager) Run() {
+	log.C(sm.ctx).Info("Running Service Manager...")
 	sm.Server.Run(sm.ctx)
 }
 
@@ -162,7 +165,7 @@ func initializeSecureStorage(ctx context.Context, secureStorage storage.Security
 	}
 	if len(encryptionKey) == 0 {
 		logger := log.C(ctx)
-		logger.Debug("No encryption key is present. Generating new one...")
+		logger.Info("No encryption key is present. Generating new one...")
 		newEncryptionKey := make([]byte, 32)
 		if _, err := rand.Read(newEncryptionKey); err != nil {
 			return fmt.Errorf("could not generate encryption key: %v", err)
@@ -171,7 +174,7 @@ func initializeSecureStorage(ctx context.Context, secureStorage storage.Security
 		if err := keySetter.SetEncryptionKey(ctx, newEncryptionKey); err != nil {
 			return err
 		}
-		logger.Debug("Successfully generated new encryption key")
+		logger.Info("Successfully generated new encryption key")
 	}
 	return secureStorage.Unlock(ctx)
 }

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -12,4 +12,3 @@ api:
   token_issuer_url: http://localhost:8080/uaa
   client_id: sm
   skip_ssl_validation: false
-

--- a/test/osb_test/osb_test.go
+++ b/test/osb_test/osb_test.go
@@ -189,7 +189,6 @@ var _ = Describe("Service Manager OSB API", func() {
 		queryParameterVerificationServer.ServiceInstanceLastOpHandler = queryParameterVerificationHandler(headerKey, headerValue)
 		queryParameterVerificationServer.BindingLastOpHandler = queryParameterVerificationHandler(headerKey, headerValue)
 		smUrlToQueryVerificationBroker = queryParameterVerificationServer.URL + "/v1/osb/" + queryParameterVerificationServerID
-
 	})
 
 	AfterSuite(func() {


### PR DESCRIPTION
This addresses a few issues with logging when executing API tests (tests located in /tests). This does not apply for the unit tests.
- Tests now only show sm logs when they fail
- Log level can now be changed in tests via the common/application.yml (which was not working before)
- Log level in tests is set to debug
- Only sm logs for the particular failing `It` will be shown