### PR TITLE
Add context to serve error logging

### DIFF
--- a/api/filters/recovery.go
+++ b/api/filters/recovery.go
@@ -19,7 +19,7 @@ func NewRecoveryMiddleware() mux.MiddlewareFunc {
 						StatusCode:  http.StatusInternalServerError,
 						Description: "Internal Server Error",
 					}
-					util.WriteError(httpError, w)
+					util.WriteError(r.Context(), httpError, w)
 					debug.PrintStack()
 					log.C(r.Context()).Error(err)
 				}

--- a/api/http_handler.go
+++ b/api/http_handler.go
@@ -64,7 +64,11 @@ func (h *HTTPHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	var response *web.Response
 	response, err = h.Handler.Handle(request)
 	ctx = request.Context() // logging filter may have enriched the context with a logger
-	if request.IsResponseWriterHijacked() || err != nil {
+	if request.IsResponseWriterHijacked() {
+		err = nil
+		return
+	}
+	if err != nil {
 		return
 	}
 

--- a/api/http_handler.go
+++ b/api/http_handler.go
@@ -47,25 +47,25 @@ func (h *HTTPHandler) Handle(req *web.Request) (resp *web.Response, err error) {
 
 // ServeHTTP implements the http.Handler interface and allows wrapping web.Handlers into http.Handlers
 func (h *HTTPHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	if err := h.serve(res, req); err != nil {
-		util.WriteError(err, res)
-	}
-}
+	var err error
+	ctx := req.Context()
+	defer func() {
+		if err != nil {
+			util.WriteError(ctx, err, res)
+		}
+	}()
 
-func (h *HTTPHandler) serve(res http.ResponseWriter, req *http.Request) error {
+	var request *web.Request
 	req.Body = http.MaxBytesReader(res, req.Body, int64(h.requestBodyMaxSize))
-
-	request, err := convertToWebRequest(req, res)
-	if err != nil {
-		return err
+	if request, err = convertToWebRequest(req, res); err != nil {
+		return
 	}
 
-	response, err := h.Handler.Handle(request)
-	if request.IsResponseWriterHijacked() {
-		return nil
-	}
-	if err != nil {
-		return err
+	var response *web.Response
+	response, err = h.Handler.Handle(request)
+	ctx = request.Context() // logging filter may have enriched the context with a logger
+	if request.IsResponseWriterHijacked() || err != nil {
+		return
 	}
 
 	// copy response headers
@@ -76,13 +76,11 @@ func (h *HTTPHandler) serve(res http.ResponseWriter, req *http.Request) error {
 	}
 
 	res.WriteHeader(response.StatusCode)
-	_, err = res.Write(response.Body)
-	if err != nil {
+	if _, err = res.Write(response.Body); err != nil {
 		// HTTP headers and status are sent already
 		// if we return an error, the error Handler will try to send them again
-		log.C(req.Context()).Error("Error sending response", err)
+		log.C(ctx).Error("Error sending response", err)
 	}
-	return nil
 }
 
 func convertToWebRequest(request *http.Request, rw http.ResponseWriter) (*web.Request, error) {

--- a/api/notifications/ws_connection.go
+++ b/api/notifications/ws_connection.go
@@ -29,7 +29,7 @@ func (c *Controller) upgrade(rw http.ResponseWriter, req *http.Request, header h
 				ErrorType:   "WebsocketUpgradeError",
 				Description: reason.Error(),
 			}
-			util.WriteError(httpErr, w)
+			util.WriteError(r.Context(), httpErr, w)
 		},
 	}
 	conn, err := upgrader.Upgrade(rw, req, header)

--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -149,7 +149,7 @@ func buildProxy(targetBrokerURL *url.URL, logger *logrus.Entry, broker *types.Se
 	}
 	proxy.ErrorHandler = func(writer http.ResponseWriter, request *http.Request, e error) {
 		logger.WithError(e).Errorf("Error while forwarding request to service broker %s", broker.Name)
-		util.WriteError(&util.HTTPError{
+		util.WriteError(request.Context(), &util.HTTPError{
 			ErrorType:   "ServiceBrokerErr",
 			Description: fmt.Sprintf("could not reach service broker %s at %s", broker.Name, request.URL),
 			StatusCode:  http.StatusBadGateway,

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -17,6 +17,7 @@
 package util
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -46,9 +47,9 @@ func (uq *UnsupportedQueryError) Error() string {
 }
 
 // WriteError sends a JSON containing the error to the response writer
-func WriteError(err error, writer http.ResponseWriter) {
+func WriteError(ctx context.Context, err error, writer http.ResponseWriter) {
 	var respError *HTTPError
-	logger := log.D()
+	logger := log.C(ctx)
 	switch t := err.(type) {
 	case *UnsupportedQueryError:
 		logger.Errorf("UnsupportedQueryError: %s", err)

--- a/pkg/util/errors_test.go
+++ b/pkg/util/errors_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Errors", func() {
 		responseRecorder *httptest.ResponseRecorder
 		fakeErrorWriter  *errorResponseWriter
 		testHTTPError    *util.HTTPError
+		ctx              context.Context
 	)
 
 	BeforeEach(func() {
@@ -52,12 +53,13 @@ var _ = Describe("Errors", func() {
 			Description: "test description",
 			StatusCode:  http.StatusTeapot,
 		}
+		ctx = context.TODO()
 	})
 
 	Describe("WriteError", func() {
 		Context("when parameter is HTTPError", func() {
 			It("writes to response writer the proper output", func() {
-				util.WriteError(testHTTPError, responseRecorder)
+				util.WriteError(ctx, testHTTPError, responseRecorder)
 
 				Expect(responseRecorder.Code).To(Equal(http.StatusTeapot))
 				Expect(responseRecorder.Body.String()).To(ContainSubstring("test description"))
@@ -65,7 +67,7 @@ var _ = Describe("Errors", func() {
 		})
 		Context("With error as parameter", func() {
 			It("Writes to response writer the proper output", func() {
-				util.WriteError(errors.New("must not be included"), responseRecorder)
+				util.WriteError(ctx, errors.New("must not be included"), responseRecorder)
 
 				Expect(responseRecorder.Code).To(Equal(http.StatusInternalServerError))
 				Expect(responseRecorder.Body.String()).To(ContainSubstring("Internal server error"))
@@ -77,7 +79,7 @@ var _ = Describe("Errors", func() {
 			It("Logs write error", func() {
 				hook := &testutil.LogInterceptor{}
 				logrus.AddHook(hook)
-				util.WriteError(errors.New(""), fakeErrorWriter)
+				util.WriteError(ctx, errors.New(""), fakeErrorWriter)
 
 				Expect(hook).To(ContainSubstring("Could not write error to response: write error"))
 			})


### PR DESCRIPTION
If an error occurs, the last log in the chain has no correlation id. 
This addresses this issue by adding context to the error handling and using the correlation id from the request
This helps troubleshooting because often the last log in the chain contains valuable information about the error and now it is difficult to find it