### PR TITLE
Fix handling with notification revision 0

### DIFF
--- a/cmd/smgen/api_type_template.go
+++ b/cmd/smgen/api_type_template.go
@@ -57,8 +57,10 @@ func (e *{{.Type}}) MarshalJSON() ([]byte, error) {
 		*E
 		CreatedAt *string ` + "`json:\"created_at,omitempty\"`" + `
 		UpdatedAt *string ` + "`json:\"updated_at,omitempty\"`" + `
+		Labels    Labels  ` + "`json:\"labels,omitempty\"`" + `
 	}{
-		E: (*E)(e),
+		E:      (*E)(e),
+		Labels: e.Labels,
 	}
 	if !e.CreatedAt.IsZero() {
 		str := util.ToRFCFormat(e.CreatedAt)

--- a/pkg/types/notification_gen.go
+++ b/pkg/types/notification_gen.go
@@ -37,8 +37,10 @@ func (e *Notification) MarshalJSON() ([]byte, error) {
 		*E
 		CreatedAt *string `json:"created_at,omitempty"`
 		UpdatedAt *string `json:"updated_at,omitempty"`
+		Labels    Labels  `json:"labels,omitempty"`
 	}{
-		E: (*E)(e),
+		E:      (*E)(e),
+		Labels: e.Labels,
 	}
 	if !e.CreatedAt.IsZero() {
 		str := util.ToRFCFormat(e.CreatedAt)

--- a/pkg/types/platform_gen.go
+++ b/pkg/types/platform_gen.go
@@ -37,8 +37,10 @@ func (e *Platform) MarshalJSON() ([]byte, error) {
 		*E
 		CreatedAt *string `json:"created_at,omitempty"`
 		UpdatedAt *string `json:"updated_at,omitempty"`
+		Labels    Labels  `json:"labels,omitempty"`
 	}{
-		E: (*E)(e),
+		E:      (*E)(e),
+		Labels: e.Labels,
 	}
 	if !e.CreatedAt.IsZero() {
 		str := util.ToRFCFormat(e.CreatedAt)

--- a/pkg/types/servicebroker_gen.go
+++ b/pkg/types/servicebroker_gen.go
@@ -37,8 +37,10 @@ func (e *ServiceBroker) MarshalJSON() ([]byte, error) {
 		*E
 		CreatedAt *string `json:"created_at,omitempty"`
 		UpdatedAt *string `json:"updated_at,omitempty"`
+		Labels    Labels  `json:"labels,omitempty"`
 	}{
-		E: (*E)(e),
+		E:      (*E)(e),
+		Labels: e.Labels,
 	}
 	if !e.CreatedAt.IsZero() {
 		str := util.ToRFCFormat(e.CreatedAt)

--- a/pkg/types/serviceoffering_gen.go
+++ b/pkg/types/serviceoffering_gen.go
@@ -37,8 +37,10 @@ func (e *ServiceOffering) MarshalJSON() ([]byte, error) {
 		*E
 		CreatedAt *string `json:"created_at,omitempty"`
 		UpdatedAt *string `json:"updated_at,omitempty"`
+		Labels    Labels  `json:"labels,omitempty"`
 	}{
-		E: (*E)(e),
+		E:      (*E)(e),
+		Labels: e.Labels,
 	}
 	if !e.CreatedAt.IsZero() {
 		str := util.ToRFCFormat(e.CreatedAt)

--- a/pkg/types/serviceplan_gen.go
+++ b/pkg/types/serviceplan_gen.go
@@ -37,8 +37,10 @@ func (e *ServicePlan) MarshalJSON() ([]byte, error) {
 		*E
 		CreatedAt *string `json:"created_at,omitempty"`
 		UpdatedAt *string `json:"updated_at,omitempty"`
+		Labels    Labels  `json:"labels,omitempty"`
 	}{
-		E: (*E)(e),
+		E:      (*E)(e),
+		Labels: e.Labels,
 	}
 	if !e.CreatedAt.IsZero() {
 		str := util.ToRFCFormat(e.CreatedAt)

--- a/pkg/types/visibility_gen.go
+++ b/pkg/types/visibility_gen.go
@@ -37,8 +37,10 @@ func (e *Visibility) MarshalJSON() ([]byte, error) {
 		*E
 		CreatedAt *string `json:"created_at,omitempty"`
 		UpdatedAt *string `json:"updated_at,omitempty"`
+		Labels    Labels  `json:"labels,omitempty"`
 	}{
-		E: (*E)(e),
+		E:      (*E)(e),
+		Labels: e.Labels,
 	}
 	if !e.CreatedAt.IsZero() {
 		str := util.ToRFCFormat(e.CreatedAt)

--- a/test/ws_notification_test/ws_notification_test.go
+++ b/test/ws_notification_test/ws_notification_test.go
@@ -60,6 +60,36 @@ var _ = Describe("WS", func() {
 	var resp *http.Response
 	var repository storage.Repository
 	var platform *types.Platform
+	var connections []*websocket.Conn
+
+	wsconnect := func(platform *types.Platform, queryParams map[string]string) (*websocket.Conn, *http.Response, error) {
+		smURL := ctx.Servers[common.SMServer].URL()
+		smEndpoint, _ := url.Parse(smURL)
+		smEndpoint.Scheme = "ws"
+		smEndpoint.Path = web.NotificationsURL
+		q := smEndpoint.Query()
+		for k, v := range queryParams {
+			q.Add(k, v)
+		}
+		smEndpoint.RawQuery = q.Encode()
+
+		headers := http.Header{}
+		encodedPlatform := base64.StdEncoding.EncodeToString([]byte(platform.Credentials.Basic.Username + ":" + platform.Credentials.Basic.Password))
+		headers.Add("Authorization", "Basic "+encodedPlatform)
+
+		wsEndpoint := smEndpoint.String()
+		conn, resp, err := websocket.DefaultDialer.Dial(wsEndpoint, headers)
+		if conn != nil {
+			connections = append(connections, conn)
+		}
+		return conn, resp, err
+	}
+
+	wsconnectWithPlatform := func() (*types.Platform, *websocket.Conn, *http.Response, error) {
+		platform := common.RegisterPlatformInSM(common.GenerateRandomPlatform(), ctx.SMWithOAuth, map[string]string{})
+		conn, resp, err := wsconnect(platform, nil)
+		return platform, conn, resp, err
+	}
 
 	BeforeEach(func() {
 		queryParams = map[string]string{}
@@ -79,7 +109,7 @@ var _ = Describe("WS", func() {
 
 	JustBeforeEach(func() {
 		var err error
-		wsconn, resp, err = wsconnect(ctx, platform, web.NotificationsURL, queryParams)
+		wsconn, resp, err = wsconnect(platform, queryParams)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -94,210 +124,198 @@ var _ = Describe("WS", func() {
 	})
 
 	JustAfterEach(func() {
-		if wsconn != nil {
-			wsconn.Close()
+		for _, conn := range connections {
+			conn.Close()
 		}
+		connections = nil
 	})
 
-	Describe("establish websocket connection", func() {
-		Context("with non websocket request", func() {
-			It("should be rejected", func() {
-				ctx.SMWithBasic.GET(web.NotificationsURL).Expect().
-					Status(http.StatusBadRequest).
-					JSON().Object().Value("error").Equal("WebsocketUpgradeError")
+	Context("when non-websocket request is received", func() {
+		It("should reject it", func() {
+			ctx.SMWithBasic.GET(web.NotificationsURL).Expect().
+				Status(http.StatusBadRequest).
+				JSON().Object().Value("error").Equal("WebsocketUpgradeError")
+		})
+	})
+
+	Context("when ping is received", func() {
+		var pongCh chan struct{}
+
+		JustBeforeEach(func() {
+			pongCh = make(chan struct{})
+			wsconn.SetReadDeadline(time.Time{})
+			wsconn.SetPongHandler(func(data string) error {
+				Expect(data).To(Equal("pingping"))
+				close(pongCh)
+				return nil
 			})
+			go func() {
+				_, _, err := wsconn.ReadMessage()
+				Expect(err).Should(HaveOccurred())
+			}()
 		})
 
-		Context("when ping is received", func() {
-			var pongCh chan struct{}
+		It("should respond with pong", func(done Done) {
+			err := wsconn.WriteMessage(websocket.PingMessage, []byte("pingping"))
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(pongCh).Should(BeClosed())
+			close(done)
+		})
+	})
 
-			JustBeforeEach(func() {
-				pongCh = make(chan struct{})
-				wsconn.SetReadDeadline(time.Time{})
-				wsconn.SetPongHandler(func(data string) error {
-					Expect(data).To(Equal("pingping"))
-					close(pongCh)
-					return nil
-				})
-				go func() {
-					_, _, err := wsconn.ReadMessage()
-					Expect(err).Should(HaveOccurred())
-				}()
-			})
-
-			It("should respond with pong", func(done Done) {
-				err := wsconn.WriteMessage(websocket.PingMessage, []byte("pingping"))
-				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(pongCh).Should(BeClosed())
+	Context("when ping is not sent on time", func() {
+		It("should close the connection", func(done Done) {
+			wsconn.SetCloseHandler(func(code int, msg string) error {
 				close(done)
+				return nil
+			})
+			go func() {
+				wsconn.ReadMessage()
+			}()
+		}, pingTimeout.Seconds()+1)
+	})
+
+	Context("when no notifications are present", func() {
+		It("should receive last known revision response header 0", func() {
+			Expect(resp.Header.Get(notifications.LastKnownRevisionHeader)).To(Equal("0"))
+		})
+
+		It("should receive max ping timeout response header", func() {
+			Expect(resp.Header.Get(notifications.MaxPingPeriodHeader)).ToNot(BeEmpty())
+		})
+
+		Context("and revision known to proxy is 0", func() {
+			It("should receive 410 Gone", func() {
+				queryParams[notifications.LastKnownRevisionQueryParam] = "0"
+				_, resp, _ := wsconnect(platform, queryParams)
+				Expect(resp.StatusCode).To(Equal(http.StatusGone))
+			})
+		})
+	})
+
+	Context("when notifications are created prior to connection", func() {
+		var notification *types.Notification
+		var notificationRevision int64
+		BeforeEach(func() {
+			notification, notificationRevision = createNotification(repository, platform.ID)
+		})
+
+		It("should receive last known revision response header greater than 0", func() {
+			lastKnownRevision, err := strconv.Atoi(resp.Header.Get(notifications.LastKnownRevisionHeader))
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(lastKnownRevision).To(BeNumerically(">", 0))
+		})
+
+		It("should receive them", func() {
+			expectNotification(wsconn, notification.ID, notification.PlatformID)
+		})
+
+		Context("and revision known to proxy is 0", func() {
+			It("should receive 410 Gone", func() {
+				queryParams[notifications.LastKnownRevisionQueryParam] = "0"
+				_, resp, _ := wsconnect(platform, queryParams)
+				Expect(resp.StatusCode).To(Equal(http.StatusGone))
 			})
 		})
 
-		Context("when ping is not sent on time", func() {
-			It("should close the connection", func(done Done) {
-				wsconn.SetCloseHandler(func(code int, msg string) error {
-					close(done)
-					return nil
-				})
-				go func() {
-					wsconn.ReadMessage()
-				}()
-			}, pingTimeout.Seconds()+1)
-		})
-
-		Context("when no notifications are present", func() {
-			It("should receive last known revision response header 0", func() {
-				Expect(resp.Header.Get(notifications.LastKnownRevisionHeader)).To(Equal("0"))
-			})
-
-			It("should receive max ping timeout response header", func() {
-				Expect(resp.Header.Get(notifications.MaxPingPeriodHeader)).ToNot(BeEmpty())
-			})
-		})
-
-		Context("when notifications are created prior to connection", func() {
-			var notification *types.Notification
-			var notificationRevision int64
+		Context("and proxy knowns some notification revision", func() {
+			var notification2 *types.Notification
 			BeforeEach(func() {
-				notification, notificationRevision = createNotification(repository, platform.ID)
+				notification2, _ = createNotification(repository, platform.ID)
+				queryParams[notifications.LastKnownRevisionQueryParam] = strconv.FormatInt(notificationRevision, 10)
 			})
 
-			It("should receive last known revision response header greater than 0", func() {
-				lastKnownRevision, err := strconv.Atoi(resp.Header.Get(notifications.LastKnownRevisionHeader))
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(lastKnownRevision).To(BeNumerically(">", 0))
-			})
-
-			It("should receive them", func() {
-				notificationMessage := readNotification(wsconn)
-				Expect(notificationMessage["id"]).To(Equal(notification.ID))
-				Expect(notificationMessage["platform_id"]).To(Equal(notification.PlatformID))
-			})
-
-			Context("and proxy knowns some notification revision", func() {
-				var notification2 *types.Notification
-				BeforeEach(func() {
-					notification2, _ = createNotification(repository, platform.ID)
-					queryParams[notifications.LastKnownRevisionQueryParam] = strconv.FormatInt(notificationRevision, 10)
-				})
-
-				It("should receive only these after the revision that it knowns", func() {
-					notificationMessage := readNotification(wsconn)
-					Expect(notificationMessage["id"]).To(Equal(notification2.ID))
-					Expect(notificationMessage["platform_id"]).To(Equal(notification2.PlatformID))
-				})
-			})
-
-			Context("and revision known to proxy is not known to sm anymore", func() {
-				It("should receive 410 Gone", func() {
-					queryParams[notifications.LastKnownRevisionQueryParam] = strconv.FormatInt(notificationRevision-1, 10)
-					_, resp, err := wsconnect(ctx, platform, web.NotificationsURL, queryParams)
-					Expect(resp.StatusCode).To(Equal(http.StatusGone))
-					Expect(err).Should(HaveOccurred())
-				})
-			})
-
-			Context("and proxy known revision is greater than sm known revision", func() {
-				It("should receive 410 Gone", func() {
-					queryParams[notifications.LastKnownRevisionQueryParam] = strconv.FormatInt(notificationRevision+1, 10)
-					_, resp, err := wsconnect(ctx, platform, web.NotificationsURL, queryParams)
-					Expect(resp.StatusCode).To(Equal(http.StatusGone))
-					Expect(err).Should(HaveOccurred())
-				})
-			})
-
-			Context("when multiple connections are opened", func() {
-				It("all other should not receive prior notifications, but only newly created", func() {
-					wsconns := make([]*websocket.Conn, 0)
-					pls := make([]*types.Platform, 0)
-					for i := 0; i < 5; i++ {
-						pl, conn, _, err := wsconnectWithPlatform(ctx)
-						pls = append(pls, pl)
-
-						Expect(err).ShouldNot(HaveOccurred())
-						wsconns = append(wsconns, conn)
-
-						createNotification(repository, pl.ID)
-					}
-
-					for i, conn := range wsconns {
-						notificationMessage := readNotification(conn)
-						Expect(notificationMessage["platform_id"]).To(Equal(pls[i].ID))
-					}
-				})
+			It("should receive only these after the revision that it knowns", func() {
+				expectNotification(wsconn, notification2.ID, notification2.PlatformID)
 			})
 		})
 
-		Context("when revision known to proxy is invalid number", func() {
-			It("should fail", func() {
-				queryParams[notifications.LastKnownRevisionQueryParam] = "not_a_number"
-				_, resp, err := wsconnect(ctx, platform, web.NotificationsURL, queryParams)
-				Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		Context("and revision known to proxy is not known to sm anymore", func() {
+			It("should receive 410 Gone", func() {
+				queryParams[notifications.LastKnownRevisionQueryParam] = strconv.FormatInt(notificationRevision-1, 10)
+				_, resp, err := wsconnect(platform, queryParams)
+				Expect(resp.StatusCode).To(Equal(http.StatusGone))
 				Expect(err).Should(HaveOccurred())
 			})
 		})
 
-		Context("when notification are created after ws conn is created", func() {
-			It("should receive new notifications", func() {
-				notification, _ := createNotification(repository, platform.ID)
-
-				notificationMessage := readNotification(wsconn)
-				Expect(notificationMessage["id"]).To(Equal(notification.ID))
-				Expect(notificationMessage["platform_id"]).To(Equal(notification.PlatformID))
+		Context("and proxy known revision is greater than sm known revision", func() {
+			It("should receive 410 Gone", func() {
+				queryParams[notifications.LastKnownRevisionQueryParam] = strconv.FormatInt(notificationRevision+1, 10)
+				_, resp, err := wsconnect(platform, queryParams)
+				Expect(resp.StatusCode).To(Equal(http.StatusGone))
+				Expect(err).Should(HaveOccurred())
 			})
 		})
 
-		Context("when one notification with empty platform and one notification with platform are created", func() {
-			var notificationEmptyPlatform, notification *types.Notification
-			BeforeEach(func() {
-				notification, _ = createNotification(repository, platform.ID)
-				notificationEmptyPlatform, _ = createNotification(repository, "")
-			})
+		Context("when multiple connections are opened", func() {
+			It("all other should not receive prior notifications, but only newly created", func() {
+				wsconns := make([]*websocket.Conn, 0)
+				createdNotifications := make([]*types.Notification, 0)
+				for i := 0; i < 5; i++ {
+					pl, conn, _, err := wsconnectWithPlatform()
 
-			It("one connection should receive both, but other only the one with empty platform", func() {
-				notificationMessage := readNotification(wsconn)
-				Expect(notificationMessage["id"]).To(Equal(notification.ID))
-				Expect(notificationMessage["platform_id"]).To(Equal(notification.PlatformID))
+					Expect(err).ShouldNot(HaveOccurred())
+					wsconns = append(wsconns, conn)
 
-				notificationMessage = readNotification(wsconn)
-				Expect(notificationMessage["id"]).To(Equal(notificationEmptyPlatform.ID))
-				Expect(notificationMessage["platform_id"]).To(BeNil())
+					n, _ := createNotification(repository, pl.ID)
+					createdNotifications = append(createdNotifications, n)
+				}
 
-				By("creating new connection")
-				_, newWsConn, _, err := wsconnectWithPlatform(ctx)
-				Expect(err).ShouldNot(HaveOccurred())
-				notificationMessage = readNotification(newWsConn)
-				Expect(notificationMessage["id"]).To(Equal(notificationEmptyPlatform.ID))
-				Expect(notificationMessage["platform_id"]).To(BeNil())
+				for i, conn := range wsconns {
+					expectNotification(conn, createdNotifications[i].ID, createdNotifications[i].PlatformID)
+				}
 			})
 		})
 	})
+
+	Context("when same platform is connected twice", func() {
+		It("should send same notifications to both", func() {
+			conn, _, err := wsconnect(platform, queryParams)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(conn).ShouldNot(BeNil())
+
+			notification, _ := createNotification(repository, platform.ID)
+			expectNotification(conn, notification.ID, platform.ID)
+			expectNotification(wsconn, notification.ID, platform.ID)
+		})
+	})
+
+	Context("when revision known to proxy is invalid number", func() {
+		It("should return status 400", func() {
+			queryParams[notifications.LastKnownRevisionQueryParam] = "not_a_number"
+			_, resp, err := wsconnect(platform, queryParams)
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+
+	Context("when notification are created after ws conn is created", func() {
+		It("should receive new notifications", func() {
+			notification, _ := createNotification(repository, platform.ID)
+			expectNotification(wsconn, notification.ID, notification.PlatformID)
+		})
+	})
+
+	Context("when one notification with empty platform and one notification with platform are created", func() {
+		var notificationEmptyPlatform, notification *types.Notification
+		BeforeEach(func() {
+			notification, _ = createNotification(repository, platform.ID)
+			notificationEmptyPlatform, _ = createNotification(repository, "")
+		})
+
+		It("one connection should receive both, but other only the one with empty platform", func() {
+			expectNotification(wsconn, notification.ID, notification.PlatformID)
+			expectNotification(wsconn, notificationEmptyPlatform.ID, "")
+
+			By("creating new connection")
+			_, newWsConn, _, err := wsconnectWithPlatform()
+			Expect(err).ShouldNot(HaveOccurred())
+			expectNotification(newWsConn, notificationEmptyPlatform.ID, "")
+		})
+	})
+
 })
-
-func wsconnectWithPlatform(ctx *common.TestContext) (*types.Platform, *websocket.Conn, *http.Response, error) {
-	platform := common.RegisterPlatformInSM(common.GenerateRandomPlatform(), ctx.SMWithOAuth, map[string]string{})
-	conn, resp, err := wsconnect(ctx, platform, web.NotificationsURL, nil)
-	return platform, conn, resp, err
-}
-
-func wsconnect(ctx *common.TestContext, platform *types.Platform, path string, queryParams map[string]string) (*websocket.Conn, *http.Response, error) {
-	smURL := ctx.Servers[common.SMServer].URL()
-	smEndpoint, _ := url.Parse(smURL)
-	smEndpoint.Scheme = "ws"
-	smEndpoint.Path = path
-	q := smEndpoint.Query()
-	for k, v := range queryParams {
-		q.Add(k, v)
-	}
-	smEndpoint.RawQuery = q.Encode()
-
-	headers := http.Header{}
-	encodedPlatform := base64.StdEncoding.EncodeToString([]byte(platform.Credentials.Basic.Username + ":" + platform.Credentials.Basic.Password))
-	headers.Add("Authorization", "Basic "+encodedPlatform)
-
-	wsEndpoint := smEndpoint.String()
-	return websocket.DefaultDialer.Dial(wsEndpoint, headers)
-}
 
 func createNotification(repository storage.Repository, platformID string) (*types.Notification, int64) {
 	notification := common.GenerateRandomNotification()
@@ -310,6 +328,16 @@ func createNotification(repository storage.Repository, platformID string) (*type
 	notificationRevision := (createdNotification.(*types.Notification)).Revision
 
 	return notification, notificationRevision
+}
+
+func expectNotification(wsconn *websocket.Conn, notificationID, platformID string) {
+	notification := readNotification(wsconn)
+	Expect(notification["id"]).To(Equal(notificationID))
+	if platformID == "" {
+		Expect(notification["platform_id"]).To(BeNil())
+	} else {
+		Expect(notification["platform_id"]).To(Equal(platformID))
+	}
 }
 
 func readNotification(wsconn *websocket.Conn) map[string]interface{} {


### PR DESCRIPTION
## Motivation

If there are no notifications in the db, SM returns last_notification_revision 0. Then the connection breaks for a long time so some notifications pass and are cleaned from the db. Then the proxy will try to reconnect with last_notification_revision 0. SM should return status 410 Gone. Otherwise the proxy may miss some notifications.

## Approach

Now SM always return status 410 if last_notification_revision = 0.
Add more tests
Fix race condition when the same notification is sent on multiple ws connections

## Pull Request status

* [x] Initial implementation
* [x] Component tests
