### PR TITLE
Do not return empty labels when no labels are present in database

### DIFF
--- a/storage/postgres/interfaces.go
+++ b/storage/postgres/interfaces.go
@@ -75,10 +75,12 @@ func rowsToList(rows *sqlx.Rows, rowCreator EntityLabelRowCreator, result types.
 			entities[row.GetID()] = entity
 			result.Add(entity)
 		}
-		if labels[entity.GetID()] == nil {
-			labels[entity.GetID()] = make(map[string][]string)
+		if row.GetKey() != "" {
+			if labels[entity.GetID()] == nil {
+				labels[entity.GetID()] = make(map[string][]string)
+			}
+			labels[entity.GetID()][row.GetKey()] = append(labels[entity.GetID()][row.GetKey()], row.GetValue())
 		}
-		labels[entity.GetID()][row.GetKey()] = append(labels[entity.GetID()][row.GetKey()], row.GetValue())
 	}
 	for i := 0; i < result.Len(); i++ {
 		b := result.ItemAt(i)

--- a/test/storage_test/storage_test.go
+++ b/test/storage_test/storage_test.go
@@ -1,0 +1,52 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Peripli/service-manager/pkg/types"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Peripli/service-manager/test/common"
+)
+
+func TestStorage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Storage Suite")
+}
+
+var _ = Describe("Test", func() {
+	var ctx *common.TestContext
+
+	BeforeEach(func() {
+		ctx = common.NewTestContextBuilder().Build()
+	})
+
+	AfterEach(func() {
+		ctx.Cleanup()
+	})
+
+	Context("when resource is created without labels", func() {
+		var platform types.Object
+		var err error
+		BeforeEach(func() {
+			platform, err = ctx.SMRepository.Create(context.Background(), &types.Platform{
+				Base: types.Base{
+					ID: "id",
+				},
+				Description: "desc",
+				Name:        "platform_name",
+				Type:        "cloudfoundry",
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should be fetched from storage without any labels", func() {
+			obj, err := ctx.SMRepository.Get(context.Background(), types.PlatformType, platform.GetID())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(obj.GetLabels()).To(HaveLen(0))
+		})
+	})
+})


### PR DESCRIPTION
# Pull Request Template

## Motivation

When entity (for example platform) is fetched directly from storage and it should not have any labels. The bug is that there are labels with empty key and empty value.
This empty labels are not returned by the REST API, because JSON encoder removes them when encoding the object.

This PR fixes the above described bug.