### PR TITLE
Patch service broker with duplicate plans per service

### DIFF
--- a/api/broker/broker_controller.go
+++ b/api/broker/broker_controller.go
@@ -227,7 +227,6 @@ func (c *Controller) patchBroker(r *web.Request) (*web.Response, error) {
 	if err := transformBrokerCredentials(ctx, broker, c.Encrypter.Decrypt); err != nil {
 		return nil, err
 	}
-
 	createdAt := broker.CreatedAt
 
 	changes, err := query.LabelChangesFromJSON(r.Body)
@@ -263,14 +262,14 @@ func (c *Controller) patchBroker(r *web.Request) (*web.Response, error) {
 	return util.NewJSONResponse(http.StatusOK, broker)
 }
 
-func convertExistingCatalogToMaps(serviceOfferings []*types.ServiceOffering) (map[string]*types.ServiceOffering, map[string]*types.ServicePlan) {
+func convertExistingServiceOferringsToMaps(serviceOfferings []*types.ServiceOffering) (map[string]*types.ServiceOffering, map[string][]*types.ServicePlan) {
 	serviceOfferingsMap := make(map[string]*types.ServiceOffering)
-	servicePlansMap := make(map[string]*types.ServicePlan)
+	servicePlansMap := make(map[string][]*types.ServicePlan)
 
 	for serviceOfferingIndex := range serviceOfferings {
 		serviceOfferingsMap[serviceOfferings[serviceOfferingIndex].CatalogID] = serviceOfferings[serviceOfferingIndex]
 		for servicePlanIndex := range serviceOfferings[serviceOfferingIndex].Plans {
-			servicePlansMap[serviceOfferings[serviceOfferingIndex].Plans[servicePlanIndex].CatalogID] = serviceOfferings[serviceOfferingIndex].Plans[servicePlanIndex]
+			servicePlansMap[serviceOfferings[serviceOfferingIndex].CatalogID] = append(servicePlansMap[serviceOfferings[serviceOfferingIndex].CatalogID], serviceOfferings[serviceOfferingIndex].Plans[servicePlanIndex])
 		}
 	}
 
@@ -410,8 +409,8 @@ func (c *Controller) resyncBrokerAndCatalog(ctx context.Context, broker *types.B
 
 		}
 
-		existingServicesOfferingsMap, existingServicePlansMap := convertExistingCatalogToMaps(existingServiceOfferingsWithServicePlans)
-		log.C(ctx).Debugf("Found %d services and %d plans currently known for broker", len(existingServicesOfferingsMap), len(existingServicePlansMap))
+		existingServicesOfferingsMap, existingServicePlansPerOferringMap := convertExistingServiceOferringsToMaps(existingServiceOfferingsWithServicePlans)
+		log.C(ctx).Debugf("Found %d services currently known for broker", len(existingServicesOfferingsMap))
 
 		catalogServices, catalogPlansMap, err := getBrokerCatalogServicesAndPlans(catalog)
 		if err != nil {
@@ -490,24 +489,59 @@ func (c *Controller) resyncBrokerAndCatalog(ctx context.Context, broker *types.B
 
 		log.C(ctx).Debugf("Resyncing service plans for broker with id %s", broker.ID)
 		for _, catalogPlan := range catalogPlans {
-			existingServicePlan, ok := existingServicePlansMap[catalogPlan.ID]
-			delete(existingServicePlansMap, catalogPlan.ID)
+			existingServicePlans, ok := existingServicePlansPerOferringMap[catalogPlan.ServiceOffering.CatalogID]
+			// delete(existingServicePlansPerOferringMap, catalogPlan.ID)
 			if ok {
-				if err := osbcCatalogPlanToServicePlan(existingServicePlan, catalogPlan); err != nil {
-					return err
-				}
-				existingServicePlan.UpdatedAt = time.Now().UTC()
-
-				if err := existingServicePlan.Validate(); err != nil {
-					return &util.HTTPError{
-						ErrorType:   "BadRequest",
-						Description: fmt.Sprintf("service plan constructed during catalog update for broker %s is invalid: %s", broker.ID, err),
-						StatusCode:  http.StatusBadRequest,
+				var existingPlan *types.ServicePlan
+				var newPlansMapping []*types.ServicePlan
+				for _, existingServicePlan := range existingServicePlans {
+					if existingServicePlan.CatalogID == catalogPlan.ID {
+						existingPlan = existingServicePlan
+					} else {
+						newPlansMapping = append(newPlansMapping, existingServicePlan)
 					}
 				}
+				if existingPlan != nil {
+					if err := osbcCatalogPlanToServicePlan(existingPlan, catalogPlan); err != nil {
+						return err
+					}
+					existingPlan.UpdatedAt = time.Now().UTC()
 
-				if err := txStorage.ServicePlan().Update(ctx, existingServicePlan); err != nil {
-					return util.HandleStorageError(err, "service_plan")
+					if err := existingPlan.Validate(); err != nil {
+						return &util.HTTPError{
+							ErrorType:   "BadRequest",
+							Description: fmt.Sprintf("service plan constructed during catalog update for broker %s is invalid: %s", broker.ID, err),
+							StatusCode:  http.StatusBadRequest,
+						}
+					}
+
+					if err := txStorage.ServicePlan().Update(ctx, existingPlan); err != nil {
+						return util.HandleStorageError(err, "service_plan")
+					}
+					existingServicePlansPerOferringMap[catalogPlan.ServiceOffering.CatalogID] = newPlansMapping
+				} else {
+					planUUID, err := uuid.NewV4()
+					if err != nil {
+						return fmt.Errorf("could not generate GUID for service_plan: %s", err)
+					}
+					servicePlan := &types.ServicePlan{}
+					if err := osbcCatalogPlanToServicePlan(servicePlan, catalogPlan); err != nil {
+						return err
+					}
+					servicePlan.ID = planUUID.String()
+					servicePlan.CreatedAt = time.Now().UTC()
+					servicePlan.UpdatedAt = time.Now().UTC()
+					if err := servicePlan.Validate(); err != nil {
+						return &util.HTTPError{
+							ErrorType:   "BadRequest",
+							Description: fmt.Sprintf("service plan constructed during catalog update for broker %s is invalid: %s", broker.ID, err),
+							StatusCode:  http.StatusBadRequest,
+						}
+					}
+
+					if _, err := txStorage.ServicePlan().Create(ctx, servicePlan); err != nil {
+						return util.HandleStorageError(err, "service_plan")
+					}
 				}
 			} else {
 				planUUID, err := uuid.NewV4()
@@ -535,14 +569,16 @@ func (c *Controller) resyncBrokerAndCatalog(ctx context.Context, broker *types.B
 			}
 		}
 
-		for _, existingServicePlan := range existingServicePlansMap {
-			byID := query.ByField(query.EqualsOperator, "id", existingServicePlan.ID)
-			if err := txStorage.ServicePlan().Delete(ctx, byID); err != nil {
-				if err == util.ErrNotFoundInStorage {
-					// If the service for the plan was deleted, plan would already be gone
-					continue
+		for _, existingServicePlansForOffering := range existingServicePlansPerOferringMap {
+			for _, existingServicePlan := range existingServicePlansForOffering {
+				byID := query.ByField(query.EqualsOperator, "id", existingServicePlan.ID)
+				if err := txStorage.ServicePlan().Delete(ctx, byID); err != nil {
+					if err == util.ErrNotFoundInStorage {
+						// If the service for the plan was deleted, plan would already be gone
+						continue
+					}
+					return util.HandleStorageError(err, "service_plan")
 				}
-				return util.HandleStorageError(err, "service_plan")
 			}
 		}
 		log.C(ctx).Debugf("Successfully resynced service plans for broker with id %s", broker.ID)

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -830,7 +830,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							brokerServer.Catalog = common.SBCatalog(catalog)
 						})
 
-						FIt("is returned from the Services API associated with the correct broker", func() {
+						It("is returned from the Services API associated with the correct broker", func() {
 							ctx.SMWithOAuth.GET("/v1/service_offerings").
 								Expect().
 								Status(http.StatusOK).


### PR DESCRIPTION
Currently a broker may expose multiple service in its catalog where each service may contain the same set of plans. This PR fixes the issue where this is not allowed