### PR TITLE
Extend test framework

### DIFF
--- a/test/common/common.go
+++ b/test/common/common.go
@@ -210,8 +210,9 @@ func RegisterBrokerInSM(brokerJSON Object, SM *httpexpect.Expect) string {
 	return reply.Value("id").String().Raw()
 }
 
-func RegisterPlatformInSM(platformJSON Object, SM *httpexpect.Expect) *types.Platform {
+func RegisterPlatformInSM(platformJSON Object, SM *httpexpect.Expect, headers map[string]string) *types.Platform {
 	reply := SM.POST("/v1/platforms").
+		WithHeaders(headers).
 		WithJSON(platformJSON).
 		Expect().Status(http.StatusCreated).JSON().Object().Raw()
 	platform := &types.Platform{

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -205,7 +205,7 @@ func removeAll(SM *httpexpect.Expect, entity, rootURLPath string) {
 	SM.DELETE(rootURLPath).Expect()
 }
 
-func RegisterBrokerInSM(brokerJSON Object, SM *httpexpect.Expect,  headers map[string]string) Object {
+func RegisterBrokerInSM(brokerJSON Object, SM *httpexpect.Expect, headers map[string]string) Object {
 	return SM.POST("/v1/service_brokers").
 		WithHeaders(headers).
 		WithJSON(brokerJSON).Expect().Status(http.StatusCreated).JSON().Object().Raw()

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -203,8 +203,9 @@ func removeAll(SM *httpexpect.Expect, entity, rootURLPath string) {
 	SM.DELETE(rootURLPath).Expect()
 }
 
-func RegisterBrokerInSM(brokerJSON Object, SM *httpexpect.Expect) string {
+func RegisterBrokerInSM(brokerJSON Object, SM *httpexpect.Expect, headers map[string]string) string {
 	reply := SM.POST("/v1/service_brokers").
+		WithHeaders(headers).
 		WithJSON(brokerJSON).
 		Expect().Status(http.StatusCreated).JSON().Object()
 	return reply.Value("id").String().Raw()

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -221,7 +221,7 @@ func (tcb *TestContextBuilder) Build() *TestContext {
 
 	if !tcb.shouldSkipBasicAuthClient {
 		platformJSON := MakePlatform("tcb-platform-test", "tcb-platform-test", "platform-type", "test-platform")
-		platform := RegisterPlatformInSM(platformJSON, SMWithOAuth)
+		platform := RegisterPlatformInSM(platformJSON, SMWithOAuth, map[string]string{})
 		SMWithBasic := SM.Builder(func(req *httpexpect.Request) {
 			username, password := platform.Credentials.Basic.Username, platform.Credentials.Basic.Password
 			req.WithBasicAuth(username, password)
@@ -334,7 +334,7 @@ func (ctx *TestContext) RegisterPlatform() *types.Platform {
 		"type":        "testType",
 		"description": "testDescrption",
 	}
-	return RegisterPlatformInSM(platformJSON, ctx.SMWithOAuth)
+	return RegisterPlatformInSM(platformJSON, ctx.SMWithOAuth, map[string]string{})
 }
 
 func (ctx *TestContext) CleanupBroker(id string) {

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -285,7 +285,7 @@ func (ctx *TestContext) RegisterBrokerWithCatalogAndLabels(catalog SBCatalog, br
 
 	MergeObjects(brokerJSON, brokerData)
 
-	brokerID := RegisterBrokerInSM(brokerJSON, ctx.SMWithOAuth)
+	brokerID := RegisterBrokerInSM(brokerJSON, ctx.SMWithOAuth, map[string]string{})
 	brokerServer.ResetCallHistory()
 	ctx.Servers[BrokerServerPrefix+brokerID] = brokerServer
 	brokerJSON["id"] = brokerID

--- a/test/osb_test/osb_test.go
+++ b/test/osb_test/osb_test.go
@@ -580,7 +580,7 @@ var _ = Describe("Service Manager OSB API", func() {
 						},
 					},
 				}
-				prefixedBrokerID = common.RegisterBrokerInSM(brokerJSON, ctx.SMWithOAuth)
+				prefixedBrokerID = common.RegisterBrokerInSM(brokerJSON, ctx.SMWithOAuth, map[string]string{})
 				ctx.Servers[common.BrokerServerPrefix+prefixedBrokerID] = server
 				osbURL = "/v1/osb/" + prefixedBrokerID
 			})


### PR DESCRIPTION
# Pull Request Template

## Prerequisites

https://github.com/Peripli/service-manager/issues/262

## Motivation

I'm trying to extend test framework to allow custom headers in the requests for creating platforms and brokers.

## Approach

New parameter is added to functions that create platforms and brokers which may contain custom headers.

## Pull Request status

Use checklists as a means to represent the status of your Pull Request.

For example:

* [ ] Initial implementation
* [x] Refactoring in tests
* [ ] Unit tests
* [ ] Integration tests

## Third-party code

Not applicable.

## Work in Progress label

Not applicable.

[1]: https://github.com/Peripli/service-manager/blob/master/CONTRIBUTING.md
