### PR TITLE
handle error from client response

### DIFF
--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -69,7 +69,11 @@ func HandleResponseError(response *http.Response) error {
 	}
 
 	err = fmt.Errorf("StatusCode: %d Body: %s", response.StatusCode, body)
-	log.C(response.Request.Context()).Errorf("Call to client failed with: %s", err)
+	if response.Request != nil {
+		log.C(response.Request.Context()).Errorf("Call to client failed with: %s", err)
+	} else {
+		log.D().Errorf("Call to client failed with: %s", err)
+	}
 	return err
 }
 

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -69,7 +69,7 @@ func HandleResponseError(response *http.Response) error {
 	}
 
 	err = fmt.Errorf("StatusCode: %d Body: %s", response.StatusCode, body)
-	log.D().Errorf("Call to client failed with: %s", err)
+	log.C(response.Request.Context()).Errorf("Call to client failed with: %s", err)
 	return err
 }
 

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -26,7 +26,7 @@ import (
 	"github.com/Peripli/service-manager/pkg/log"
 )
 
-// HTTPError is an error type that provides error details compliant with the Open Service Broker API conventions
+// HTTPError is an error type that provides error details that Service Manager error handlers would propagate to the client
 type HTTPError struct {
 	ErrorType   string `json:"error,omitempty"`
 	Description string `json:"description,omitempty"`
@@ -44,10 +44,10 @@ func WriteError(err error, writer http.ResponseWriter) {
 	logger := log.D()
 	switch t := err.(type) {
 	case *HTTPError:
-		logger.Debug(err)
+		logger.Errorf("HTTPError: %s", err)
 		respError = t
 	default:
-		logger.Error(err)
+		logger.Errorf("Unexpected error: %s", err)
 		respError = &HTTPError{
 			ErrorType:   "InternalError",
 			Description: "Internal server error",
@@ -63,22 +63,14 @@ func WriteError(err error, writer http.ResponseWriter) {
 
 // HandleResponseError builds at HttpErrorResponse from the given response.
 func HandleResponseError(response *http.Response) error {
-	logger := log.D()
-	logger.Errorf("Handling failure response: returned status code %d", response.StatusCode)
-	httpErr := &HTTPError{
-		StatusCode: response.StatusCode,
-	}
-
 	body, err := BodyToBytes(response.Body)
 	if err != nil {
 		return fmt.Errorf("error processing response body of resp with status code %d: %s", response.StatusCode, err)
 	}
 
-	if err := BytesToObject(body, httpErr); err != nil || httpErr.Description == "" {
-		logger.Debugf("Failure response with status code %d is not an HTTPError. Error converting body: %v. Default err will be returned.", response.StatusCode, err)
-		return fmt.Errorf("StatusCode: %d Body: %s", response.StatusCode, body)
-	}
-	return httpErr
+	err = fmt.Errorf("StatusCode: %d Body: %s", response.StatusCode, body)
+	log.D().Errorf("Call to client failed with: %s", err)
+	return err
 }
 
 var (

--- a/pkg/util/errors_test.go
+++ b/pkg/util/errors_test.go
@@ -17,6 +17,7 @@
 package util_test
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -104,9 +105,11 @@ var _ = Describe("Errors", func() {
 		Context("when response contains standard error", func() {
 			It("returns an error containing information about the error handling failure", func() {
 				e := fmt.Errorf("test error")
+				r := http.Request{}
 				response := &http.Response{
 					StatusCode: http.StatusTeapot,
 					Body:       common.Closer(e.Error()),
+					Request:    r.WithContext(context.TODO()),
 				}
 
 				err := util.HandleResponseError(response)
@@ -117,9 +120,11 @@ var _ = Describe("Errors", func() {
 		Context("when response contains JSON error that has no description", func() {
 			It("returns an error containing the response body", func() {
 				e := `{"key":"value"}`
+				r := http.Request{}
 				response := &http.Response{
 					StatusCode: http.StatusTeapot,
 					Body:       common.Closer(e),
+					Request:    r.WithContext(context.TODO()),
 				}
 
 				err := util.HandleResponseError(response)

--- a/pkg/util/errors_test.go
+++ b/pkg/util/errors_test.go
@@ -96,7 +96,7 @@ var _ = Describe("Errors", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				err = util.HandleResponseError(response)
-				validateHTTPErrorOccured(err, response.StatusCode)
+				validateHTTPErrorOccurred(err, response.StatusCode)
 
 			})
 		})
@@ -140,7 +140,7 @@ var _ = Describe("Errors", func() {
 				It("returns proper HTTPError", func() {
 					err := util.HandleStorageError(util.ErrAlreadyExistsInStorage, "entityName")
 
-					validateHTTPErrorOccured(err, http.StatusConflict)
+					validateHTTPErrorOccurred(err, http.StatusConflict)
 				})
 			})
 
@@ -148,7 +148,7 @@ var _ = Describe("Errors", func() {
 				It("returns proper HTTPError", func() {
 					err := util.HandleStorageError(util.ErrNotFoundInStorage, "entityName")
 
-					validateHTTPErrorOccured(err, http.StatusNotFound)
+					validateHTTPErrorOccurred(err, http.StatusNotFound)
 				})
 			})
 


### PR DESCRIPTION
When handing client errors, we don't want to propagate the client error to the api consumer but rather log it and return a general error