### PR TITLE
[Fixit] Allow patching labels of services and plans

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -113,6 +113,7 @@ func New(ctx context.Context, options *Options) (*web.API, error) {
 			secfilters.NewRequiredAuthnFilter(),
 			&filters.SelectionCriteria{},
 			&filters.PlatformAwareVisibilityFilter{},
+			&filters.PatchOnlyLabelsFilter{},
 		},
 		Registry: health.NewDefaultRegistry(),
 	}, nil

--- a/api/base_controller.go
+++ b/api/base_controller.go
@@ -19,7 +19,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/tidwall/gjson"
 	"net/http"
 	"time"
 
@@ -236,49 +235,6 @@ func (c *BaseController) PatchObject(r *web.Request) (*web.Response, error) {
 	stripCredentials(ctx, object)
 
 	return util.NewJSONResponse(http.StatusOK, object)
-}
-
-// PatchLabelsOnly handles the update of labels of the object with the if specified in request
-func (c *BaseController) PatchLabelsOnly(r *web.Request) (*web.Response, error) {
-	objectID := r.PathParams[PathParamID]
-	ctx := r.Context()
-	log.C(ctx).Debugf("Updating %s with id %s", c.objectType, objectID)
-
-	if !onlyLabelsRequest(r.Body) {
-		return nil, &util.HTTPError{
-			ErrorType:   "BadRequest",
-			Description: fmt.Sprintf("Only labels can be patched for %s ", c.objectType),
-			StatusCode:  http.StatusBadRequest,
-		}
-	}
-
-	labelChanges, err := query.LabelChangesFromJSON(r.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	objFromDB, err := c.repository.Get(ctx, c.objectType, objectID)
-	if err != nil {
-		return nil, util.HandleStorageError(err, string(c.objectType))
-	}
-
-	labels, _, _ := query.ApplyLabelChangesToLabels(labelChanges, objFromDB.GetLabels())
-	objFromDB.SetLabels(labels)
-
-	object, err := c.repository.Update(ctx, objFromDB, labelChanges...)
-	if err != nil {
-		return nil, util.HandleStorageError(err, string(c.objectType))
-	}
-
-	stripCredentials(ctx, object)
-
-	return util.NewJSONResponse(http.StatusOK, object)
-}
-
-func onlyLabelsRequest(body []byte) bool {
-	jsonMap := gjson.ParseBytes(body).Map()
-	delete(jsonMap, "labels")
-	return len(jsonMap) == 0
 }
 
 func stripCredentials(ctx context.Context, object types.Object) {

--- a/api/filters/patch_labels_only.go
+++ b/api/filters/patch_labels_only.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import (
+	"github.com/Peripli/service-manager/pkg/util"
+	"github.com/Peripli/service-manager/pkg/web"
+	"github.com/tidwall/gjson"
+	"net/http"
+)
+
+const PatchOnlyLabelsFilterName = "PatchOnlyLabelsFilter"
+
+// PatchOnlyLabelsFilter checks patch request for service offerings and plans include only label changes
+type PatchOnlyLabelsFilter struct {
+}
+
+func (*PatchOnlyLabelsFilter) Name() string {
+	return PatchOnlyLabelsFilterName
+}
+
+func (*PatchOnlyLabelsFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
+	if !onlyLabelsRequest(req.Body) {
+		return nil, &util.HTTPError{
+			ErrorType:   "BadRequest",
+			Description: "Only labels can be patched for service offerings and plans",
+			StatusCode:  http.StatusBadRequest,
+		}
+	}
+	return next.Handle(req)
+}
+
+func (*PatchOnlyLabelsFilter) FilterMatchers() []web.FilterMatcher {
+	return []web.FilterMatcher{
+		{
+			Matchers: []web.Matcher{
+				web.Path(web.ServiceOfferingsURL + "/**"),
+				web.Methods(http.MethodPatch),
+			},
+		},
+		{
+			Matchers: []web.Matcher{
+				web.Path(web.ServicePlansURL + "/**"),
+				web.Methods(http.MethodPatch),
+			},
+		},
+	}
+}
+
+func onlyLabelsRequest(body []byte) bool {
+	jsonMap := gjson.ParseBytes(body).Map()
+	delete(jsonMap, "labels")
+	return len(jsonMap) == 0
+}

--- a/api/filters/patch_labels_only.go
+++ b/api/filters/patch_labels_only.go
@@ -34,7 +34,10 @@ func (*PatchOnlyLabelsFilter) Name() string {
 }
 
 func (*PatchOnlyLabelsFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
-	if !onlyLabelsRequest(req.Body) {
+	jsonMap := gjson.ParseBytes(req.Body).Map()
+	delete(jsonMap, "labels")
+
+	if len(jsonMap) > 0 {
 		return nil, &util.HTTPError{
 			ErrorType:   "BadRequest",
 			Description: "Only labels can be patched for service offerings and plans",
@@ -59,10 +62,4 @@ func (*PatchOnlyLabelsFilter) FilterMatchers() []web.FilterMatcher {
 			},
 		},
 	}
-}
-
-func onlyLabelsRequest(body []byte) bool {
-	jsonMap := gjson.ParseBytes(body).Map()
-	delete(jsonMap, "labels")
-	return len(jsonMap) == 0
 }

--- a/api/service_offering_controller.go
+++ b/api/service_offering_controller.go
@@ -59,7 +59,7 @@ func (c *ServiceOfferingController) Routes() []web.Route {
 				Method: http.MethodPatch,
 				Path:   fmt.Sprintf("%s/{%s}", web.ServiceOfferingsURL, PathParamID),
 			},
-			Handler: c.PatchObject,
+			Handler: c.PatchLabelsOnly,
 		},
 	}
 }

--- a/api/service_offering_controller.go
+++ b/api/service_offering_controller.go
@@ -54,5 +54,12 @@ func (c *ServiceOfferingController) Routes() []web.Route {
 			},
 			Handler: c.ListObjects,
 		},
+		{
+			Endpoint: web.Endpoint{
+				Method: http.MethodPatch,
+				Path:   fmt.Sprintf("%s/{%s}", web.ServiceOfferingsURL, PathParamID),
+			},
+			Handler: c.PatchLabelsOnly,
+		},
 	}
 }

--- a/api/service_offering_controller.go
+++ b/api/service_offering_controller.go
@@ -59,7 +59,7 @@ func (c *ServiceOfferingController) Routes() []web.Route {
 				Method: http.MethodPatch,
 				Path:   fmt.Sprintf("%s/{%s}", web.ServiceOfferingsURL, PathParamID),
 			},
-			Handler: c.PatchLabelsOnly,
+			Handler: c.PatchObject,
 		},
 	}
 }

--- a/api/service_plan_controller.go
+++ b/api/service_plan_controller.go
@@ -59,7 +59,7 @@ func (c *ServicePlanController) Routes() []web.Route {
 				Method: http.MethodPatch,
 				Path:   fmt.Sprintf("%s/{%s}", web.ServicePlansURL, PathParamID),
 			},
-			Handler: c.PatchLabelsOnly,
+			Handler: c.PatchObject,
 		},
 	}
 }

--- a/api/service_plan_controller.go
+++ b/api/service_plan_controller.go
@@ -54,5 +54,12 @@ func (c *ServicePlanController) Routes() []web.Route {
 			},
 			Handler: c.ListObjects,
 		},
+		{
+			Endpoint: web.Endpoint{
+				Method: http.MethodPatch,
+				Path:   fmt.Sprintf("%s/{%s}", web.ServicePlansURL, PathParamID),
+			},
+			Handler: c.PatchLabelsOnly,
+		},
 	}
 }

--- a/api/service_plan_controller.go
+++ b/api/service_plan_controller.go
@@ -59,7 +59,7 @@ func (c *ServicePlanController) Routes() []web.Route {
 				Method: http.MethodPatch,
 				Path:   fmt.Sprintf("%s/{%s}", web.ServicePlansURL, PathParamID),
 			},
-			Handler: c.PatchObject,
+			Handler: c.PatchLabelsOnly,
 		},
 	}
 }

--- a/pkg/query/update.go
+++ b/pkg/query/update.go
@@ -129,6 +129,9 @@ func ApplyLabelChangesToLabels(changes LabelChanges, labels types.Labels) (types
 					for i, value := range mergedLabels[change.Key] {
 						if value == valueToRemove {
 							mergedLabels[change.Key] = append(mergedLabels[change.Key][:i], mergedLabels[change.Key][i+1:]...)
+							if len(mergedLabels[change.Key]) == 0 {
+								delete(mergedLabels, change.Key)
+							}
 						}
 					}
 				}

--- a/pkg/query/update_test.go
+++ b/pkg/query/update_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Update", func() {
 	Describe("ApplyLabelChangesToLabels", func() {
 		Context("for changes with add and remove operations", func() {
 			type testEntry struct {
-				IntialLabels           types.Labels
+				InitialLabels          types.Labels
 				Changes                LabelChanges
 				ExpectedMergedLabels   types.Labels
 				ExpectedLabelsToRemove types.Labels
@@ -139,7 +139,7 @@ var _ = Describe("Update", func() {
 			entries := []TableEntry{
 				Entry("mixed",
 					testEntry{
-						IntialLabels: types.Labels{
+						InitialLabels: types.Labels{
 							"organization_guid": {
 								"org0",
 							},
@@ -206,7 +206,7 @@ var _ = Describe("Update", func() {
 					}),
 				Entry("remove key removes all values",
 					testEntry{
-						IntialLabels: types.Labels{
+						InitialLabels: types.Labels{
 							"organization_guid": {
 								"org0",
 							},
@@ -226,10 +226,32 @@ var _ = Describe("Update", func() {
 						},
 						ExpectedLabelsToAdd: types.Labels{},
 					}),
+				Entry("remove last value removes the key too",
+					testEntry{
+						InitialLabels: types.Labels{
+							"organization_guid": {
+								"org0",
+							},
+						},
+						Changes: LabelChanges{
+							&LabelChange{
+								Operation: RemoveLabelValuesOperation,
+								Key:       "organization_guid",
+								Values:    []string{"org0"},
+							},
+						},
+						ExpectedMergedLabels: types.Labels{},
+						ExpectedLabelsToRemove: types.Labels{
+							"organization_guid": {
+								"org0",
+							},
+						},
+						ExpectedLabelsToAdd: types.Labels{},
+					}),
 			}
 
 			DescribeTable("", func(t testEntry) {
-				mergedLabels, labelsToAdd, labelsToRemove := ApplyLabelChangesToLabels(t.Changes, t.IntialLabels)
+				mergedLabels, labelsToAdd, labelsToRemove := ApplyLabelChangesToLabels(t.Changes, t.InitialLabels)
 
 				Expect(mergedLabels).To(Equal(t.ExpectedMergedLabels))
 				Expect(labelsToAdd).To(Equal(t.ExpectedLabelsToAdd))

--- a/storage/postgres/postgresfakes/fake_notification_storage.go
+++ b/storage/postgres/postgresfakes/fake_notification_storage.go
@@ -2,10 +2,10 @@
 package postgresfakes
 
 import (
-	context "context"
-	sync "sync"
+	"context"
+	"sync"
 
-	types "github.com/Peripli/service-manager/pkg/types"
+	"github.com/Peripli/service-manager/pkg/types"
 )
 
 type FakeNotificationStorage struct {

--- a/storage/postgres/secured_storage_test.go
+++ b/storage/postgres/secured_storage_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Secured Storage", func() {
 		mock.ExpectQuery(`SELECT CURRENT_DATABASE()`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("mock"))
 		mock.ExpectQuery(`SELECT COUNT(1)*`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("1"))
 		mock.ExpectExec("SELECT pg_advisory_lock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("9,false"))
+		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("10,false"))
 		mock.ExpectExec("SELECT pg_advisory_unlock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 		options := storage.DefaultSettings()
 		options.EncryptionKey = string(envEncryptionKey)

--- a/storage/storagefakes/fake_secured_transactional_repository.go
+++ b/storage/storagefakes/fake_secured_transactional_repository.go
@@ -891,3 +891,5 @@ func (fake *FakeSecuredTransactionalRepository) recordInvocation(key string, arg
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }
+
+var _ storage.SecuredTransactionalRepository = new(FakeSecuredTransactionalRepository)

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -43,8 +43,7 @@ func TestBrokers(t *testing.T) {
 }
 
 var _ = test.DescribeTestsFor(test.TestCase{
-	API:            "/v1/service_brokers",
-	SupportsLabels: true,
+	API: "/v1/service_brokers",
 	SupportedOps: []test.Op{
 		test.Get, test.List, test.Delete, test.DeleteList,
 	},

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -1288,7 +1288,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						})
 						patchLabelsBody["labels"] = patchLabels
 
-						id = ctx.SMWithOAuth.POST("/v1/service_brokers").
+						id = ctx.SMWithOAuth.POST(web.ServiceBrokersURL).
 							WithJSON(postBrokerRequestWithLabels).
 							Expect().Status(http.StatusCreated).JSON().Object().Value("id").String().Raw()
 					})
@@ -1296,7 +1296,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 					Context("Add new label", func() {
 						It("Should return 200", func() {
 							label := types.Labels{changedLabelKey: changedLabelValues}
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK).JSON().Object().Value("labels").Object().ContainsMap(label)
@@ -1305,12 +1305,12 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 					Context("Add label with existing key and value", func() {
 						It("Should return 200", func() {
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK)
 
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK)
@@ -1328,7 +1328,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							for _, val := range changedLabelValues {
 								labelValuesObj = append(labelValuesObj, val)
 							}
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK).JSON().
@@ -1348,7 +1348,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								labelValuesObj = append(labelValuesObj, val)
 							}
 
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK).JSON().
@@ -1364,7 +1364,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							changedLabelValues = []string{values[0].(string)}
 						})
 						It("Should return 200", func() {
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK)
@@ -1377,7 +1377,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							changedLabelKey = "cluster_id"
 						})
 						It("Should return 200", func() {
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK).JSON().
@@ -1391,7 +1391,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							changedLabelKey = ""
 						})
 						It("Should return 400", func() {
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusBadRequest)
@@ -1404,7 +1404,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							changedLabelKey = "non-existing-ey"
 						})
 						It("Should return 200", func() {
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK)
@@ -1420,11 +1420,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							changedLabelValues = []string{valueToRemove}
 						})
 						It("Should return 200", func() {
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK).JSON().
-								Path("$.labels[*].value[*]").Array().NotContains(valueToRemove)
+								Path("$.labels[*]").Array().NotContains(valueToRemove)
 						})
 					})
 
@@ -1439,11 +1439,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							changedLabelValues = valuesToRemove
 						})
 						It("Should return 200", func() {
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK).JSON().
-								Path("$.labels[*].value[*]").Array().NotContains(valuesToRemove)
+								Path("$.labels[*]").Array().NotContains(valuesToRemove)
 						})
 					})
 
@@ -1459,11 +1459,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							changedLabelValues = valuesToRemove
 						})
 						It("Should return 200 with this key gone", func() {
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK).JSON().
-								Path("$.labels[*].key[*]").Array().NotContains(changedLabelKey)
+								Path("$.labels").Object().Keys().NotContains(changedLabelKey)
 						})
 					})
 
@@ -1473,7 +1473,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							changedLabelValues = []string{}
 						})
 						It("Should return 400", func() {
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusBadRequest)
@@ -1487,7 +1487,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							changedLabelValues = []string{"non-existing-value"}
 						})
 						It("Should return 200", func() {
-							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + id).
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + id).
 								WithJSON(patchLabelsBody).
 								Expect().
 								Status(http.StatusOK)

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -17,6 +17,7 @@ package broker_test
 
 import (
 	"fmt"
+	"github.com/Peripli/service-manager/pkg/web"
 	"net/http"
 	"strings"
 	"testing"
@@ -43,7 +44,7 @@ func TestBrokers(t *testing.T) {
 }
 
 var _ = test.DescribeTestsFor(test.TestCase{
-	API: "/v1/service_brokers",
+	API: web.ServiceBrokersURL,
 	SupportedOps: []test.Op{
 		test.Get, test.List, test.Delete, test.DeleteList,
 	},
@@ -1505,7 +1506,7 @@ func blueprint(setNullFieldsValues bool) func(ctx *common.TestContext) common.Ob
 		if !setNullFieldsValues {
 			delete(brokerJSON, "description")
 		}
-		obj := ctx.SMWithOAuth.POST("/v1/service_brokers").WithJSON(brokerJSON).
+		obj := ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(brokerJSON).
 			Expect().
 			Status(http.StatusCreated).JSON().Object().Raw()
 		delete(obj, "credentials")

--- a/test/list.go
+++ b/test/list.go
@@ -86,9 +86,7 @@ func DescribeListTestsFor(ctx *common.TestContext, t TestCase) bool {
 		By(fmt.Sprintf("Attempting to create a random resource of %s", t.API))
 
 		gen := t.ResourceBlueprint(ctx)
-		if t.SupportsLabels {
-			gen = attachLabel(gen)
-		}
+		gen = attachLabel(gen)
 		delete(gen, "created_at")
 		delete(gen, "updated_at")
 		r = append(r, gen)
@@ -460,7 +458,7 @@ func DescribeListTestsFor(ctx *common.TestContext, t TestCase) bool {
 				})
 
 				labels := params.queryArgs["labels"]
-				if t.SupportsLabels && labels != nil {
+				if labels != nil {
 
 					multiQueryValue, queryValues = expandLabelQuery(labels.(map[string]interface{}), params.queryTemplate)
 					lquery := "labelQuery" + "=" + multiQueryValue

--- a/test/platform_test/platform_test.go
+++ b/test/platform_test/platform_test.go
@@ -17,6 +17,7 @@
 package platform_test
 
 import (
+	"github.com/Peripli/service-manager/pkg/web"
 	"net/http"
 	"testing"
 
@@ -35,7 +36,7 @@ func TestPlatforms(t *testing.T) {
 }
 
 var _ = test.DescribeTestsFor(test.TestCase{
-	API: "/v1/platforms",
+	API: web.PlatformsURL,
 	SupportedOps: []test.Op{
 		test.Get, test.List, test.Delete, test.DeleteList,
 	},
@@ -297,7 +298,7 @@ func blueprint(setNullFieldsValues bool) func(ctx *common.TestContext) common.Ob
 		if !setNullFieldsValues {
 			delete(randomPlatform, "description")
 		}
-		platform := ctx.SMWithOAuth.POST("/v1/platforms").WithJSON(randomPlatform).
+		platform := ctx.SMWithOAuth.POST(web.PlatformsURL).WithJSON(randomPlatform).
 			Expect().
 			Status(http.StatusCreated).JSON().Object().Raw()
 		delete(platform, "credentials")

--- a/test/platform_test/platform_test.go
+++ b/test/platform_test/platform_test.go
@@ -35,8 +35,7 @@ func TestPlatforms(t *testing.T) {
 }
 
 var _ = test.DescribeTestsFor(test.TestCase{
-	API:            "/v1/platforms",
-	SupportsLabels: true,
+	API: "/v1/platforms",
 	SupportedOps: []test.Op{
 		test.Get, test.List, test.Delete, test.DeleteList,
 	},

--- a/test/service_offering_test/service_offering_test.go
+++ b/test/service_offering_test/service_offering_test.go
@@ -46,6 +46,55 @@ var _ = test.DescribeTestsFor(test.TestCase{
 	ResourceWithoutNullableFieldsBlueprint: blueprint,
 	AdditionalTests: func(ctx *common.TestContext) {
 		Context("additional non-generic tests", func() {
+
+			Describe("PATCH", func() {
+				var id string
+
+				var patchLabels []query.LabelChange
+				var patchLabelsBody map[string]interface{}
+				changedLabelKey := "label_key"
+				changedLabelValues := []string{"label_value1", "label_value2"}
+				operation := query.AddLabelOperation
+
+				BeforeEach(func() {
+					patchLabelsBody = make(map[string]interface{})
+					patchLabels = append(patchLabels, query.LabelChange{
+						Operation: operation,
+						Key:       changedLabelKey,
+						Values:    changedLabelValues,
+					})
+					patchLabelsBody["labels"] = patchLabels
+
+					offering := blueprint(ctx)
+					id = offering["id"].(string)
+				})
+
+				Context("When not only labels updated", func() {
+					It("should return bad request", func() {
+						patchLabelsBody["description"] = "new-description"
+
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusBadRequest)
+
+					})
+				})
+
+				Context("When labels not updated", func() {
+					It("should return bad request", func() {
+						body := make(map[string]interface{})
+						body["description"] = "new-description"
+
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(body).
+							Expect().
+							Status(http.StatusBadRequest)
+
+					})
+				})
+			})
+
 			Describe("Labelled", func() {
 				var id string
 

--- a/test/service_offering_test/service_offering_test.go
+++ b/test/service_offering_test/service_offering_test.go
@@ -17,6 +17,7 @@
 package service_test
 
 import (
+	"github.com/Peripli/service-manager/pkg/web"
 	"net/http"
 	"testing"
 
@@ -35,7 +36,7 @@ func TestServiceOfferings(t *testing.T) {
 }
 
 var _ = test.DescribeTestsFor(test.TestCase{
-	API: "/v1/service_offerings",
+	API: web.ServiceOfferingsURL,
 	SupportedOps: []test.Op{
 		test.Get, test.List,
 	},
@@ -49,7 +50,7 @@ func blueprint(ctx *common.TestContext) common.Object {
 	catalog.AddService(cService)
 	id, _, _ := ctx.RegisterBrokerWithCatalog(catalog)
 
-	so := ctx.SMWithOAuth.GET("/v1/service_offerings").WithQuery("fieldQuery", "broker_id = "+id).
+	so := ctx.SMWithOAuth.GET(web.ServiceOfferingsURL).WithQuery("fieldQuery", "broker_id = "+id).
 		Expect().
 		Status(http.StatusOK).JSON().Object().Value("service_offerings").Array().First()
 

--- a/test/service_offering_test/service_offering_test.go
+++ b/test/service_offering_test/service_offering_test.go
@@ -35,8 +35,7 @@ func TestServiceOfferings(t *testing.T) {
 }
 
 var _ = test.DescribeTestsFor(test.TestCase{
-	API:            "/v1/service_offerings",
-	SupportsLabels: true,
+	API: "/v1/service_offerings",
 	SupportedOps: []test.Op{
 		test.Get, test.List,
 	},

--- a/test/service_offering_test/service_offering_test.go
+++ b/test/service_offering_test/service_offering_test.go
@@ -36,7 +36,7 @@ func TestServiceOfferings(t *testing.T) {
 
 var _ = test.DescribeTestsFor(test.TestCase{
 	API:            "/v1/service_offerings",
-	SupportsLabels: false,
+	SupportsLabels: true,
 	SupportedOps: []test.Op{
 		test.Get, test.List,
 	},

--- a/test/service_offering_test/service_offering_test.go
+++ b/test/service_offering_test/service_offering_test.go
@@ -17,6 +17,8 @@
 package service_test
 
 import (
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/pkg/web"
 	"net/http"
 	"testing"
@@ -42,6 +44,250 @@ var _ = test.DescribeTestsFor(test.TestCase{
 	},
 	ResourceBlueprint:                      blueprint,
 	ResourceWithoutNullableFieldsBlueprint: blueprint,
+	AdditionalTests: func(ctx *common.TestContext) {
+		Context("additional non-generic tests", func() {
+			Describe("Labelled", func() {
+				var id string
+
+				var initialLabels []query.LabelChange
+				var initialLabelsBody map[string]interface{}
+				initialLabelsKeys := []string{"initial_key", "initial_key2"}
+				initialLabelValues := []string{"initial_value", "initial_value2"}
+
+				var patchLabels []query.LabelChange
+				var patchLabelsBody map[string]interface{}
+				changedLabelKey := "label_key"
+				changedLabelValues := []string{"label_value1", "label_value2"}
+				operation := query.AddLabelOperation
+
+				BeforeEach(func() {
+					patchLabels = []query.LabelChange{}
+					initialLabelsBody = make(map[string]interface{})
+					initialLabels = []query.LabelChange{
+						{
+							Operation: query.AddLabelOperation,
+							Key:       initialLabelsKeys[0],
+							Values:    initialLabelValues[:1],
+						},
+						{
+							Operation: query.AddLabelOperation,
+							Key:       initialLabelsKeys[1],
+							Values:    initialLabelValues,
+						},
+					}
+					initialLabelsBody["labels"] = initialLabels
+				})
+
+				JustBeforeEach(func() {
+					patchLabelsBody = make(map[string]interface{})
+					patchLabels = append(patchLabels, query.LabelChange{
+						Operation: operation,
+						Key:       changedLabelKey,
+						Values:    changedLabelValues,
+					})
+					patchLabelsBody["labels"] = patchLabels
+
+					offering := blueprint(ctx)
+					id = offering["id"].(string)
+
+					ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+						WithJSON(initialLabelsBody).
+						Expect().
+						Status(http.StatusOK)
+
+				})
+
+				Context("Add new label", func() {
+					It("Should return 200", func() {
+						label := types.Labels{changedLabelKey: changedLabelValues}
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().Object().Value("labels").Object().ContainsMap(label)
+					})
+				})
+
+				Context("Add label with existing key and value", func() {
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK)
+
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK)
+					})
+				})
+
+				Context("Add new label value", func() {
+					BeforeEach(func() {
+						operation = query.AddLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[0]
+						changedLabelValues = []string{"new-label-value"}
+					})
+					It("Should return 200", func() {
+						var labelValuesObj []interface{}
+						for _, val := range changedLabelValues {
+							labelValuesObj = append(labelValuesObj, val)
+						}
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels").Object().Values().Path("$[*][*]").Array().Contains(labelValuesObj...)
+					})
+				})
+
+				Context("Add new label value to a non-existing label", func() {
+					BeforeEach(func() {
+						operation = query.AddLabelValuesOperation
+						changedLabelKey = "cluster_id_new"
+						changedLabelValues = []string{"new-label-value"}
+					})
+					It("Should return 200", func() {
+						var labelValuesObj []interface{}
+						for _, val := range changedLabelValues {
+							labelValuesObj = append(labelValuesObj, val)
+						}
+
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels").Object().Values().Path("$[*][*]").Array().Contains(labelValuesObj...)
+					})
+				})
+
+				Context("Add duplicate label value", func() {
+					BeforeEach(func() {
+						operation = query.AddLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[0]
+						changedLabelValues = initialLabelValues[:1]
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK)
+					})
+				})
+
+				Context("Remove a label", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelOperation
+						changedLabelKey = initialLabelsKeys[0]
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels").Object().Keys().NotContains(changedLabelKey)
+					})
+				})
+
+				Context("Remove a label and providing no key", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelOperation
+						changedLabelKey = ""
+					})
+					It("Should return 400", func() {
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusBadRequest)
+					})
+				})
+
+				Context("Remove a label key which does not exist", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelOperation
+						changedLabelKey = "non-existing-key"
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK)
+					})
+				})
+
+				Context("Remove label values and providing a single value", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[0]
+						changedLabelValues = initialLabelValues[:1]
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels[*]").Array().NotContains(changedLabelValues)
+					})
+				})
+
+				Context("Remove label values and providing multiple values", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[1]
+						changedLabelValues = initialLabelValues
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels[*]").Array().NotContains(changedLabelValues)
+					})
+				})
+
+				Context("Remove all label values for a key", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[0]
+						changedLabelValues = initialLabelValues[:1]
+					})
+					It("Should return 200 with this key gone", func() {
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels").Object().Keys().NotContains(changedLabelKey)
+					})
+				})
+
+				Context("Remove label values and not providing value to remove", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelValuesOperation
+						changedLabelValues = []string{}
+					})
+					It("Should return 400", func() {
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusBadRequest)
+					})
+				})
+
+				Context("Remove label value which does not exist", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[0]
+						changedLabelValues = []string{"non-existing-value"}
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServiceOfferingsURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK)
+					})
+				})
+			})
+		})
+	},
 })
 
 func blueprint(ctx *common.TestContext) common.Object {

--- a/test/service_plan_test/service_plan_test.go
+++ b/test/service_plan_test/service_plan_test.go
@@ -18,6 +18,8 @@ package service_test
 
 import (
 	"fmt"
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/pkg/web"
 	"net/http"
 	"testing"
@@ -41,6 +43,299 @@ var _ = test.DescribeTestsFor(test.TestCase{
 	},
 	ResourceBlueprint:                      blueprint,
 	ResourceWithoutNullableFieldsBlueprint: blueprint,
+	AdditionalTests: func(ctx *common.TestContext) {
+		Context("additional non-generic tests", func() {
+
+			Describe("PATCH", func() {
+				var id string
+
+				var patchLabels []query.LabelChange
+				var patchLabelsBody map[string]interface{}
+				changedLabelKey := "label_key"
+				changedLabelValues := []string{"label_value1", "label_value2"}
+				operation := query.AddLabelOperation
+
+				BeforeEach(func() {
+					patchLabelsBody = make(map[string]interface{})
+					patchLabels = append(patchLabels, query.LabelChange{
+						Operation: operation,
+						Key:       changedLabelKey,
+						Values:    changedLabelValues,
+					})
+					patchLabelsBody["labels"] = patchLabels
+
+					plan := blueprint(ctx)
+					id = plan["id"].(string)
+				})
+
+				Context("When not only labels updated", func() {
+					It("should return bad request", func() {
+						patchLabelsBody["description"] = "new-description"
+
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusBadRequest)
+
+					})
+				})
+
+				Context("When labels not updated", func() {
+					It("should return bad request", func() {
+						body := make(map[string]interface{})
+						body["description"] = "new-description"
+
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(body).
+							Expect().
+							Status(http.StatusBadRequest)
+
+					})
+				})
+			})
+
+			Describe("Labelled", func() {
+				var id string
+
+				var initialLabels []query.LabelChange
+				var initialLabelsBody map[string]interface{}
+				initialLabelsKeys := []string{"initial_key", "initial_key2"}
+				initialLabelValues := []string{"initial_value", "initial_value2"}
+
+				var patchLabels []query.LabelChange
+				var patchLabelsBody map[string]interface{}
+				changedLabelKey := "label_key"
+				changedLabelValues := []string{"label_value1", "label_value2"}
+				operation := query.AddLabelOperation
+
+				BeforeEach(func() {
+					patchLabels = []query.LabelChange{}
+					initialLabelsBody = make(map[string]interface{})
+					initialLabels = []query.LabelChange{
+						{
+							Operation: query.AddLabelOperation,
+							Key:       initialLabelsKeys[0],
+							Values:    initialLabelValues[:1],
+						},
+						{
+							Operation: query.AddLabelOperation,
+							Key:       initialLabelsKeys[1],
+							Values:    initialLabelValues,
+						},
+					}
+					initialLabelsBody["labels"] = initialLabels
+				})
+
+				JustBeforeEach(func() {
+					patchLabelsBody = make(map[string]interface{})
+					patchLabels = append(patchLabels, query.LabelChange{
+						Operation: operation,
+						Key:       changedLabelKey,
+						Values:    changedLabelValues,
+					})
+					patchLabelsBody["labels"] = patchLabels
+
+					plan := blueprint(ctx)
+					id = plan["id"].(string)
+
+					ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+						WithJSON(initialLabelsBody).
+						Expect().
+						Status(http.StatusOK)
+
+				})
+
+				Context("Add new label", func() {
+					It("Should return 200", func() {
+						label := types.Labels{changedLabelKey: changedLabelValues}
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().Object().Value("labels").Object().ContainsMap(label)
+					})
+				})
+
+				Context("Add label with existing key and value", func() {
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK)
+
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK)
+					})
+				})
+
+				Context("Add new label value", func() {
+					BeforeEach(func() {
+						operation = query.AddLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[0]
+						changedLabelValues = []string{"new-label-value"}
+					})
+					It("Should return 200", func() {
+						var labelValuesObj []interface{}
+						for _, val := range changedLabelValues {
+							labelValuesObj = append(labelValuesObj, val)
+						}
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels").Object().Values().Path("$[*][*]").Array().Contains(labelValuesObj...)
+					})
+				})
+
+				Context("Add new label value to a non-existing label", func() {
+					BeforeEach(func() {
+						operation = query.AddLabelValuesOperation
+						changedLabelKey = "cluster_id_new"
+						changedLabelValues = []string{"new-label-value"}
+					})
+					It("Should return 200", func() {
+						var labelValuesObj []interface{}
+						for _, val := range changedLabelValues {
+							labelValuesObj = append(labelValuesObj, val)
+						}
+
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels").Object().Values().Path("$[*][*]").Array().Contains(labelValuesObj...)
+					})
+				})
+
+				Context("Add duplicate label value", func() {
+					BeforeEach(func() {
+						operation = query.AddLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[0]
+						changedLabelValues = initialLabelValues[:1]
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK)
+					})
+				})
+
+				Context("Remove a label", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelOperation
+						changedLabelKey = initialLabelsKeys[0]
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels").Object().Keys().NotContains(changedLabelKey)
+					})
+				})
+
+				Context("Remove a label and providing no key", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelOperation
+						changedLabelKey = ""
+					})
+					It("Should return 400", func() {
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusBadRequest)
+					})
+				})
+
+				Context("Remove a label key which does not exist", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelOperation
+						changedLabelKey = "non-existing-key"
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK)
+					})
+				})
+
+				Context("Remove label values and providing a single value", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[0]
+						changedLabelValues = initialLabelValues[:1]
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels[*]").Array().NotContains(changedLabelValues)
+					})
+				})
+
+				Context("Remove label values and providing multiple values", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[1]
+						changedLabelValues = initialLabelValues
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels[*]").Array().NotContains(changedLabelValues)
+					})
+				})
+
+				Context("Remove all label values for a key", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[0]
+						changedLabelValues = initialLabelValues[:1]
+					})
+					It("Should return 200 with this key gone", func() {
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK).JSON().
+							Path("$.labels").Object().Keys().NotContains(changedLabelKey)
+					})
+				})
+
+				Context("Remove label values and not providing value to remove", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelValuesOperation
+						changedLabelValues = []string{}
+					})
+					It("Should return 400", func() {
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusBadRequest)
+					})
+				})
+
+				Context("Remove label value which does not exist", func() {
+					BeforeEach(func() {
+						operation = query.RemoveLabelValuesOperation
+						changedLabelKey = initialLabelsKeys[0]
+						changedLabelValues = []string{"non-existing-value"}
+					})
+					It("Should return 200", func() {
+						ctx.SMWithOAuth.PATCH(web.ServicePlansURL + "/" + id).
+							WithJSON(patchLabelsBody).
+							Expect().
+							Status(http.StatusOK)
+					})
+				})
+			})
+		})
+	},
 })
 
 func blueprint(ctx *common.TestContext) common.Object {

--- a/test/service_plan_test/service_plan_test.go
+++ b/test/service_plan_test/service_plan_test.go
@@ -34,8 +34,7 @@ func TestServicePlans(t *testing.T) {
 }
 
 var _ = test.DescribeTestsFor(test.TestCase{
-	API:            "/v1/service_plans",
-	SupportsLabels: true,
+	API: "/v1/service_plans",
 	SupportedOps: []test.Op{
 		test.Get, test.List,
 	},

--- a/test/service_plan_test/service_plan_test.go
+++ b/test/service_plan_test/service_plan_test.go
@@ -35,7 +35,7 @@ func TestServicePlans(t *testing.T) {
 
 var _ = test.DescribeTestsFor(test.TestCase{
 	API:            "/v1/service_plans",
-	SupportsLabels: false,
+	SupportsLabels: true,
 	SupportedOps: []test.Op{
 		test.Get, test.List,
 	},

--- a/test/service_plan_test/service_plan_test.go
+++ b/test/service_plan_test/service_plan_test.go
@@ -18,6 +18,7 @@ package service_test
 
 import (
 	"fmt"
+	"github.com/Peripli/service-manager/pkg/web"
 	"net/http"
 	"testing"
 
@@ -34,7 +35,7 @@ func TestServicePlans(t *testing.T) {
 }
 
 var _ = test.DescribeTestsFor(test.TestCase{
-	API: "/v1/service_plans",
+	API: web.ServicePlansURL,
 	SupportedOps: []test.Op{
 		test.Get, test.List,
 	},
@@ -49,11 +50,11 @@ func blueprint(ctx *common.TestContext) common.Object {
 	catalog.AddService(cService)
 	id, _, _ := ctx.RegisterBrokerWithCatalog(catalog)
 
-	so := ctx.SMWithOAuth.GET("/v1/service_offerings").WithQuery("fieldQuery", "broker_id = "+id).
+	so := ctx.SMWithOAuth.GET(web.ServiceOfferingsURL).WithQuery("fieldQuery", "broker_id = "+id).
 		Expect().
 		Status(http.StatusOK).JSON().Object().Value("service_offerings").Array().First()
 
-	sp := ctx.SMWithOAuth.GET("/v1/service_plans").WithQuery("fieldQuery", fmt.Sprintf("service_offering_id = %s", so.Object().Value("id").String().Raw())).
+	sp := ctx.SMWithOAuth.GET(web.ServicePlansURL).WithQuery("fieldQuery", fmt.Sprintf("service_offering_id = %s", so.Object().Value("id").String().Raw())).
 		Expect().
 		Status(http.StatusOK).JSON().Object().Value("service_plans").Array().First()
 

--- a/test/test.go
+++ b/test/test.go
@@ -35,9 +35,8 @@ const (
 )
 
 type TestCase struct {
-	API            string
-	SupportsLabels bool
-	SupportedOps   []Op
+	API          string
+	SupportedOps []Op
 
 	ResourceBlueprint                      func(ctx *common.TestContext) common.Object
 	ResourceWithoutNullableFieldsBlueprint func(ctx *common.TestContext) common.Object

--- a/test/visibility_test/visibility_test.go
+++ b/test/visibility_test/visibility_test.go
@@ -40,7 +40,6 @@ func TestVisibilities(t *testing.T) {
 
 var _ = test.DescribeTestsFor(test.TestCase{
 	API:            web.VisibilitiesURL,
-	SupportsLabels: true,
 	SupportedOps: []test.Op{
 		test.Get, test.List, test.Delete, test.DeleteList,
 	},

--- a/test/visibility_test/visibility_test.go
+++ b/test/visibility_test/visibility_test.go
@@ -39,7 +39,7 @@ func TestVisibilities(t *testing.T) {
 }
 
 var _ = test.DescribeTestsFor(test.TestCase{
-	API:            web.VisibilitiesURL,
+	API: web.VisibilitiesURL,
 	SupportedOps: []test.Op{
 		test.Get, test.List, test.Delete, test.DeleteList,
 	},


### PR DESCRIPTION
## Motivation

Currently there is no way to add/remove labels on service offerings and service plans.

## Approach

Introduces a patch API to service offerings and service plans apis that allows patching only the labels.