### PR TITLE
Release connection when working with rows

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -12,6 +12,7 @@ storage:
   uri: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
   encryption_key: ejHjRNHbS0NaqARSRvnweVV9zcmhQEa8
   skip_ssl_validation: false
+  max_idle_connections: 5
 api:
   token_issuer_url: http://localhost:8080/uaa
   client_id: cf

--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -59,10 +59,11 @@ type Settings struct {
 // DefaultSettings returns default values for storage settings
 func DefaultSettings() *Settings {
 	return &Settings{
-		URI:               "",
-		MigrationsURL:     fmt.Sprintf("file://%s/postgres/migrations", basepath),
-		EncryptionKey:     "",
-		SkipSSLValidation: false,
+		URI:                "",
+		MigrationsURL:      fmt.Sprintf("file://%s/postgres/migrations", basepath),
+		EncryptionKey:      "",
+		SkipSSLValidation:  false,
+		MaxIdleConnections: 5,
 	}
 }
 

--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -49,10 +49,11 @@ var (
 
 // Settings type to be loaded from the environment
 type Settings struct {
-	URI               string
-	MigrationsURL     string `mapstructure:"migrations_url"`
-	EncryptionKey     string `mapstructure:"encryption_key"`
-	SkipSSLValidation bool   `mapstructure:"skip_ssl_validation"`
+	URI                string
+	MigrationsURL      string `mapstructure:"migrations_url"`
+	EncryptionKey      string `mapstructure:"encryption_key"`
+	SkipSSLValidation  bool   `mapstructure:"skip_ssl_validation"`
+	MaxIdleConnections int    `mapstructure:"max_idle_connections"`
 }
 
 // DefaultSettings returns default values for storage settings

--- a/storage/postgres/abstract.go
+++ b/storage/postgres/abstract.go
@@ -254,6 +254,15 @@ func checkIntegrityViolation(ctx context.Context, err error) error {
 	return err
 }
 
+func closeRows(ctx context.Context, rows *sqlx.Rows) {
+	if rows == nil {
+		return
+	}
+	if err := rows.Close(); err != nil {
+		log.C(ctx).WithError(err).Errorf("Could not release connection")
+	}
+}
+
 func checkRowsAffected(ctx context.Context, result sql.Result) error {
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {

--- a/storage/postgres/security.go
+++ b/storage/postgres/security.go
@@ -92,6 +92,7 @@ type keyFetcher struct {
 func (s *keyFetcher) GetEncryptionKey(ctx context.Context) ([]byte, error) {
 	safe := &Safe{}
 	rows, err := listByFieldCriteria(ctx, s.db, "safe", []query.Criterion{})
+	defer closeRows(ctx, rows)
 	if err != nil {
 		return nil, err
 	}
@@ -115,6 +116,7 @@ type keySetter struct {
 // Sets the encryption key by encrypting it beforehand with the encryption key in the environment
 func (k *keySetter) SetEncryptionKey(ctx context.Context, key []byte) error {
 	rows, err := listByFieldCriteria(ctx, k.db, "safe", []query.Criterion{})
+	defer closeRows(ctx, rows)
 	if err != nil {
 		return err
 	}

--- a/storage/postgres/storage.go
+++ b/storage/postgres/storage.go
@@ -214,14 +214,7 @@ func (ps *PostgresStorage) Delete(ctx context.Context, objType types.ObjectType,
 		return nil, err
 	}
 	rows, err := deleteAllByFieldCriteria(ctx, ps.pgDB, entity.TableName(), entity, criteria)
-	defer func() {
-		if rows == nil {
-			return
-		}
-		if err := rows.Close(); err != nil {
-			log.C(ctx).Errorf("Could not release connection when checking database. Error: %s", err)
-		}
-	}()
+	defer closeRows(ctx, rows)
 	if err != nil {
 		return nil, err
 	}
@@ -252,6 +245,7 @@ func (ps *PostgresStorage) Update(ctx context.Context, obj types.Object, labelCh
 	if err != nil {
 		return nil, err
 	}
+	defer closeRows(ctx, rows)
 	labels, err := labelsRowsToList(rows, func() PostgresLabel { return entity.LabelEntity() })
 	if err != nil {
 		return nil, err
@@ -290,9 +284,10 @@ func (ps *PostgresStorage) InTransaction(ctx context.Context, f func(ctx context
 	}()
 
 	transactionalStorage := &PostgresStorage{
-		pgDB:   tx,
-		db:     ps.db,
-		scheme: ps.scheme,
+		pgDB:          tx,
+		db:            ps.db,
+		scheme:        ps.scheme,
+		encryptionKey: ps.encryptionKey,
 	}
 
 	if err = f(ctx, transactionalStorage); err != nil {

--- a/storage/postgres/storage.go
+++ b/storage/postgres/storage.go
@@ -90,6 +90,7 @@ func (ps *PostgresStorage) Open(options *storage.Settings) error {
 		if err := ps.updateSchema(options.MigrationsURL); err != nil {
 			log.D().Panicln("Could not update database schema:", err)
 		}
+		ps.db.SetMaxIdleConns(options.MaxIdleConnections)
 		ps.pgDB = ps.db
 		ps.scheme = newScheme()
 		ps.scheme.introduce(&Broker{})


### PR DESCRIPTION
Currently, rows are not closed in multiple places.  
This results in connection exhaustion when decrypting credentials for more than 50 items at a time.

### Tests
Tested on a local dockerized Postgres with max connections = 100. 
110 platforms in the database. On `List` the password is decrypted:

## Before this fix
No call to list platforms passes, because for each platform, a new connection is opened to the database, but is not closed / released. So with any more than 50 platforms in the database, this call fails.

## With this fix

* 50 parallel requests. 
We get a spike of idle & total connections.
![016FB74C-D0B5-4337-A8B0-ADD80AECB6BE](https://user-images.githubusercontent.com/4910295/55953834-dc5c4e80-5c65-11e9-94d4-4d2d6eb90ef6.png)

* 97 parallel requests. 
Sometimes  `sorry, too many clients already` which is expected, as the maximum number of connections is 100
![978247BC-92AD-483E-8491-E3433F8CA960](https://user-images.githubusercontent.com/4910295/55953888-fc8c0d80-5c65-11e9-96b3-90a9861b9039.png)

Tried to perform the tests by starting a transaction to fetch the platforms & encryption key inside it. No difference, new connections are opened, but they are active. No new idle connections remain.
![566E7CFD-C0E0-4B28-A0DE-DAB7B26838DF](https://user-images.githubusercontent.com/4910295/55954449-61943300-5c67-11e9-9659-d4150e56b992.png)

We might decide not to fetch the encryption key on every encrypt/decrypt operation, but fetch it on startup, and keep the secondary encryption key in memory.


