### PR TITLE
 Make test SM server listener replaceable

### DIFF
--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -271,15 +271,14 @@ func (tcb *TestContextBuilder) BuildWithListener(listener net.Listener) *TestCon
 func NewSMListener() (net.Listener, error) {
 	minPort := 8100
 	maxPort := 9999
-
-	rand.Seed(time.Now().UnixNano())
-	port := rand.Intn(maxPort-minPort) + minPort
-
 	retries := 10
 
 	var listener net.Listener
 	var err error
 	for ; retries >= 0; retries-- {
+		rand.Seed(time.Now().UnixNano())
+		port := rand.Intn(maxPort-minPort) + minPort
+
 		smURL := "127.0.0.1:" + strconv.Itoa(port)
 		listener, err = net.Listen("tcp", smURL)
 		if err == nil {

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -330,16 +330,12 @@ func newSMServer(smEnv env.Environment, wg *sync.WaitGroup, fs []func(ctx contex
 		panic(err)
 	}
 
-	var testServer *httptest.Server
-	if listener == nil {
-		testServer = httptest.NewServer(serviceManager.Server.Router)
-	} else {
-		testServer = httptest.NewUnstartedServer(serviceManager.Server.Router)
+	testServer := httptest.NewUnstartedServer(serviceManager.Server.Router)
+	if listener != nil {
 		testServer.Listener.Close()
 		testServer.Listener = listener
-
-		testServer.Start()
 	}
+	testServer.Start()
 
 	return &testSMServer{
 		cancel: cancel,

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -332,7 +332,7 @@ func newSMServer(smEnv env.Environment, wg *sync.WaitGroup, fs []func(ctx contex
 	if listener == nil {
 		testServer = httptest.NewServer(serviceManager.Server.Router)
 	} else {
-		testServer := httptest.NewUnstartedServer(serviceManager.Server.Router)
+		testServer = httptest.NewUnstartedServer(serviceManager.Server.Router)
 		testServer.Listener.Close()
 		testServer.Listener = listener
 

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -267,7 +267,7 @@ func (tcb *TestContextBuilder) BuildWithListener(listener net.Listener) *TestCon
 	return testContext
 }
 
-func newSMListener() (net.Listener, string, error) {
+func NewSMListener() (net.Listener, string, error) {
 	minPort := 8100
 	maxPort := 9999
 	port := rand.Intn((maxPort - minPort) + minPort)

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -30,6 +30,7 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/gavv/httpexpect"
 	"github.com/gofrs/uuid"
@@ -267,10 +268,12 @@ func (tcb *TestContextBuilder) BuildWithListener(listener net.Listener) *TestCon
 	return testContext
 }
 
-func NewSMListener() (net.Listener, string, error) {
+func NewSMListener() (net.Listener, error) {
 	minPort := 8100
 	maxPort := 9999
-	port := rand.Intn((maxPort - minPort) + minPort)
+
+	rand.Seed(time.Now().UnixNano())
+	port := rand.Intn(maxPort-minPort) + minPort
 
 	retries := 10
 
@@ -280,11 +283,11 @@ func NewSMListener() (net.Listener, string, error) {
 		smURL := "127.0.0.1:" + strconv.Itoa(port)
 		listener, err = net.Listen("tcp", smURL)
 		if err == nil {
-			return listener, smURL, nil
+			return listener, nil
 		}
 	}
 
-	return nil, "", fmt.Errorf("unable to create sm listener: %s", err)
+	return nil, fmt.Errorf("unable to create sm listener: %s", err)
 }
 
 func newSMServer(smEnv env.Environment, wg *sync.WaitGroup, fs []func(ctx context.Context, smb *sm.ServiceManagerBuilder, env env.Environment) error, listener net.Listener) (*testSMServer, storage.Repository) {


### PR DESCRIPTION
#  Make test SM server listener replaceable

## Motivation

Some tests might require to provide a custom server listener, ex. in order to control on which port it is deployed and be able to construct accurate expectations.

## Approach

Introduce a new `BuildWithListener` method for building `TestContext` structs with a predefined listener.

## Pull Request status


* [x] Initial implementation
