### PR TITLE
Allow pflag creation for slices

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -218,7 +218,7 @@
   revision = "38398a30ed8516ffda617a04c822de09df8a3ec5"
 
 [[projects]]
-  digest = "1:aaa8e0e7e35d92e21daed3f241832cee73d15ca1cd3302ba3843159a959a7eac"
+  digest = "1:589fb1a525a9596f15cf90064ad57cfad5de59b3579e91f272f470ab49051647"
   name = "github.com/klauspost/compress"
   packages = [
     "flate",
@@ -226,8 +226,8 @@
     "zlib",
   ]
   pruneopts = "UT"
-  revision = "b4b6d9e7f099f14b3a4a08f0664986cd4c85ebd6"
-  version = "v1.5.0"
+  revision = "8756f2777357367e8b792ec60331ce0d40fb925e"
+  version = "v1.6.2"
 
 [[projects]]
   digest = "1:923c4d7194b42e054b2eb8a6c62824ac55e23ececc1c7e48d4da69c971c55954"
@@ -548,7 +548,7 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "20be4c3c3ed52bfccdb2d59a412ee1a936d175a7"
+  revision = "f99c8df09eb5bff426315721bfa5f16a99cad32c"
 
 [[projects]]
   branch = "master"
@@ -564,7 +564,7 @@
     "publicsuffix",
   ]
   pruneopts = "UT"
-  revision = "f3200d17e092c607f615320ecaad13d87ad9a2b3"
+  revision = "60506f45cf65977eb3a9c6e30f995f54a721c271"
 
 [[projects]]
   branch = "master"
@@ -575,15 +575,15 @@
     "internal",
   ]
   pruneopts = "UT"
-  revision = "aaccbc9213b0974828f81aaac109d194880e3014"
+  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
 
 [[projects]]
   branch = "master"
-  digest = "1:668e8c66b8895d69391429b0f64a72c35603c94f364c94d4e5fab5053d57a0b6"
+  digest = "1:8f5108406bc43c7669b0d67d282e40d05c9f268615fcaf8c1f0f76965aa3f09f"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "69e3a3a65b5bed52b8194d33c59d955757d87523"
+  revision = "4c4f7f33c9ed00de01c4c741d2177abfcfe19307"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -77,7 +77,12 @@ func CreatePFlags(set *pflag.FlagSet, value interface{}) {
 
 	for i, parameter := range parameters {
 		if set.Lookup(parameter.Name) == nil {
-			set.Var(&flag{value: parameter.DefaultValue}, parameter.Name, descriptions[i])
+			switch val := parameter.DefaultValue.(type) {
+			case []string:
+				set.StringSlice(parameter.Name, val, descriptions[i])
+			default:
+				set.Var(&flag{value: val}, parameter.Name, descriptions[i])
+			}
 		}
 	}
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -173,10 +173,5 @@ func (f *flag) Set(s string) error {
 }
 
 func (f *flag) Type() string {
-	flagType := reflect.TypeOf(f.value)
-	if flagType.Kind() == reflect.Slice {
-		return fmt.Sprintf("%sSlice", flagType.Elem().Name())
-	}
-
-	return flagType.Name()
+	return reflect.TypeOf(f.value).Name()
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -77,12 +77,7 @@ func CreatePFlags(set *pflag.FlagSet, value interface{}) {
 
 	for i, parameter := range parameters {
 		if set.Lookup(parameter.Name) == nil {
-			switch val := parameter.DefaultValue.(type) {
-			case []string:
-				set.StringSlice(parameter.Name, val, descriptions[i])
-			default:
-				set.Var(&flag{value: val}, parameter.Name, descriptions[i])
-			}
+			set.Var(&flag{value: parameter.DefaultValue}, parameter.Name, descriptions[i])
 		}
 	}
 }
@@ -178,5 +173,10 @@ func (f *flag) Set(s string) error {
 }
 
 func (f *flag) Type() string {
-	return reflect.TypeOf(f.value).Name()
+	flagType := reflect.TypeOf(f.value)
+	if flagType.Kind() == reflect.Slice {
+		return fmt.Sprintf("%sSlice", flagType.Elem().Name())
+	}
+
+	return flagType.Name()
 }

--- a/pkg/env/helpers.go
+++ b/pkg/env/helpers.go
@@ -109,6 +109,11 @@ func buildDescriptionTreeWithParameters(value interface{}, tree *descriptionTree
 			} else {
 				name = field.Name()
 			}
+
+			if name == "-" || name == ",squash" {
+				continue
+			}
+
 			description := ""
 			if field.Tag("description") != "" {
 				description = field.Tag("description")

--- a/pkg/env/helpers.go
+++ b/pkg/env/helpers.go
@@ -126,5 +126,5 @@ func buildDescriptionTreeWithParameters(value interface{}, tree *descriptionTree
 
 func isValidField(field *structs.Field) bool {
 	kind := field.Kind()
-	return field.IsExported() && kind != reflect.Slice && kind != reflect.Interface && kind != reflect.Func
+	return field.IsExported() && kind != reflect.Interface && kind != reflect.Func
 }


### PR DESCRIPTION
# Allow pflag creation for slices

## Motivation

There could be situations where slices are part of SM's configuration and corresponding pflags should be able to be created based on that.

## Approach

Remove the restriction for slices.

## Pull Request status

For example:

* [x] Initial implementation
