### PR TITLE
Test Broker request body not usable

### DIFF
--- a/test/common/broker.go
+++ b/test/common/broker.go
@@ -17,6 +17,7 @@
 package common
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -173,8 +174,16 @@ func (b *BrokerServer) authenticationMiddleware(next http.Handler) http.Handler 
 
 func (b *BrokerServer) saveRequestMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		defer func() {
+			err := req.Body.Close()
+			if err != nil {
+				panic(err)
+			}
+		}()
 		b.LastRequest = req
 		bodyBytes, err := ioutil.ReadAll(req.Body)
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+
 		if err != nil {
 			SetResponse(w, http.StatusInternalServerError, Object{
 				"description": "Could not read body",


### PR DESCRIPTION
Currently the test broker reads the request body in one of its middlewares and does not allow the subsequent handlers to use the body.

This PR addresses the issue.