### PR TITLE
Info endpoint returns token_basic_auth

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -48,6 +48,7 @@ type Settings struct {
 	TokenIssuerURL    string `mapstructure:"token_issuer_url"`
 	ClientID          string `mapstructure:"client_id"`
 	SkipSSLValidation bool   `mapstructure:"skip_ssl_validation"`
+	TokenBasicAuth    bool   `mapstructure:"token_basic_auth"`
 }
 
 // DefaultSettings returns default values for API settings
@@ -56,6 +57,7 @@ func DefaultSettings() *Settings {
 		TokenIssuerURL:    "",
 		ClientID:          "",
 		SkipSSLValidation: false,
+		TokenBasicAuth:    true, // RFC 6749 section 2.3.1
 	}
 }
 
@@ -95,7 +97,8 @@ func New(ctx context.Context, repository storage.Repository, settings *Settings,
 				Repository: repository,
 			},
 			&info.Controller{
-				TokenIssuer: settings.TokenIssuerURL,
+				TokenIssuer:    settings.TokenIssuerURL,
+				TokenBasicAuth: settings.TokenBasicAuth,
 			},
 			osb.NewController(&osb.StorageBrokerFetcher{
 				BrokerStorage: repository.Broker(),

--- a/api/info/info_controller.go
+++ b/api/info/info_controller.go
@@ -23,21 +23,17 @@ import (
 	"github.com/Peripli/service-manager/pkg/web"
 )
 
-// DetailsResponse describes the public information provided by the Service Manager and is returned as a
-// response from the info API.
-type DetailsResponse struct {
-	TokenIssuer string `json:"token_issuer_url"`
-}
-
 // Controller info controller
 type Controller struct {
-	TokenIssuer string
+	TokenIssuer string `json:"token_issuer_url"`
+
+	// TokenBasicAuth specifies if client credentials should be sent in the header
+	// as basic auth (true) or in the body (false)
+	TokenBasicAuth bool `json:"token_basic_auth"`
 }
 
 var _ web.Controller = &Controller{}
 
 func (c *Controller) getInfo(request *web.Request) (*web.Response, error) {
-	return util.NewJSONResponse(http.StatusOK, &DetailsResponse{
-		TokenIssuer: c.TokenIssuer,
-	})
+	return util.NewJSONResponse(http.StatusOK, c)
 }


### PR DESCRIPTION
Some authorization servers like CF UAA have issues when client credentials are passed as basic auth.
See cloudfoundry/uaa#778

SM returns on the info endpoint a new property token_basic_auth (default true).
If token_basic_auth is false, client credentials should be sent in the body instead of in authorization header (basic auth).