### PR TITLE
Drop Broker URL constraint

### DIFF
--- a/storage/postgres/migrations/007_drop_broker_url_constraint.down.sql
+++ b/storage/postgres/migrations/007_drop_broker_url_constraint.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE brokers ADD CONSTRAINT unique_broker_url UNIQUE (broker_url);
+
+COMMIT;

--- a/storage/postgres/migrations/007_drop_broker_url_constraint.up.sql
+++ b/storage/postgres/migrations/007_drop_broker_url_constraint.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE brokers DROP CONSTRAINT unique_broker_url;
+
+COMMIT;


### PR DESCRIPTION
# Pull Request Template

## Motivation

Broker registrations should not be restricted to unique URLs. Unique names should be sufficient for now.

## Approach

Added migration.

## Pull Request status

* [x] Initial implementation
