### PR TITLE
Fix deletion query building

### DIFF
--- a/storage/postgres/query_builder.go
+++ b/storage/postgres/query_builder.go
@@ -221,21 +221,23 @@ func (pgq *pgQuery) limitSQL() *pgQuery {
 
 func (pgq *pgQuery) returningSQL(entity PostgresEntity) *pgQuery {
 	for i := range pgq.returningFields {
-		pgq.returningFields[i] = fmt.Sprintf("%s.%s", mainTableAlias, pgq.returningFields[i])
-	}
-
-	if len(pgq.returningFields) != 0 {
-		labelEntity := entity.LabelEntity()
-		if labelEntity != nil {
-			labelsTableName := labelEntity.LabelsTableName()
-			for _, dbTag := range getDBTags(labelEntity, isAutoIncrementable) {
-				pgq.returningFields = append(pgq.returningFields, fmt.Sprintf(`%[1]s.%[2]s "%[1]s.%[2]s"`, labelsTableName, dbTag.Tag))
-			}
+		if !strings.HasPrefix(pgq.returningFields[i], fmt.Sprintf("%s.", mainTableAlias)) {
+			pgq.returningFields[i] = fmt.Sprintf("%s.%s", mainTableAlias, pgq.returningFields[i])
 		}
 	}
 
+	//if len(pgq.returningFields) != 0 {
+	//	labelEntity := entity.LabelEntity()
+	//	if labelEntity != nil {
+	//		labelsTableName := labelEntity.LabelsTableName()
+	//		for _, dbTag := range getDBTags(labelEntity, isAutoIncrementable) {
+	//			pgq.returningFields = append(pgq.returningFields, fmt.Sprintf(`%[1]s.%[2]s "%[1]s.%[2]s"`, labelsTableName, dbTag.Tag))
+	//		}
+	//	}
+	//}
+
 	if len(pgq.returningFields) == 1 {
-		pgq.sql.WriteString(fmt.Sprintf(" RETURNING %s.%s", mainTableAlias, pgq.returningFields[0]))
+		pgq.sql.WriteString(fmt.Sprintf(" RETURNING " + pgq.returningFields[0]))
 	} else if len(pgq.returningFields) > 0 {
 		pgq.sql.WriteString(" RETURNING " + strings.Join(pgq.returningFields, ", "))
 	}

--- a/storage/postgres/query_builder.go
+++ b/storage/postgres/query_builder.go
@@ -226,16 +226,6 @@ func (pgq *pgQuery) returningSQL(entity PostgresEntity) *pgQuery {
 		}
 	}
 
-	//if len(pgq.returningFields) != 0 {
-	//	labelEntity := entity.LabelEntity()
-	//	if labelEntity != nil {
-	//		labelsTableName := labelEntity.LabelsTableName()
-	//		for _, dbTag := range getDBTags(labelEntity, isAutoIncrementable) {
-	//			pgq.returningFields = append(pgq.returningFields, fmt.Sprintf(`%[1]s.%[2]s "%[1]s.%[2]s"`, labelsTableName, dbTag.Tag))
-	//		}
-	//	}
-	//}
-
 	if len(pgq.returningFields) == 1 {
 		pgq.sql.WriteString(fmt.Sprintf(" RETURNING " + pgq.returningFields[0]))
 	} else if len(pgq.returningFields) > 0 {

--- a/storage/postgres/query_builder.go
+++ b/storage/postgres/query_builder.go
@@ -184,7 +184,7 @@ func (pgq *pgQuery) finalizeSQL(ctx context.Context, entity PostgresEntity, wher
 		orderBySQL().
 		limitSQL().
 		lockSQL(entity.TableName()).
-		returningSQL(entity).
+		returningSQL().
 		expandMultivariateOp()
 
 	if pgq.err != nil {
@@ -219,7 +219,7 @@ func (pgq *pgQuery) limitSQL() *pgQuery {
 	return pgq
 }
 
-func (pgq *pgQuery) returningSQL(entity PostgresEntity) *pgQuery {
+func (pgq *pgQuery) returningSQL() *pgQuery {
 	for i := range pgq.returningFields {
 		if !strings.HasPrefix(pgq.returningFields[i], fmt.Sprintf("%s.", mainTableAlias)) {
 			pgq.returningFields[i] = fmt.Sprintf("%s.%s", mainTableAlias, pgq.returningFields[i])

--- a/storage/postgres/query_builder_test.go
+++ b/storage/postgres/query_builder_test.go
@@ -350,14 +350,7 @@ WHERE t.id = visibilities.id
 FROM visibilities USING visibilities t
 LEFT JOIN visibility_labels ON t.id = visibility_labels.visibility_id
 WHERE t.id = visibilities.id 
-RETURNING t.id,
-	t.service_plan_id,
-	visibility_labels.id "visibility_labels.id",
-	visibility_labels.key "visibility_labels.key",
-	visibility_labels.val "visibility_labels.val",
-	visibility_labels.created_at "visibility_labels.created_at",
-	visibility_labels.updated_at "visibility_labels.updated_at",
-	visibility_labels.visibility_id "visibility_labels.visibility_id";`)))
+RETURNING t.id, t.service_plan_id;`)))
 			})
 
 			It("builds query with *", func() {
@@ -368,13 +361,7 @@ RETURNING t.id,
 FROM visibilities USING visibilities t
 LEFT JOIN visibility_labels ON t.id = visibility_labels.visibility_id
 WHERE t.id = visibilities.id 
-RETURNING t.*,
-	visibility_labels.id "visibility_labels.id",
-	visibility_labels.key "visibility_labels.key",
-	visibility_labels.val "visibility_labels.val",
-	visibility_labels.created_at "visibility_labels.created_at",
-	visibility_labels.updated_at "visibility_labels.updated_at",
-	visibility_labels.visibility_id "visibility_labels.visibility_id";`)))
+RETURNING t.*;`)))
 			})
 
 			Context("when unknown field is specified", func() {
@@ -418,13 +405,7 @@ WHERE t.id = visibilities.id
   AND t.service_plan_id::text NOT IN (?, ?, ?)
   AND (t.platform_id::text = ?
 	   OR t.platform_id IS NULL) 
-RETURNING t.*,
-	visibility_labels.id "visibility_labels.id",
-	visibility_labels.key "visibility_labels.key",
-	visibility_labels.val "visibility_labels.val",
-	visibility_labels.created_at "visibility_labels.created_at",
-	visibility_labels.updated_at "visibility_labels.updated_at",
-	visibility_labels.visibility_id "visibility_labels.visibility_id";`)))
+RETURNING t.*;`)))
 				Expect(queryArgs).To(HaveLen(12))
 				Expect(queryArgs[0]).Should(Equal("left1"))
 				Expect(queryArgs[1]).Should(Equal("right1"))


### PR DESCRIPTION
Currently the delete query attempts to return labels. If we delete a visibility that has a one label called `org_id` and three values (org1,org2 and org3) the query will return one row containing the details about the visibility and the first deleted label value (org1). Then the created notification will include only one value (org1) in the payload for the label `org_id`  and the proxy will disable the service plan access for only this org and miss disabling for the other two.

There is no great benefit in trying to complicate the query further and try to return all deleted labels as deleting the resource will delete all labels linked to it anyway (unless we find some neat solution). 
Proposed solution with this PR is to revert to not returning information about labels when deleting a resource (this was the old implementation before introducing delete by label query). Delete by label query will still work.