### PR TITLE
Fix failing notification cleaner test

### DIFF
--- a/test/notification_cleaner_test/notification_cleaner_test.go
+++ b/test/notification_cleaner_test/notification_cleaner_test.go
@@ -101,11 +101,13 @@ var _ = Describe("Notification cleaner", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(old.GetID()).ToNot(BeNil())
 
+			Eventually(logInterceptor.String, eventuallyTimeout).
+				Should(ContainSubstring("successfully deleted 1 old notifications"))
+
 			Eventually(func() error {
 				_, err = repository.Get(ctx, types.NotificationType, old.GetID())
 				return err
 			}, eventuallyTimeout).Should(Equal(util.ErrNotFoundInStorage))
-			Expect(logInterceptor.String()).To(ContainSubstring("successfully deleted 1 old notifications"))
 
 			obj, err := repository.Get(ctx, types.NotificationType, new.GetID())
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
# Pull Request Template

Notification cleaner test was failing because of using Expect in async test. Eventually is used to fix the test.