### PR TITLE
Fix cf/env_test when STORAGE.URI is set

### DIFF
--- a/cf/env_test.go
+++ b/cf/env_test.go
@@ -68,6 +68,7 @@ var _ = Describe("CF Env", func() {
 		Expect(os.Setenv("VCAP_APPLICATION", "{}")).ShouldNot(HaveOccurred())
 		Expect(os.Setenv("VCAP_SERVICES", VCAP_SERVICES_VALUE)).ShouldNot(HaveOccurred())
 		Expect(os.Setenv("STORAGE_NAME", "smdb")).ShouldNot(HaveOccurred())
+		Expect(os.Unsetenv("STORAGE_URI")).ShouldNot(HaveOccurred())
 
 		environment, err = env.New(env.EmptyFlagSet())
 		Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
When STORAGE_URI env variable is set the test cf/env_test.go fails.
Solution is to unset the variable before the tests begin.