### PR TITLE
Broker API response now returns "service_brokers" instead of "brokers"

### DIFF
--- a/pkg/types/broker.go
+++ b/pkg/types/broker.go
@@ -28,7 +28,7 @@ import (
 
 // Brokers struct
 type Brokers struct {
-	Brokers []*Broker `json:"brokers"`
+	Brokers []*Broker `json:"service_brokers"`
 }
 
 // Broker broker struct

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -769,7 +769,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							ctx.SMWithOAuth.GET("/v1/service_brokers").
 								Expect().
 								Status(http.StatusOK).
-								JSON().Object().Value("brokers").Array().First().Object().
+								JSON().Object().Value("service_brokers").Array().First().Object().
 								ContainsMap(expectedBrokerResponse)
 
 							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -162,7 +162,7 @@ func MapContains(actual Object, expected Object) {
 }
 
 func RemoveAllBrokers(SM *httpexpect.Expect) {
-	removeAll(SM, "brokers", "/v1/service_brokers")
+	removeAll(SM, "service_brokers", "/v1/service_brokers")
 }
 
 func RemoveAllPlatforms(SM *httpexpect.Expect) {

--- a/test/delete_list.go
+++ b/test/delete_list.go
@@ -285,12 +285,7 @@ func DescribeDeleteListFor(ctx *common.TestContext, t TestCase) bool {
 	}
 
 	verifyDeleteListOpHelper := func(deleteListOpEntry deleteOpEntry, query string) {
-
-		// workaround for brokers api
 		jsonArrayKey := strings.Replace(t.API, "/v1/", "", 1)
-		if jsonArrayKey == "service_brokers" {
-			jsonArrayKey = "brokers"
-		}
 
 		expectedAfterOpIDs := make([]string, 0)
 		unexpectedAfterOpIDs := make([]string, 0)

--- a/test/list.go
+++ b/test/list.go
@@ -273,11 +273,7 @@ func DescribeListTestsFor(ctx *common.TestContext, t TestCase) bool {
 		expectedAfterOpIDs = common.ExtractResourceIDs(listOpEntry.resourcesToExpectAfterOp)
 		unexpectedAfterOpIDs = common.ExtractResourceIDs(listOpEntry.resourcesNotToExpectAfterOp)
 
-		// workaround for brokers api
 		jsonArrayKey := strings.Replace(t.API, "/v1/", "", 1)
-		if jsonArrayKey == "service_brokers" {
-			jsonArrayKey = "brokers"
-		}
 
 		By(fmt.Sprintf("[TEST]: Verifying expected %s before operation after present", t.API))
 		beforeOpArray := ctx.SMWithOAuth.GET(t.API).


### PR DESCRIPTION
Broker API response now returns "service_brokers" instead of "brokers"

* Requires adoption in proxy-core
* Requires adoption in CLI