### PR TITLE
apply label updates to labels before triggering interceptors

### DIFF
--- a/api/base_controller.go
+++ b/api/base_controller.go
@@ -218,13 +218,19 @@ func (c *BaseController) PatchObject(r *web.Request) (*web.Response, error) {
 	if err := util.BytesToObject(r.Body, objFromDB); err != nil {
 		return nil, err
 	}
+
 	objFromDB.SetID(objectID)
 	objFromDB.SetCreatedAt(createdAt)
 	objFromDB.SetUpdatedAt(updatedAt)
+
+	labels, _, _ := query.ApplyLabelChangesToLabels(labelChanges, objFromDB.GetLabels())
+	objFromDB.SetLabels(labels)
+
 	object, err := c.repository.Update(ctx, objFromDB, labelChanges...)
 	if err != nil {
 		return nil, util.HandleStorageError(err, string(c.objectType))
 	}
+
 	stripCredentials(ctx, object)
 
 	return util.NewJSONResponse(http.StatusOK, object)

--- a/pkg/query/update.go
+++ b/pkg/query/update.go
@@ -100,8 +100,6 @@ func ApplyLabelChangesToLabels(changes LabelChanges, labels types.Labels) (types
 	}
 
 	for _, change := range changes {
-		change := change
-
 		switch change.Operation {
 		case AddLabelOperation:
 			fallthrough

--- a/pkg/query/update.go
+++ b/pkg/query/update.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Peripli/service-manager/pkg/types"
+
 	"github.com/Peripli/service-manager/pkg/util"
 
 	"github.com/tidwall/gjson"
@@ -88,4 +90,53 @@ func LabelChangesFromJSON(jsonBytes []byte) ([]*LabelChange, error) {
 		}
 	}
 	return labelChanges, nil
+}
+
+// ApplyLabelChangesToLabels applies the specified label changes to the specified labels
+func ApplyLabelChangesToLabels(changes LabelChanges, labels types.Labels) (types.Labels, types.Labels, types.Labels) {
+	mergedLabels, labelsToAdd, labelsToRemove := types.Labels{}, types.Labels{}, types.Labels{}
+	for k, v := range labels {
+		mergedLabels[k] = v
+	}
+
+	for _, change := range changes {
+		change := change
+
+		switch change.Operation {
+		case AddLabelOperation:
+			fallthrough
+		case AddLabelValuesOperation:
+			for _, value := range change.Values {
+				found := false
+				for _, currentValue := range mergedLabels[change.Key] {
+					if currentValue == value {
+						found = true
+						break
+					}
+				}
+				if !found {
+					labelsToAdd[change.Key] = append(labelsToAdd[change.Key], value)
+					mergedLabels[change.Key] = append(mergedLabels[change.Key], value)
+				}
+			}
+		case RemoveLabelOperation:
+			fallthrough
+		case RemoveLabelValuesOperation:
+			if len(change.Values) == 0 {
+				labelsToRemove[change.Key] = labels[change.Key]
+				delete(mergedLabels, change.Key)
+			} else {
+				labelsToRemove[change.Key] = append(labelsToRemove[change.Key], change.Values...)
+				for _, valueToRemove := range change.Values {
+					for i, value := range mergedLabels[change.Key] {
+						if value == valueToRemove {
+							mergedLabels[change.Key] = append(mergedLabels[change.Key][:i], mergedLabels[change.Key][i+1:]...)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return mergedLabels, labelsToAdd, labelsToRemove
 }

--- a/storage/interceptable_repository.go
+++ b/storage/interceptable_repository.go
@@ -190,6 +190,9 @@ func (ir *interceptableRepository) Update(ctx context.Context, obj types.Object,
 			return nil, err
 		}
 
+		labels, _, _ := query.ApplyLabelChangesToLabels(labelChanges, newObj.GetLabels())
+		object.SetLabels(labels)
+
 		return object, nil
 	}
 

--- a/storage/postgres/interfaces.go
+++ b/storage/postgres/interfaces.go
@@ -86,15 +86,3 @@ func rowsToList(rows *sqlx.Rows, rowCreator EntityLabelRowCreator, result types.
 	}
 	return nil
 }
-
-func labelsRowsToList(rows *sqlx.Rows, labelBlueprint func() PostgresLabel) ([]storage.Label, error) {
-	var result []storage.Label
-	for rows.Next() {
-		row := labelBlueprint()
-		if err := rows.StructScan(row); err != nil {
-			return nil, err
-		}
-		result = append(result, row)
-	}
-	return result, nil
-}

--- a/storage/postgres/storage.go
+++ b/storage/postgres/storage.go
@@ -246,21 +246,8 @@ func (ps *PostgresStorage) Update(ctx context.Context, obj types.Object, labelCh
 	if err = ps.updateLabels(ctx, entity.GetID(), entity, labelChanges); err != nil {
 		return nil, err
 	}
-	labelsInfo := entity.LabelEntity()
-	byEntityID := query.ByField(query.EqualsOperator, labelsInfo.ReferenceColumn(), entity.GetID())
-	rows, err := listByFieldCriteria(ctx, ps.pgDB, labelsInfo.LabelsTableName(), []query.Criterion{byEntityID})
-	if err != nil {
-		return nil, err
-	}
-	defer closeRows(ctx, rows)
-	labels, err := labelsRowsToList(rows, func() PostgresLabel { return entity.LabelEntity() })
-	if err != nil {
-		return nil, err
-	}
-	typeLabels := storageLabelsToType(labels)
 
 	result := entity.ToObject()
-	result.SetLabels(typeLabels)
 	return result, nil
 }
 
@@ -316,17 +303,4 @@ func (migrateLogger) Printf(format string, v ...interface{}) {
 
 func (migrateLogger) Verbose() bool {
 	return true
-}
-
-func storageLabelsToType(labels []storage.Label) types.Labels {
-	labelValues := make(map[string][]string)
-	for _, label := range labels {
-		values, exists := labelValues[label.GetKey()]
-		if exists {
-			labelValues[label.GetKey()] = append(values, label.GetValue())
-		} else {
-			labelValues[label.GetKey()] = []string{label.GetValue()}
-		}
-	}
-	return labelValues
 }


### PR DESCRIPTION
Applying the label changes to the labels before handing them to the interceptor chains allows the interceptors to use the new objects labels and creating entitlements and visibilities. This fixes an issue in the internal update interceptors (sub-accounts, entitlements)