### PR TITLE
Omit platform credentials for Platform PATCH API response

### DIFF
--- a/api/platform/platform_controller.go
+++ b/api/platform/platform_controller.go
@@ -174,5 +174,6 @@ func (c *Controller) patchPlatform(r *web.Request) (*web.Response, error) {
 		return nil, err
 	}
 
+	platform.Credentials = nil
 	return util.NewJSONResponse(http.StatusOK, platform)
 }

--- a/test/platform_test/platform_test.go
+++ b/test/platform_test/platform_test.go
@@ -182,6 +182,8 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							Expect().
 							Status(http.StatusOK).JSON().Object()
 
+						reply.NotContainsKey("credentials")
+
 						updatedPlatform["id"] = id
 						common.MapContains(reply.Raw(), updatedPlatform)
 
@@ -209,6 +211,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							Expect().
 							Status(http.StatusOK).JSON().Object().
 							ContainsKey("created_at").
+							NotContainsKey("credentials").
 							ValueNotEqual("created_at", createdAt)
 
 						By("Update is persisted")
@@ -234,6 +237,8 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).JSON().Object()
 
+							reply.NotContainsKey("credentials")
+
 							platform[prop] = val
 							common.MapContains(reply.Raw(), platform)
 
@@ -251,7 +256,8 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						ctx.SMWithOAuth.PATCH("/v1/platforms/" + id).
 							WithJSON(common.Object{"id": "123"}).
 							Expect().
-							Status(http.StatusOK)
+							Status(http.StatusOK).JSON().Object().
+							NotContainsKey("credentials")
 
 						ctx.SMWithOAuth.GET("/v1/platforms/123").
 							Expect().


### PR DESCRIPTION
# Pull Request Template

## Motivation

Currently when updating a platform the response body would contain credentials where the password would be messed up (because it's encrypted).

In reality, we have specified in the Service Manager specification that platform credentials will be returned only upon platform credentials. So we should not return then in any form for other APIs.
