### PR TITLE
Disallow duplicate label querying

### DIFF
--- a/pkg/query/selection_test.go
+++ b/pkg/query/selection_test.go
@@ -219,9 +219,9 @@ var _ = Describe("Selection", func() {
 			})
 		})
 
-		Context("Duplicate label query", func() {
+		Context("Duplicate label query key", func() {
 			It("Should return error", func() {
-				criteriaFromRequest, err := buildCriteria(`http://localhost:8080/v1/visibilities?labelQuery=leftop1 = rightop|leftop1 = rightop`)
+				criteriaFromRequest, err := buildCriteria(`http://localhost:8080/v1/visibilities?labelQuery=leftop1 = rightop|leftop1 = rightop2`)
 				Expect(err).To(HaveOccurred())
 				Expect(criteriaFromRequest).To(BeNil())
 			})

--- a/pkg/query/selection_test.go
+++ b/pkg/query/selection_test.go
@@ -211,9 +211,17 @@ var _ = Describe("Selection", func() {
 			})
 		})
 
-		Context("Duplicate query key", func() {
+		Context("Duplicate field query key", func() {
 			It("Should return error", func() {
 				criteriaFromRequest, err := buildCriteria(`http://localhost:8080/v1/visibilities?fieldQuery=leftop1 = rightop|leftop1 = rightop2`)
+				Expect(err).To(HaveOccurred())
+				Expect(criteriaFromRequest).To(BeNil())
+			})
+		})
+
+		Context("Duplicate label query", func() {
+			It("Should return error", func() {
+				criteriaFromRequest, err := buildCriteria(`http://localhost:8080/v1/visibilities?labelQuery=leftop1 = rightop|leftop1 = rightop`)
 				Expect(err).To(HaveOccurred())
 				Expect(criteriaFromRequest).To(BeNil())
 			})


### PR DESCRIPTION
Currently label querying allows `duplicate label query keys` and disallows `duplicate field query keys` which is rather inconsistent. This PR disallows duplicate label querying. (e.x. labelQuery=key-op-val|key-op-val is disallowed and  labelQuery=key-op-val|key-op-val2  is not allowed) 

