### PR TITLE
Construct SMBuilder with config instead of environment

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,8 +53,18 @@ func DefaultSettings() *Settings {
 	}
 }
 
+// New creates a configuration from the default env
+func New() (*Settings, error) {
+	env, err := env.Default(AddPFlags)
+	if err != nil {
+		return nil, fmt.Errorf("error loading default env: %s", err)
+	}
+
+	return NewForEnv(env)
+}
+
 // New creates a configuration from the provided env
-func New(env env.Environment) (*Settings, error) {
+func NewForEnv(env env.Environment) (*Settings, error) {
 	config := DefaultSettings()
 	if err := env.Unmarshal(config); err != nil {
 		return nil, fmt.Errorf("error loading configuration: %s", err)

--- a/config/config.go
+++ b/config/config.go
@@ -44,14 +44,13 @@ func AddPFlags(set *pflag.FlagSet) {
 
 // DefaultSettings returns the default values for configuring the Service Manager
 func DefaultSettings() *Settings {
-	config := &Settings{
+	return &Settings{
 		Server:    server.DefaultSettings(),
 		Storage:   storage.DefaultSettings(),
 		Log:       log.DefaultSettings(),
 		API:       api.DefaultSettings(),
 		WebSocket: ws.DefaultSettings(),
 	}
-	return config
 }
 
 // New creates a configuration from the provided env

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"fmt"
 	"github.com/Peripli/service-manager/api"
 	"github.com/Peripli/service-manager/pkg/env"
 	"github.com/Peripli/service-manager/pkg/log"
@@ -57,7 +58,7 @@ func DefaultSettings() *Settings {
 func New(env env.Environment) (*Settings, error) {
 	config := DefaultSettings()
 	if err := env.Unmarshal(config); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error loading configuration: %s", err)
 	}
 
 	return config, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -165,7 +165,7 @@ var _ = Describe("config", func() {
 		)
 
 		assertErrorDuringNewConfiguration := func() {
-			_, err := cfg.New(fakeEnv)
+			_, err := cfg.NewForEnv(fakeEnv)
 			Expect(err).To(HaveOccurred())
 		}
 
@@ -227,7 +227,7 @@ var _ = Describe("config", func() {
 				})
 
 				It("uses the config values from env", func() {
-					c, err := cfg.New(fakeEnv)
+					c, err := cfg.NewForEnv(fakeEnv)
 
 					Expect(err).To(Not(HaveOccurred()))
 					Expect(fakeEnv.UnmarshalCallCount()).To(Equal(1))
@@ -244,7 +244,7 @@ var _ = Describe("config", func() {
 				})
 
 				It("returns an empty config", func() {
-					c, err := cfg.New(fakeEnv)
+					c, err := cfg.NewForEnv(fakeEnv)
 
 					Expect(err).To(Not(HaveOccurred()))
 					Expect(fakeEnv.UnmarshalCallCount()).To(Equal(1))

--- a/main.go
+++ b/main.go
@@ -30,12 +30,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	env, err := sm.DefaultEnv()
-	if err != nil {
-		panic(err)
-	}
-
-	cfg, err := config.New(env)
+	cfg, err := config.New()
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"github.com/Peripli/service-manager/config"
 
 	"github.com/Peripli/service-manager/pkg/sm"
 	"github.com/Peripli/service-manager/version"
@@ -29,7 +30,20 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	env := sm.DefaultEnv()
-	serviceManager := sm.New(ctx, cancel, env).Build()
-	serviceManager.Run()
+	env, err := sm.DefaultEnv()
+	if err != nil {
+		panic(err)
+	}
+
+	cfg, err := config.New(env)
+	if err != nil {
+		panic(err)
+	}
+
+	serviceManager, err := sm.New(ctx, cancel, cfg)
+	if err != nil {
+		panic(err)
+	}
+
+	serviceManager.Build().Run()
 }

--- a/pkg/env/cf.go
+++ b/pkg/env/cf.go
@@ -14,20 +14,19 @@
  * limitations under the License.
  */
 
-package cf
+package env
 
 import (
 	"fmt"
 	"os"
 
-	"github.com/Peripli/service-manager/pkg/env"
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/cloudfoundry-community/go-cfenv"
 	"github.com/spf13/cast"
 )
 
-// SetCFOverrides overrides some SM environment with values from CF's VCAP environment variables
-func SetCFOverrides(env env.Environment) error {
+// setCFOverrides overrides some SM environment with values from CF's VCAP environment variables
+func setCFOverrides(env Environment) error {
 	if _, exists := os.LookupEnv("VCAP_APPLICATION"); exists {
 		cfEnv, err := cfenv.Current()
 		if err != nil {

--- a/pkg/env/cf_test.go
+++ b/pkg/env/cf_test.go
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package cf
+package env
 
 import (
 	"os"
 	"testing"
 
-	"github.com/Peripli/service-manager/pkg/env"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -60,7 +59,7 @@ func TestApi(t *testing.T) {
 
 var _ = Describe("CF Env", func() {
 	var (
-		environment env.Environment
+		environment Environment
 		err         error
 	)
 
@@ -70,7 +69,7 @@ var _ = Describe("CF Env", func() {
 		Expect(os.Setenv("STORAGE_NAME", "smdb")).ShouldNot(HaveOccurred())
 		Expect(os.Unsetenv("STORAGE_URI")).ShouldNot(HaveOccurred())
 
-		environment, err = env.New(env.EmptyFlagSet())
+		environment, err = New(EmptyFlagSet())
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 
@@ -85,7 +84,7 @@ var _ = Describe("CF Env", func() {
 			It("returns no error", func() {
 				Expect(os.Unsetenv("VCAP_APPLICATION")).ShouldNot(HaveOccurred())
 
-				Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+				Expect(setCFOverrides(environment)).ShouldNot(HaveOccurred())
 				Expect(environment.Get("store.uri")).Should(BeNil())
 			})
 		})
@@ -95,7 +94,7 @@ var _ = Describe("CF Env", func() {
 				It("returns no error", func() {
 					Expect(os.Unsetenv("STORAGE_NAME")).ShouldNot(HaveOccurred())
 
-					Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+					Expect(setCFOverrides(environment)).ShouldNot(HaveOccurred())
 					Expect(environment.Get("storage.name")).Should(BeNil())
 					Expect(environment.Get("storage.uri")).Should(BeNil())
 
@@ -106,8 +105,8 @@ var _ = Describe("CF Env", func() {
 				It("returns error", func() {
 					Expect(os.Setenv("STORAGE_NAME", "missing")).ShouldNot(HaveOccurred())
 
-					err := SetCFOverrides(environment)
-					Expect(SetCFOverrides(environment)).Should(HaveOccurred())
+					err := setCFOverrides(environment)
+					Expect(setCFOverrides(environment)).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("could not find service with name"))
 				})
 			})
@@ -116,7 +115,7 @@ var _ = Describe("CF Env", func() {
 				It("returns error", func() {
 					Expect(os.Setenv("VCAP_SERVICES", "Invalid")).ShouldNot(HaveOccurred())
 
-					Expect(SetCFOverrides(environment)).Should(HaveOccurred())
+					Expect(setCFOverrides(environment)).Should(HaveOccurred())
 				})
 			})
 
@@ -124,12 +123,12 @@ var _ = Describe("CF Env", func() {
 				It("returns error", func() {
 					Expect(os.Unsetenv("VCAP_SERVICES")).ShouldNot(HaveOccurred())
 
-					Expect(SetCFOverrides(environment)).Should(HaveOccurred())
+					Expect(setCFOverrides(environment)).Should(HaveOccurred())
 				})
 			})
 
 			It("sets the storage.uri if successful", func() {
-				Expect(SetCFOverrides(environment)).ShouldNot(HaveOccurred())
+				Expect(setCFOverrides(environment)).ShouldNot(HaveOccurred())
 
 				Expect(environment.Get("storage.uri")).ShouldNot(BeEmpty())
 			})

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -142,10 +142,9 @@ func (v *ViperEnv) setupConfigFile() error {
 }
 
 // Default creates a default environment that can be used to boot up a Service Manager
-func Default(defaultPFlags func(set *pflag.FlagSet), additionalPFlags ...func(set *pflag.FlagSet)) (Environment, error) {
+func Default(additionalPFlags ...func(set *pflag.FlagSet)) (Environment, error) {
 	set := EmptyFlagSet()
 
-	defaultPFlags(set)
 	for _, addFlags := range additionalPFlags {
 		addFlags(set)
 	}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -141,6 +141,25 @@ func (v *ViperEnv) setupConfigFile() error {
 	return nil
 }
 
+// Default creates a default environment that can be used to boot up a Service Manager
+func Default(defaultPFlags func(set *pflag.FlagSet), additionalPFlags ...func(set *pflag.FlagSet)) (Environment, error) {
+	set := EmptyFlagSet()
+
+	defaultPFlags(set)
+	for _, addFlags := range additionalPFlags {
+		addFlags(set)
+	}
+
+	environment, err := New(set)
+	if err != nil {
+		return nil, fmt.Errorf("error loading environment: %s", err)
+	}
+	if err := setCFOverrides(environment); err != nil {
+		return nil, fmt.Errorf("error setting CF environment values: %s", err)
+	}
+	return environment, nil
+}
+
 type flag struct {
 	value interface{}
 }

--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -68,8 +68,8 @@ func DefaultSettings() *Settings {
 
 // Validate validates the logging settings
 func (s *Settings) Validate() error {
-	if len(s.Level) == 0 {
-		return fmt.Errorf("validate Settings: LogLevel missing")
+	if _, err := logrus.ParseLevel(s.Level); err != nil {
+		return fmt.Errorf("validate Settings: %s", err)
 	}
 	if len(s.Format) == 0 {
 		return fmt.Errorf("validate Settings: LogFormat missing")

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -43,10 +43,7 @@ import (
 	"github.com/Peripli/service-manager/storage/postgres"
 
 	"github.com/Peripli/service-manager/api/filters"
-	"github.com/Peripli/service-manager/cf"
-	"github.com/Peripli/service-manager/pkg/env"
 	"github.com/Peripli/service-manager/pkg/web"
-	"github.com/spf13/pflag"
 )
 
 // ServiceManagerBuilder type is an extension point that allows adding additional filters, plugins and
@@ -69,25 +66,6 @@ type ServiceManager struct {
 	Server              *server.Server
 	Notificator         storage.Notificator
 	NotificationCleaner *storage.NotificationCleaner
-}
-
-// DefaultEnv creates a default environment that can be used to boot up a Service Manager
-func DefaultEnv(additionalPFlags ...func(set *pflag.FlagSet)) (env.Environment, error) {
-	set := env.EmptyFlagSet()
-
-	config.AddPFlags(set)
-	for _, addFlags := range additionalPFlags {
-		addFlags(set)
-	}
-
-	environment, err := env.New(set)
-	if err != nil {
-		return nil, fmt.Errorf("error loading environment: %s", err)
-	}
-	if err := cf.SetCFOverrides(environment); err != nil {
-		return nil, fmt.Errorf("error setting CF environment values: %s", err)
-	}
-	return environment, nil
 }
 
 // New returns service-manager Server with default setup

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -59,7 +59,7 @@ type ServiceManagerBuilder struct {
 	NotificationCleaner *storage.NotificationCleaner
 	ctx                 context.Context
 	wg                  *sync.WaitGroup
-	cfg                 *config.Settings
+	cfg                 *server.Settings
 }
 
 // ServiceManager  struct
@@ -161,7 +161,7 @@ func New(ctx context.Context, cancel context.CancelFunc, cfg *config.Settings) (
 		NotificationCleaner: notificationCleaner,
 		ctx:                 ctx,
 		wg:                  waitGroup,
-		cfg:                 cfg,
+		cfg:                 cfg.Server,
 	}
 
 	// Register default interceptors that represent the core SM business logic
@@ -192,7 +192,7 @@ func (smb *ServiceManagerBuilder) Build() *ServiceManager {
 	// setup server and add relevant global middleware
 	smb.installHealth()
 
-	srv := server.New(smb.cfg.Server, smb.API)
+	srv := server.New(smb.cfg, smb.API)
 	srv.Use(filters.NewRecoveryMiddleware())
 
 	return &ServiceManager{

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -59,7 +59,7 @@ type ServiceManagerBuilder struct {
 	NotificationCleaner *storage.NotificationCleaner
 	ctx                 context.Context
 	wg                  *sync.WaitGroup
-	cfg                 *server.Settings
+	cfg                 *config.Settings
 }
 
 // ServiceManager  struct
@@ -165,7 +165,7 @@ func New(ctx context.Context, cancel context.CancelFunc, env env.Environment) *S
 		NotificationCleaner: notificationCleaner,
 		ctx:                 ctx,
 		wg:                  waitGroup,
-		cfg:                 cfg.Server,
+		cfg:                 cfg,
 	}
 
 	// Register default interceptors that represent the core SM business logic
@@ -196,7 +196,7 @@ func (smb *ServiceManagerBuilder) Build() *ServiceManager {
 	// setup server and add relevant global middleware
 	smb.installHealth()
 
-	srv := server.New(smb.cfg, smb.API)
+	srv := server.New(smb.cfg.Server, smb.API)
 	srv.Use(filters.NewRecoveryMiddleware())
 
 	return &ServiceManager{

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -90,7 +90,7 @@ func DefaultEnv(additionalPFlags ...func(set *pflag.FlagSet)) (env.Environment, 
 	return environment, nil
 }
 
-// New returns service-manager Server with default setup. The function panics on bad configuration
+// New returns service-manager Server with default setup
 func New(ctx context.Context, cancel context.CancelFunc, cfg *config.Settings) (*ServiceManagerBuilder, error) {
 	var err error
 	if err = cfg.Validate(); err != nil {

--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -76,6 +76,9 @@ func (s *Settings) Validate() error {
 	if len(s.URI) == 0 {
 		return fmt.Errorf("validate Settings: StorageURI missing")
 	}
+	if len(s.MigrationsURL) == 0 {
+		return fmt.Errorf("validate Settings: StorageMigrationsURL missing")
+	}
 	if len(s.EncryptionKey) != 32 {
 		return fmt.Errorf("validate Settings: StorageEncryptionKey must be exactly 32 symbols long but was %d symbols long", len(s.EncryptionKey))
 	}

--- a/storage/postgres/storage.go
+++ b/storage/postgres/storage.go
@@ -59,8 +59,7 @@ func (ps *Storage) SelectContext(ctx context.Context, dest interface{}, query st
 }
 
 func (ps *Storage) Open(settings *storage.Settings) error {
-	var err error
-	if err = settings.Validate(); err != nil {
+	if err := settings.Validate(); err != nil {
 		return err
 	}
 

--- a/storage/registry.go
+++ b/storage/registry.go
@@ -26,8 +26,8 @@ import (
 	"github.com/Peripli/service-manager/pkg/log"
 )
 
-func InitializeWithSafeTermination(ctx context.Context, s Storage, options *Settings, wg *sync.WaitGroup, decorators ...TransactionalRepositoryDecorator) (TransactionalRepository, error) {
-	if s == nil || options == nil {
+func InitializeWithSafeTermination(ctx context.Context, s Storage, settings *Settings, wg *sync.WaitGroup, decorators ...TransactionalRepositoryDecorator) (TransactionalRepository, error) {
+	if s == nil || settings == nil {
 		return nil, fmt.Errorf("storage and storage settings cannot be nil")
 	}
 
@@ -39,7 +39,7 @@ func InitializeWithSafeTermination(ctx context.Context, s Storage, options *Sett
 		}
 	}, wg)
 
-	if err := s.Open(options); err != nil {
+	if err := s.Open(settings); err != nil {
 		return nil, fmt.Errorf("error opening storage: %s", err)
 	}
 

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -165,7 +165,7 @@ func TestEnv(additionalFlagFuncs ...func(set *pflag.FlagSet)) env.Environment {
 
 	additionalFlagFuncs = append(additionalFlagFuncs, f)
 
-	env, _ := env.Default(config.AddPFlags, additionalFlagFuncs...)
+	env, _ := env.Default(append([]func(set *pflag.FlagSet){config.AddPFlags}, additionalFlagFuncs...)...)
 	return env
 }
 

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/Peripli/service-manager/config"
 	"net/http/httptest"
 	"path"
 	"runtime"
@@ -164,7 +165,8 @@ func TestEnv(additionalFlagFuncs ...func(set *pflag.FlagSet)) env.Environment {
 
 	additionalFlagFuncs = append(additionalFlagFuncs, f)
 
-	return sm.DefaultEnv(additionalFlagFuncs...)
+	env, _ := sm.DefaultEnv(additionalFlagFuncs...)
+	return env
 }
 
 func (tcb *TestContextBuilder) SkipBasicAuthClientSetup(shouldSkip bool) *TestContextBuilder {
@@ -271,7 +273,17 @@ func newSMServer(smEnv env.Environment, wg *sync.WaitGroup, fs []func(ctx contex
 		panic(err)
 	}
 	ctx = log.Configure(ctx, s.Log)
-	smb := sm.New(ctx, cancel, smEnv)
+
+	cfg, err := config.New(smEnv)
+	if err != nil {
+		panic(err)
+	}
+
+	smb, err := sm.New(ctx, cancel, cfg)
+	if err != nil {
+		panic(err)
+	}
+
 	for _, registerExtensionsFunc := range fs {
 		if err := registerExtensionsFunc(ctx, smb, smEnv); err != nil {
 			panic(fmt.Sprintf("error creating test SM server: %s", err))

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -165,7 +165,7 @@ func TestEnv(additionalFlagFuncs ...func(set *pflag.FlagSet)) env.Environment {
 
 	additionalFlagFuncs = append(additionalFlagFuncs, f)
 
-	env, _ := sm.DefaultEnv(additionalFlagFuncs...)
+	env, _ := env.Default(config.AddPFlags, additionalFlagFuncs...)
 	return env
 }
 
@@ -274,7 +274,7 @@ func newSMServer(smEnv env.Environment, wg *sync.WaitGroup, fs []func(ctx contex
 	}
 	ctx = log.Configure(ctx, s.Log)
 
-	cfg, err := config.New(smEnv)
+	cfg, err := config.NewForEnv(smEnv)
 	if err != nil {
 		panic(err)
 	}

--- a/test/sm_test/sm_test.go
+++ b/test/sm_test/sm_test.go
@@ -19,6 +19,7 @@ package sm_test
 import (
 	"context"
 	"github.com/Peripli/service-manager/config"
+	"github.com/Peripli/service-manager/pkg/env"
 	"net/http/httptest"
 	"testing"
 
@@ -60,12 +61,12 @@ var _ = Describe("SM", func() {
 	Describe("New", func() {
 		Context("when validating config fails", func() {
 			It("should return error", func() {
-				env, err := sm.DefaultEnv(common.SetTestFileLocation)
+				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", oauthServer.URL())
 				env.Set("log.level", "invalid")
 
-				cfg, err := config.New(env)
+				cfg, err := config.NewForEnv(env)
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = sm.New(ctx, cancel, cfg)
@@ -76,12 +77,12 @@ var _ = Describe("SM", func() {
 
 		Context("when setting up storage with invalid uri", func() {
 			It("should throw error during migrations setup", func() {
-				env, err := sm.DefaultEnv(common.SetTestFileLocation)
+				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", oauthServer.URL())
 				env.Set("storage.uri", "invalid")
 
-				cfg, err := config.New(env)
+				cfg, err := config.NewForEnv(env)
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = sm.New(ctx, cancel, cfg)
@@ -92,11 +93,11 @@ var _ = Describe("SM", func() {
 
 		Context("when setting up API fails", func() {
 			It("should return error", func() {
-				env, err := sm.DefaultEnv(common.SetTestFileLocation)
+				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", "")
 
-				cfg, err := config.New(env)
+				cfg, err := config.NewForEnv(env)
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = sm.New(ctx, cancel, cfg)
@@ -106,11 +107,11 @@ var _ = Describe("SM", func() {
 
 		Context("when no API extensions are registered", func() {
 			It("should return working service manager", func() {
-				env, err := sm.DefaultEnv(common.SetTestFileLocation)
+				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", oauthServer.URL())
 
-				cfg, err := config.New(env)
+				cfg, err := config.NewForEnv(env)
 				Expect(err).ToNot(HaveOccurred())
 
 				smanager, err := sm.New(ctx, cancel, cfg)
@@ -122,11 +123,11 @@ var _ = Describe("SM", func() {
 
 		Context("when additional filter is registered", func() {
 			It("should return working service manager with a new filter", func() {
-				env, err := sm.DefaultEnv(common.SetTestFileLocation)
+				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", oauthServer.URL())
 
-				cfg, err := config.New(env)
+				cfg, err := config.NewForEnv(env)
 				Expect(err).ToNot(HaveOccurred())
 
 				smanager, err := sm.New(ctx, cancel, cfg)
@@ -144,11 +145,11 @@ var _ = Describe("SM", func() {
 
 		Context("when additional controller is registered", func() {
 			It("should return working service manager with additional controller", func() {
-				env, err := sm.DefaultEnv(common.SetTestFileLocation)
+				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", oauthServer.URL())
 
-				cfg, err := config.New(env)
+				cfg, err := config.NewForEnv(env)
 				Expect(err).ToNot(HaveOccurred())
 
 				smanager, err := sm.New(ctx, cancel, cfg)


### PR DESCRIPTION
# Construct SMBuilder with configuration instead of environment

## Motivation

Service Manager custom implementations most likely would require information regarding different base SM configuration properties. In this way, custom SM implementations can wrap the default SM configuration easier, only provide the default one to the SM Builder and not have the default configuration "encapsulated" inside the constructor of the SM Builder.

## Approach

The `sm.New()` function now takes as final parameter a config instead of environment.

This PR also removes panicing inside some functions and delegating the error down to the `main()` functions.

## Pull Request status

* [x] Initial implementation
