### PR TITLE
Adjust label errors

### DIFF
--- a/api/broker/broker_controller.go
+++ b/api/broker/broker_controller.go
@@ -232,7 +232,7 @@ func (c *Controller) patchBroker(r *web.Request) (*web.Response, error) {
 
 	changes, err := query.LabelChangesFromJSON(r.Body)
 	if err != nil {
-		return nil, util.HandleLabelChangeError(err)
+		return nil, err
 	}
 	if r.Body, err = sjson.DeleteBytes(r.Body, "labels"); err != nil {
 		return nil, err

--- a/api/visibility/visibility_controller.go
+++ b/api/visibility/visibility_controller.go
@@ -147,7 +147,7 @@ func (c *Controller) patchVisibility(r *web.Request) (*web.Response, error) {
 
 	changes, err := query.LabelChangesFromJSON(r.Body)
 	if err != nil {
-		return nil, util.HandleLabelChangeError(err)
+		return nil, err
 	}
 	if r.Body, err = sjson.DeleteBytes(r.Body, "labels"); err != nil {
 		return nil, err

--- a/pkg/query/selection.go
+++ b/pkg/query/selection.go
@@ -120,7 +120,7 @@ func (c Criterion) Validate() error {
 		return fmt.Errorf("multiple values %s received for single value operation %s", c.RightOp, c.Operator)
 	}
 	if c.Operator.IsNullable() && c.Type != FieldQuery {
-		return &util.UnsupportedQueryError{"nullable operations are supported only for field queries"}
+		return &util.UnsupportedQueryError{Message: "nullable operations are supported only for field queries"}
 	}
 	if c.Operator.IsNumeric() && !isNumeric(c.RightOp[0]) {
 		return &util.UnsupportedQueryError{Message: fmt.Sprintf("%s is numeric operator, but the right operand %s is not numeric", c.Operator, c.RightOp[0])}

--- a/pkg/query/selection.go
+++ b/pkg/query/selection.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Peripli/service-manager/pkg/util"
+
 	"github.com/Peripli/service-manager/pkg/web"
 )
 
@@ -87,15 +89,6 @@ const (
 
 var supportedQueryTypes = []CriterionType{FieldQuery, LabelQuery}
 
-// UnsupportedQueryError is an error to show that the provided query cannot be executed
-type UnsupportedQueryError struct {
-	Message string
-}
-
-func (uq *UnsupportedQueryError) Error() string {
-	return uq.Message
-}
-
 // Criterion is a single part of a query criteria
 type Criterion struct {
 	// LeftOp is the left operand in the query
@@ -127,17 +120,17 @@ func (c Criterion) Validate() error {
 		return fmt.Errorf("multiple values %s received for single value operation %s", c.RightOp, c.Operator)
 	}
 	if c.Operator.IsNullable() && c.Type != FieldQuery {
-		return &UnsupportedQueryError{"nullable operations are supported only for field queries"}
+		return &util.UnsupportedQueryError{"nullable operations are supported only for field queries"}
 	}
 	if c.Operator.IsNumeric() && !isNumeric(c.RightOp[0]) {
-		return &UnsupportedQueryError{Message: fmt.Sprintf("%s is numeric operator, but the right operand %s is not numeric", c.Operator, c.RightOp[0])}
+		return &util.UnsupportedQueryError{Message: fmt.Sprintf("%s is numeric operator, but the right operand %s is not numeric", c.Operator, c.RightOp[0])}
 	}
 	if strings.ContainsRune(c.LeftOp, Separator) {
 		parts := strings.FieldsFunc(c.LeftOp, func(r rune) bool {
 			return r == Separator
 		})
 		possibleKey := parts[len(parts)-1]
-		return &UnsupportedQueryError{Message: fmt.Sprintf("separator %c is not allowed in %s with left operand \"%s\". Maybe you meant \"%s\"? Make sure if the separator is present in any right operand, that it is escaped with a backslash (\\)", Separator, c.Type, c.LeftOp, possibleKey)}
+		return &util.UnsupportedQueryError{Message: fmt.Sprintf("separator %c is not allowed in %s with left operand \"%s\". Maybe you meant \"%s\"? Make sure if the separator is present in any right operand, that it is escaped with a backslash (\\)", Separator, c.Type, c.LeftOp, possibleKey)}
 	}
 	for _, op := range c.RightOp {
 		if strings.ContainsRune(op, '\n') {
@@ -165,11 +158,11 @@ func mergeCriteria(c1 []Criterion, c2 []Criterion) ([]Criterion, error) {
 		leftOp := newCriterion.LeftOp
 		// disallow duplicate label queries
 		if count, ok := labelQueryLeftOperands[leftOp]; ok && count > 1 && newCriterion.Type == LabelQuery {
-			return nil, &UnsupportedQueryError{Message: fmt.Sprintf("duplicate label query key: %s", newCriterion.LeftOp)}
+			return nil, &util.UnsupportedQueryError{Message: fmt.Sprintf("duplicate label query key: %s", newCriterion.LeftOp)}
 		}
 		// disallow duplicate field query keys
 		if count, ok := fieldQueryLeftOperands[leftOp]; ok && count > 1 && newCriterion.Type == FieldQuery {
-			return nil, &UnsupportedQueryError{Message: fmt.Sprintf("duplicate field query key: %s", newCriterion.LeftOp)}
+			return nil, &util.UnsupportedQueryError{Message: fmt.Sprintf("duplicate field query key: %s", newCriterion.LeftOp)}
 		}
 		if err := newCriterion.Validate(); err != nil {
 			return nil, err

--- a/pkg/query/update.go
+++ b/pkg/query/update.go
@@ -72,13 +72,13 @@ func (lc *LabelChanges) Validate() error {
 
 // LabelChangesFromJSON returns the label changes from the json byte array and an error if the changes are not valid
 func LabelChangesFromJSON(jsonBytes []byte) ([]*LabelChange, error) {
-	var labelChanges LabelChanges
+	labelChanges := LabelChanges{}
 	labelChangesBytes := gjson.GetBytes(jsonBytes, "labels").String()
 	if len(labelChangesBytes) <= 0 {
 		return LabelChanges{}, nil
 	}
 
-	if err := util.BytesToObject(jsonBytes, &labelChanges); err != nil {
+	if err := util.BytesToObject([]byte(labelChangesBytes), &labelChanges); err != nil {
 		return nil, err
 	}
 

--- a/pkg/query/update.go
+++ b/pkg/query/update.go
@@ -17,8 +17,10 @@
 package query
 
 import (
-	"encoding/json"
+	"errors"
 	"fmt"
+
+	"github.com/Peripli/service-manager/pkg/util"
 
 	"github.com/tidwall/gjson"
 )
@@ -42,15 +44,6 @@ func (o LabelOperation) RequiresValues() bool {
 	return o != RemoveLabelOperation
 }
 
-// LabelChangeError is an error that shows that the constructed label change cannot be executed
-type LabelChangeError struct {
-	Message string
-}
-
-func (l LabelChangeError) Error() string {
-	return l.Message
-}
-
 // LabelChange represents the changes that should be performed to a label
 type LabelChange struct {
 	Operation LabelOperation `json:"op"`
@@ -58,34 +51,40 @@ type LabelChange struct {
 	Values    []string       `json:"values"`
 }
 
-func (lc LabelChange) Validate() error {
+func (lc *LabelChange) Validate() error {
 	if lc.Operation.RequiresValues() && len(lc.Values) == 0 {
-		return &LabelChangeError{fmt.Sprintf("operation %s requires values to be provided", lc.Operation)}
+		return fmt.Errorf("operation %s requires values to be provided", lc.Operation)
 	}
 	if lc.Key == "" || lc.Operation == "" {
-		return &LabelChangeError{Message: "both key and operation are required for label change"}
+		return errors.New("both key and operation are missing but are required for label change")
+	}
+	return nil
+}
+
+type LabelChanges []*LabelChange
+
+func (lc *LabelChanges) Validate() error {
+	for _, labelChange := range *lc {
+		return labelChange.Validate()
 	}
 	return nil
 }
 
 // LabelChangesFromJSON returns the label changes from the json byte array and an error if the changes are not valid
 func LabelChangesFromJSON(jsonBytes []byte) ([]*LabelChange, error) {
-	var labelChanges []*LabelChange
+	var labelChanges LabelChanges
 	labelChangesBytes := gjson.GetBytes(jsonBytes, "labels").String()
 	if len(labelChangesBytes) <= 0 {
-		return []*LabelChange{}, nil
+		return LabelChanges{}, nil
 	}
-	if err := json.Unmarshal([]byte(labelChangesBytes), &labelChanges); err != nil {
+
+	if err := util.BytesToObject(jsonBytes, &labelChanges); err != nil {
 		return nil, err
 	}
+
 	for _, v := range labelChanges {
 		if v.Operation == RemoveLabelOperation {
 			v.Values = nil
-		}
-	}
-	for _, change := range labelChanges {
-		if err := change.Validate(); err != nil {
-			return nil, err
 		}
 	}
 	return labelChanges, nil

--- a/pkg/query/update_test.go
+++ b/pkg/query/update_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Update", func() {
 		})
 
 		JustBeforeEach(func() {
-			body = []byte(fmt.Sprintf(`{"labels":[
+			body = []byte(fmt.Sprintf(`{"labels": [
 	{
 		"op": "%s",
 		"key": "key1",

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Peripli/service-manager/pkg/query"
-
 	"github.com/Peripli/service-manager/pkg/log"
 )
 
@@ -36,6 +34,15 @@ type HTTPError struct {
 // Error HTTPError should implement error
 func (e *HTTPError) Error() string {
 	return e.Description
+}
+
+// UnsupportedQueryError is an error to show that the provided query cannot be executed
+type UnsupportedQueryError struct {
+	Message string
+}
+
+func (uq *UnsupportedQueryError) Error() string {
+	return uq.Message
 }
 
 // WriteError sends a JSON containing the error to the response writer
@@ -131,7 +138,7 @@ func HandleSelectionError(err error, entityName ...string) error {
 		return nil
 	}
 
-	if _, ok := err.(*query.UnsupportedQueryError); ok {
+	if _, ok := err.(*UnsupportedQueryError); ok {
 		return &HTTPError{
 			Description: err.Error(),
 			ErrorType:   "BadRequest",

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -143,18 +143,3 @@ func HandleSelectionError(err error, entityName ...string) error {
 	}
 	return HandleStorageError(err, entityName[0])
 }
-
-func HandleLabelChangeError(err error) error {
-	if err == nil {
-		return nil
-	}
-
-	if _, ok := err.(*query.LabelChangeError); ok {
-		return &HTTPError{
-			Description: err.Error(),
-			ErrorType:   "BadRequest",
-			StatusCode:  http.StatusBadRequest,
-		}
-	}
-	return HandleStorageError(err, "")
-}

--- a/storage/postgres/abstract.go
+++ b/storage/postgres/abstract.go
@@ -131,7 +131,7 @@ func listByFieldCriteria(ctx context.Context, db pgDB, table string, entity inte
 func deleteAllByFieldCriteria(ctx context.Context, extContext sqlx.ExtContext, table string, dto interface{}, criteria []query.Criterion) error {
 	for _, criterion := range criteria {
 		if criterion.Type != query.FieldQuery {
-			return &query.UnsupportedQueryError{Message: "conditional delete is only supported for field queries"}
+			return &util.UnsupportedQueryError{Message: "conditional delete is only supported for field queries"}
 		}
 	}
 	if err := validateFieldQueryParams(dto, criteria); err != nil {
@@ -158,7 +158,7 @@ func validateFieldQueryParams(baseEntity interface{}, criteria []query.Criterion
 	}
 	for _, criterion := range criteria {
 		if criterion.Type == query.FieldQuery && !availableColumns[criterion.LeftOp] {
-			return &query.UnsupportedQueryError{Message: fmt.Sprintf("unsupported field query key: %s", criterion.LeftOp)}
+			return &util.UnsupportedQueryError{Message: fmt.Sprintf("unsupported field query key: %s", criterion.LeftOp)}
 		}
 	}
 	return nil

--- a/storage/postgres/labels.go
+++ b/storage/postgres/labels.go
@@ -38,11 +38,8 @@ func updateLabelsAbstract(ctx context.Context, newLabelFunc func(labelID string,
 			fallthrough
 		case query.AddLabelValuesOperation:
 			for _, labelValue := range action.Values {
-				if err := addLabel(ctx, newLabelFunc, pgDB, action.Key, labelValue); err != nil {
-					if err == util.ErrAlreadyExistsInStorage {
-						log.C(ctx).Infof("label with key %s and value %s already exists for this entity", action.Key, labelValue)
-						return nil
-					}
+				if err := addLabel(ctx, newLabelFunc, pgDB, action.Key, labelValue, referenceID); err != nil {
+					return err
 				}
 			}
 		case query.RemoveLabelOperation:
@@ -50,10 +47,6 @@ func updateLabelsAbstract(ctx context.Context, newLabelFunc func(labelID string,
 		case query.RemoveLabelValuesOperation:
 			pgLabel := newLabelFunc("", "", "")
 			if err := removeLabel(ctx, pgDB, pgLabel, referenceID, action.Key, action.Values...); err != nil {
-				if err == util.ErrNotFoundInStorage {
-					log.C(ctx).Infof("label with key %s cannot be modified or deleted as it does not exist", action.Key)
-					return nil
-				}
 				return err
 			}
 		}
@@ -61,16 +54,25 @@ func updateLabelsAbstract(ctx context.Context, newLabelFunc func(labelID string,
 	return nil
 }
 
-func addLabel(ctx context.Context, newLabelFunc func(labelID string, labelKey string, labelValue string) Labelable, db pgDB, key string, value string) error {
+func addLabel(ctx context.Context, newLabelFunc func(labelID string, labelKey string, labelValue string) Labelable, db pgDB, key string, value string, referenceID string) error {
 	uuids, err := uuid.NewV4()
 	if err != nil {
 		return fmt.Errorf("could not generate id for new label: %v", err)
 	}
 	labelID := uuids.String()
 	newLabel := newLabelFunc(labelID, key, value)
-	labelTable, _, _ := newLabel.Label()
-	if _, err := create(ctx, db, labelTable, newLabel); err != nil {
-		return err
+	labelTable, referenceColumnName, _ := newLabel.Label()
+
+	query := fmt.Sprintf("SELECT * FROM %s WHERE key=$1 and val=$2 and %s=$3", labelTable, referenceColumnName)
+	log.C(ctx).Debugf("Executing query %s", query)
+
+	err = db.GetContext(ctx, newLabel, query, key, value, referenceID)
+	if checkSQLNoRows(err) == util.ErrNotFoundInStorage {
+		if _, err := create(ctx, db, labelTable, newLabel); err != nil {
+			return err
+		}
+	} else {
+		log.C(ctx).Debugf("Nothing to create. Label with key=%s value=%s %s=%s already exists in table %s", key, value, referenceColumnName, referenceID, labelTable)
 	}
 	return nil
 }
@@ -81,7 +83,14 @@ func removeLabel(ctx context.Context, execer sqlx.ExtContext, labelable Labelabl
 	args := []interface{}{labelKey, referenceID}
 	// remove all labels with this key
 	if len(labelValues) == 0 {
-		return executeNew(ctx, execer, baseQuery, args)
+		if err := executeNew(ctx, execer, baseQuery, args); err != nil {
+			if err == util.ErrNotFoundInStorage {
+				log.C(ctx).Debugf("Nothing to delete. Label with key=%s %s=%s not found in table %s", labelKey, referenceColumnName, referenceID, labelTableName)
+				return nil
+			}
+			return err
+		}
+		return nil
 	}
 	// remove labels with a specific key and a value which is in the provided list
 	args = append(args, labelValues)
@@ -90,7 +99,15 @@ func removeLabel(ctx context.Context, execer sqlx.ExtContext, labelable Labelabl
 	if err != nil {
 		return err
 	}
-	return executeNew(ctx, execer, sqlQuery, queryParams)
+
+	if err := executeNew(ctx, execer, sqlQuery, queryParams); err != nil {
+		if err == util.ErrNotFoundInStorage {
+			log.C(ctx).Debugf("Nothing to delete. Label with key=%s values in %s %s=%s not found in table %s", labelKey, labelValues, referenceColumnName, referenceID, labelTableName)
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func buildQueryWithParams(extContext sqlx.ExtContext, sqlQuery string, baseTableName string, labelable Labelable, criteria []query.Criterion) (string, []interface{}, error) {

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -1237,7 +1237,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 					})
 
 					Context("Add label with existing key and value", func() {
-						It("Should return 400", func() {
+						It("Should return 200", func() {
 							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
@@ -1246,7 +1246,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
-								Status(http.StatusBadRequest)
+								Status(http.StatusOK)
 						})
 					})
 
@@ -1296,12 +1296,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							values := labels["cluster_id"].([]interface{})
 							changedLabelValues = []string{values[0].(string)}
 						})
-						It("Should return 400", func() {
+						It("Should return 200", func() {
 							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
-								Status(http.StatusBadRequest).JSON().Object().
-								Value("description").String().Contains("already exists")
+								Status(http.StatusOK)
 						})
 					})
 
@@ -1337,11 +1336,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							operation = query.RemoveLabelOperation
 							changedLabelKey = "non-existing-ey"
 						})
-						It("Should return 400", func() {
+						It("Should return 200", func() {
 							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
-								Status(http.StatusBadRequest)
+								Status(http.StatusOK)
 						})
 					})
 
@@ -1420,11 +1419,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							changedLabelKey = "cluster_id"
 							changedLabelValues = []string{"non-existing-value"}
 						})
-						It("Should return 400", func() {
+						It("Should return 200", func() {
 							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
-								Status(http.StatusBadRequest)
+								Status(http.StatusOK)
 						})
 					})
 				})

--- a/test/visibility_test/visibility_test.go
+++ b/test/visibility_test/visibility_test.go
@@ -503,7 +503,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 					})
 
 					Context("Add label with existing key and value", func() {
-						It("Should return 400", func() {
+						It("Should return 200", func() {
 							ctx.SMWithOAuth.PATCH("/v1/visibilities/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
@@ -512,7 +512,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							ctx.SMWithOAuth.PATCH("/v1/visibilities/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
-								Status(http.StatusBadRequest)
+								Status(http.StatusOK)
 						})
 					})
 
@@ -562,12 +562,12 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							values := labels["cluster_id"].([]interface{})
 							changedLabelValues = []string{values[0].(string)}
 						})
-						It("Should return 400", func() {
+
+						It("Should return 200", func() {
 							ctx.SMWithOAuth.PATCH("/v1/visibilities/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
-								Status(http.StatusBadRequest).JSON().Object().
-								Value("description").String().Contains("already exists")
+								Status(http.StatusOK)
 						})
 					})
 
@@ -603,11 +603,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							operation = query.RemoveLabelOperation
 							changedLabelKey = "non-existing-ey"
 						})
-						It("Should return 400", func() {
+						It("Should return 200", func() {
 							ctx.SMWithOAuth.PATCH("/v1/visibilities/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
-								Status(http.StatusBadRequest)
+								Status(http.StatusOK)
 						})
 					})
 
@@ -686,11 +686,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							changedLabelKey = "cluster_id"
 							changedLabelValues = []string{"non-existing-value"}
 						})
-						It("Should return 400", func() {
+						It("Should return 200", func() {
 							ctx.SMWithOAuth.PATCH("/v1/visibilities/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
-								Status(http.StatusBadRequest)
+								Status(http.StatusOK)
 						})
 					})
 				})


### PR DESCRIPTION
* small refactoring on labels
* when creating or updating a resource with labels, return 2xx instead of 409 if a label value is already present
* when creating or updating a resource with labels, return 2xx instead of 409 if a label is already present
* when creating or updating a resource with labels, return 2xx instead of 404 if a label is already deleted
* when creating or updating a resource with labels, return 2xx instead of 404 if a label value is already deleted