### PR TITLE
Fix postgres Listen not called in some cases

### DIFF
--- a/api/notifications/ws_connection.go
+++ b/api/notifications/ws_connection.go
@@ -64,13 +64,13 @@ func (c *Controller) configureConn(ctx context.Context, conn *websocket.Conn) {
 	})
 }
 
-func (c *Controller) closeConn(ctx context.Context, conn *websocket.Conn, done <-chan struct{}) {
+func (c *Controller) closeConn(ctx context.Context, cancel context.CancelFunc, conn *websocket.Conn, done <-chan struct{}) {
 	defer func() {
 		if err := recover(); err != nil {
 			log.C(ctx).Errorf("recovered from panic while closing websocket connection: %s", err)
 		}
 	}()
-
+	defer cancel()
 	// if base context is cancelled, write loop will quit and write to done
 	<-done
 

--- a/storage/postgres/notification_connection/connection.go
+++ b/storage/postgres/notification_connection/connection.go
@@ -30,6 +30,10 @@ type NotificationConnection interface {
 	// Close closes the connection
 	Close() error
 
+	// Ping the remote server to make sure it's alive.  Non-nil return value means
+	// that there is no active connection.
+	Ping() error
+
 	// NotificationChannel returns channel for receiving notifications
 	NotificationChannel() <-chan *pq.Notification
 }

--- a/storage/postgres/notification_connection/notification_connectionfakes/fake_notification_connection.go
+++ b/storage/postgres/notification_connection/notification_connectionfakes/fake_notification_connection.go
@@ -40,6 +40,16 @@ type FakeNotificationConnection struct {
 	notificationChannelReturnsOnCall map[int]struct {
 		result1 <-chan *pq.Notification
 	}
+	PingStub        func() error
+	pingMutex       sync.RWMutex
+	pingArgsForCall []struct {
+	}
+	pingReturns struct {
+		result1 error
+	}
+	pingReturnsOnCall map[int]struct {
+		result1 error
+	}
 	UnlistenStub        func(string) error
 	unlistenMutex       sync.RWMutex
 	unlistenArgsForCall []struct {
@@ -219,6 +229,58 @@ func (fake *FakeNotificationConnection) NotificationChannelReturnsOnCall(i int, 
 	}{result1}
 }
 
+func (fake *FakeNotificationConnection) Ping() error {
+	fake.pingMutex.Lock()
+	ret, specificReturn := fake.pingReturnsOnCall[len(fake.pingArgsForCall)]
+	fake.pingArgsForCall = append(fake.pingArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Ping", []interface{}{})
+	fake.pingMutex.Unlock()
+	if fake.PingStub != nil {
+		return fake.PingStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.pingReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeNotificationConnection) PingCallCount() int {
+	fake.pingMutex.RLock()
+	defer fake.pingMutex.RUnlock()
+	return len(fake.pingArgsForCall)
+}
+
+func (fake *FakeNotificationConnection) PingCalls(stub func() error) {
+	fake.pingMutex.Lock()
+	defer fake.pingMutex.Unlock()
+	fake.PingStub = stub
+}
+
+func (fake *FakeNotificationConnection) PingReturns(result1 error) {
+	fake.pingMutex.Lock()
+	defer fake.pingMutex.Unlock()
+	fake.PingStub = nil
+	fake.pingReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeNotificationConnection) PingReturnsOnCall(i int, result1 error) {
+	fake.pingMutex.Lock()
+	defer fake.pingMutex.Unlock()
+	fake.PingStub = nil
+	if fake.pingReturnsOnCall == nil {
+		fake.pingReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.pingReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeNotificationConnection) Unlisten(arg1 string) error {
 	fake.unlistenMutex.Lock()
 	ret, specificReturn := fake.unlistenReturnsOnCall[len(fake.unlistenArgsForCall)]
@@ -288,6 +350,8 @@ func (fake *FakeNotificationConnection) Invocations() map[string][][]interface{}
 	defer fake.listenMutex.RUnlock()
 	fake.notificationChannelMutex.RLock()
 	defer fake.notificationChannelMutex.RUnlock()
+	fake.pingMutex.RLock()
+	defer fake.pingMutex.RUnlock()
 	fake.unlistenMutex.RLock()
 	defer fake.unlistenMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/storage/postgres/notificator.go
+++ b/storage/postgres/notificator.go
@@ -42,7 +42,7 @@ const (
 )
 
 type Notificator struct {
-	isListening bool
+	isListening bool // To be used only under connectionMutex.Lock
 	isConnected int32
 
 	queueSize int
@@ -118,6 +118,8 @@ func (n *Notificator) Start(ctx context.Context, group *sync.WaitGroup) error {
 }
 
 func (n *Notificator) addConsumer(platform *types.Platform, queue storage.NotificationQueue) (int64, error) {
+	// must listen and add consumer under connectionMutex lock as UnregisterConsumer
+	// might stop notification processing if no other consumers are present
 	n.connectionMutex.Lock()
 	defer n.connectionMutex.Unlock()
 	if !n.isListening {

--- a/storage/postgres/notificator_test.go
+++ b/storage/postgres/notificator_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/gofrs/uuid"
 
@@ -99,7 +100,9 @@ var _ = Describe("Notificator", func() {
 			},
 			storage:           fakeStorage,
 			connectionCreator: fakeConnectionCreator,
+			stopProcessing:    func() {},
 			lastKnownRevision: types.InvalidRevision,
+			dbPingInterval:    time.Millisecond * 10,
 		}
 	}
 
@@ -129,6 +132,15 @@ var _ = Describe("Notificator", func() {
 		return string(notificationPayloadJSON)
 	}
 
+	expectUnlistenCalled := func(unlistenCalled chan struct{}) {
+		select {
+		case <-unlistenCalled:
+			break
+		case <-time.After(time.Second * 3):
+			Fail("Expected unlisten to be called")
+		}
+	}
+
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(context.Background())
 		wg = &sync.WaitGroup{}
@@ -142,6 +154,7 @@ var _ = Describe("Notificator", func() {
 		fakeNotificationConnection = &notificationConnectionFakes.FakeNotificationConnection{}
 		fakeNotificationConnection.ListenReturns(nil)
 		fakeNotificationConnection.UnlistenReturns(nil)
+		fakeNotificationConnection.PingReturns(nil)
 		fakeNotificationConnection.CloseReturns(nil)
 		notificationChannel = make(chan *pq.Notification, 2)
 		fakeNotificationConnection.NotificationChannelReturns(notificationChannel)
@@ -262,9 +275,41 @@ var _ = Describe("Notificator", func() {
 
 		Context("When id is found", func() {
 			It("Should unregister consumer", func() {
+				unlistenCalled := make(chan struct{}, 1)
+				fakeNotificationConnection.UnlistenStub = func(s string) error {
+					Expect(s).To(Equal(postgresChannel))
+					unlistenCalled <- struct{}{}
+					return nil
+				}
 				err := testNotificator.UnregisterConsumer(queue)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(fakeNotificationConnection.UnlistenCallCount()).To(Equal(1))
+				expectUnlistenCalled(unlistenCalled)
+			})
+		})
+
+		Context("When unregister is called twice on a given consumer", func() {
+			It("Should not return error on second unregister", func() {
+				err := testNotificator.UnregisterConsumer(queue)
+				Expect(err).ToNot(HaveOccurred())
+				err = testNotificator.UnregisterConsumer(queue)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("When consumer is unregistered and then registered again after unlisten", func() {
+			It("Should listen again", func(done Done) {
+				fakeNotificationConnection.UnlistenStub = func(s string) error {
+					Expect(s).To(Equal(postgresChannel))
+					fakeNotificationConnection.UnlistenReturns(nil)
+					go func() {
+						registerDefaultPlatform()
+						Expect(fakeNotificationConnection.ListenCallCount()).To(Equal(2))
+						close(done)
+					}()
+					return nil
+				}
+				err := testNotificator.UnregisterConsumer(queue)
+				Expect(err).ToNot(HaveOccurred())
 			})
 		})
 
@@ -277,14 +322,6 @@ var _ = Describe("Notificator", func() {
 			})
 		})
 
-		Context("When unlisten returns error", func() {
-			It("Should unregister consumer", func() {
-				fakeNotificationConnection.UnlistenReturns(expectedError)
-				err := testNotificator.UnregisterConsumer(queue)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(expectedError.Error()))
-			})
-		})
 	})
 
 	Describe("RegisterConsumer", func() {
@@ -311,6 +348,16 @@ var _ = Describe("Notificator", func() {
 			})
 		})
 
+		Context("When Notificator is running", func() {
+			It("Should ping db regularly", func(done Done) {
+				fakeNotificationConnection.PingStub = func() error {
+					defer close(done)
+					return nil
+				}
+				registerDefaultPlatform()
+			})
+		})
+
 		Context("When notification revision is grater than the the one SM knows", func() {
 			It("Should return error", func() {
 				expectRegisterConsumerFail(util.ErrInvalidNotificationRevision.Error(), defaultLastRevision+1)
@@ -320,18 +367,29 @@ var _ = Describe("Notificator", func() {
 		Context("When registering with 0 < revision < sm_revision", func() {
 			Context("When storage returns error when getting notification with revision", func() {
 				It("Should return the error", func() {
+					unlistenCalled := make(chan struct{}, 1)
+					fakeNotificationConnection.UnlistenStub = func(s string) error {
+						Expect(s).To(Equal(postgresChannel))
+						unlistenCalled <- struct{}{}
+						return nil
+					}
 					fakeStorage.GetNotificationByRevisionReturns(nil, expectedError)
 					expectRegisterConsumerFail(expectedError.Error(), defaultLastRevision-1)
-					Expect(fakeNotificationConnection.UnlistenCallCount()).To(Equal(1))
+					expectUnlistenCalled(unlistenCalled)
 				})
 			})
 
 			Context("When storage returns error and unlisten returns error when getting notification with revision", func() {
 				It("Should return the storage error", func() {
+					unlistenCalled := make(chan struct{}, 1)
+					fakeNotificationConnection.UnlistenStub = func(s string) error {
+						Expect(s).To(Equal(postgresChannel))
+						unlistenCalled <- struct{}{}
+						return errors.New("unlisten error")
+					}
 					fakeStorage.GetNotificationByRevisionReturns(nil, expectedError)
-					fakeNotificationConnection.UnlistenReturns(errors.New("unlisten error"))
 					expectRegisterConsumerFail(expectedError.Error(), defaultLastRevision-1)
-					Expect(fakeNotificationConnection.UnlistenCallCount()).To(Equal(1))
+					expectUnlistenCalled(unlistenCalled)
 				})
 			})
 

--- a/storage/postgres/notificator_test.go
+++ b/storage/postgres/notificator_test.go
@@ -337,7 +337,7 @@ var _ = Describe("Notificator", func() {
 			})
 
 			It("Should return error", func() {
-				expectRegisterConsumerFail("listen to notifications channel failed "+expectedError.Error(), types.InvalidRevision)
+				expectRegisterConsumerFail("getting last revision failed "+expectedError.Error(), types.InvalidRevision)
 			})
 		})
 
@@ -448,6 +448,13 @@ var _ = Describe("Notificator", func() {
 			It("Should return error", func() {
 				fakeNotificationConnection.ListenReturns(expectedError)
 				expectRegisterConsumerFail(expectedError.Error(), types.InvalidRevision)
+			})
+
+			Context("And this error is pq.ErrChannelAlreadyOpen", func() {
+				It("Should register consumer", func() {
+					fakeNotificationConnection.ListenReturns(pq.ErrChannelAlreadyOpen)
+					expectRegisterConsumerSuccess(defaultPlatform, types.InvalidRevision)
+				})
 			})
 		})
 


### PR DESCRIPTION
# Fix postgres Listen not called in some cases

## Scenario

If only one proxy is connected to SM it should receive notifications.
When this proxy disconnects, SM calls Unlisted to postgres so that it does not receive unnecessary notifications. When a proxy reconnects again SM does not call listen again.

## Fix

Always call unlisten/listen when proxy disconnects/connects. 
Also improve logging for these scenarios.


