### PR TITLE
Fix test

### DIFF
--- a/test/notification_test/notification_test.go
+++ b/test/notification_test/notification_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Peripli/service-manager/pkg/log"
-
 	"github.com/Peripli/service-manager/pkg/env"
 	"github.com/Peripli/service-manager/pkg/sm"
 	"github.com/Peripli/service-manager/storage/interceptors"
@@ -308,7 +306,6 @@ var _ = Describe("Notifications Suite", func() {
 	})
 
 	for _, entry := range entries {
-		log.Default().Error(fmt.Sprintf("%T %v", entry, entries))
 		entry := entry
 
 		getNotifications := func(ids ...string) (*types.Notifications, []string) {

--- a/test/notification_test/notification_test.go
+++ b/test/notification_test/notification_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Peripli/service-manager/pkg/log"
+
 	"github.com/Peripli/service-manager/pkg/env"
 	"github.com/Peripli/service-manager/pkg/sm"
 	"github.com/Peripli/service-manager/storage/interceptors"
@@ -306,6 +308,7 @@ var _ = Describe("Notifications Suite", func() {
 	})
 
 	for _, entry := range entries {
+		log.Default().Error(fmt.Sprintf("%T %v", entry, entries))
 		entry := entry
 
 		getNotifications := func(ids ...string) (*types.Notifications, []string) {

--- a/test/notification_test/notification_test.go
+++ b/test/notification_test/notification_test.go
@@ -306,6 +306,8 @@ var _ = Describe("Notifications Suite", func() {
 	})
 
 	for _, entry := range entries {
+		entry := entry
+
 		getNotifications := func(ids ...string) (*types.Notifications, []string) {
 			filters := make([]query.Criterion, 0)
 			if len(ids) != 0 {


### PR DESCRIPTION
The last value of the entry is reused and the visibility tests are executed twice. Reason is the variable entry was being shared (same address memory). The fix would allow for the broker tests to execute too