### PR TITLE
Ignore make leftover files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.dll
 *.so
 *.dylib
+/bin
 
 # Test binary, build with `go test -c`
 *.test
@@ -10,6 +11,10 @@
 # Output of the go coverage tool
 *.out
 *.cov
+coverage.html
+
+# Temporary build artefacts
+/generate
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/


### PR DESCRIPTION
## Motivation

After running make some generated files appear as new files to git. These files should not be commited.

## Approach

Add those files to .gitignore


