### PR TITLE
Add sending request with headers

### DIFF
--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -32,6 +32,11 @@ type DoRequestFunc func(request *http.Request) (*http.Response, error)
 
 // SendRequest sends a request to the specified client and the provided URL with the specified parameters and body.
 func SendRequest(ctx context.Context, doRequest DoRequestFunc, method, url string, params map[string]string, body interface{}) (*http.Response, error) {
+	return SendRequestWithHeaders(ctx, doRequest, method, url, params, body, map[string]string{})
+}
+
+// SendRequestWithHeaders sends a request to the specified client and the provided URL with the specified parameters, body and headers.
+func SendRequestWithHeaders(ctx context.Context, doRequest DoRequestFunc, method, url string, params map[string]string, body interface{}, headers map[string]string) (*http.Response, error) {
 	var bodyReader io.Reader
 
 	if body != nil {
@@ -45,6 +50,10 @@ func SendRequest(ctx context.Context, doRequest DoRequestFunc, method, url strin
 	request, err := http.NewRequest(method, url, bodyReader)
 	if err != nil {
 		return nil, err
+	}
+
+	for key, value := range headers {
+		request.Header.Add(key, value)
 	}
 
 	if params != nil {

--- a/pkg/util/client_test.go
+++ b/pkg/util/client_test.go
@@ -107,6 +107,27 @@ var _ = Describe("Client Utils", func() {
 		})
 	})
 
+	Context("When sending a request with a header", func() {
+		BeforeEach(func() {
+			expectations.URL = "http://example.com"
+
+			reaction.Err = nil
+			reaction.Status = http.StatusOK
+		})
+
+		It("should attach it as header", func() {
+			ctx := context.TODO()
+			resp, err := util.SendRequestWithHeaders(ctx, requestFunc, "GET", "http://example.com", nil, nil, map[string]string{
+				"header": "header",
+			})
+
+			header := resp.Request.Header.Get("header")
+			Expect(header).To(Equal("header"))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		})
+	})
+
 	Describe("BodyToObject", func() {
 		var resp *http.Response
 		var err error


### PR DESCRIPTION
Currently send request util cannot be used for post/patch apis that require content-type header. A new util method is added to allow providing headers (this is also backward compatible as the go API of the old SendRequest method is not changed)