### PR TITLE
Add test for updating broker with 2 services and identical plans

### DIFF
--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -840,6 +840,13 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								WithJSON(common.Object{}).
 								Expect().
 								Status(http.StatusOK)
+
+							By("updating broker again with 2 services with identical plans, should succeed")
+							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + brokerID).
+								WithJSON(common.Object{}).
+								Expect().
+								Status(http.StatusOK)
+
 							servicesJsonResp := ctx.SMWithOAuth.GET("/v1/service_offerings").
 								Expect().
 								Status(http.StatusOK).
@@ -869,7 +876,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							plansJsonResp.Path("$.service_plans[*].catalog_id").Array().Contains(existingPlanID)
 							plansJsonResp.Path("$.service_plans[*].service_offering_id").Array().Contains(soID)
 
-							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+							assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 						})
 					})
 					Context("when a new service offering with new plans is added", func() {


### PR DESCRIPTION
## Motivation

When broker with 2 services and identical plans is updated (broker's catalog is not changed), Service Manager should not confuse these plans. This PR addresses this behavior with component test.

## Pull Request status

* [x] Unit tests
