### PR TITLE
Add timeout for osb calls

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -4,6 +4,11 @@ server:
   port: 8085
   # max_body_bytes: 4000
   # max_header_bytes: 1000
+httpclient:
+  response_header_timeout: 10000ms
+  tls_handshake_timeout: 10000ms
+  idle_conn_timeout: 10000ms
+  dial_timeout: 10000ms
 websocket:
   ping_timeout: 6000ms
   write_timeout: 6000ms

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,8 @@ package config
 import (
 	"fmt"
 
+	"github.com/Peripli/service-manager/pkg/httpclient"
+
 	"github.com/Peripli/service-manager/api"
 	"github.com/Peripli/service-manager/pkg/env"
 	"github.com/Peripli/service-manager/pkg/log"
@@ -30,11 +32,12 @@ import (
 
 // Settings is used to setup the Service Manager
 type Settings struct {
-	Server    *server.Settings
-	Storage   *storage.Settings
-	Log       *log.Settings
-	API       *api.Settings
-	WebSocket *ws.Settings
+	Server     *server.Settings
+	Storage    *storage.Settings
+	Log        *log.Settings
+	API        *api.Settings
+	WebSocket  *ws.Settings
+	HTTPClient *httpclient.Settings
 }
 
 // AddPFlags adds the SM config flags to the provided flag set
@@ -46,11 +49,12 @@ func AddPFlags(set *pflag.FlagSet) {
 // DefaultSettings returns the default values for configuring the Service Manager
 func DefaultSettings() *Settings {
 	return &Settings{
-		Server:    server.DefaultSettings(),
-		Storage:   storage.DefaultSettings(),
-		Log:       log.DefaultSettings(),
-		API:       api.DefaultSettings(),
-		WebSocket: ws.DefaultSettings(),
+		Server:     server.DefaultSettings(),
+		Storage:    storage.DefaultSettings(),
+		Log:        log.DefaultSettings(),
+		API:        api.DefaultSettings(),
+		WebSocket:  ws.DefaultSettings(),
+		HTTPClient: httpclient.DefaultSettings(),
 	}
 }
 

--- a/pkg/httpclient/settings.go
+++ b/pkg/httpclient/settings.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package httpclient
+
+import (
+	"fmt"
+	"time"
+)
+
+type Settings struct {
+	TLSHandshakeTimeout   time.Duration `mapstructure:"tls_handshake_timeout"`
+	IdleConnTimeout       time.Duration `mapstructure:"idle_conn_timeout"`
+	ResponseHeaderTimeout time.Duration `mapstructure:"response_header_timeout"`
+	DialTimeout           time.Duration `mapstructure:"dial_timeout"`
+}
+
+// DefaultSettings return the default values for httpclient settings
+func DefaultSettings() *Settings {
+	return &Settings{
+		TLSHandshakeTimeout:   time.Second * 10,
+		IdleConnTimeout:       time.Second * 10,
+		ResponseHeaderTimeout: time.Second * 10,
+		DialTimeout:           time.Second * 10,
+	}
+}
+
+// Validate validates the httpclient settings
+func (s *Settings) Validate() error {
+	if s.TLSHandshakeTimeout < 0 {
+		return fmt.Errorf("validate httpclient settings: tls_handshake_timeout should be >= 0")
+	}
+	if s.IdleConnTimeout < 0 {
+		return fmt.Errorf("validate httpclient settings: idle_conn_timeout should be >= 0")
+	}
+	if s.ResponseHeaderTimeout < 0 {
+		return fmt.Errorf("validate httpclient settings: response_header_timeout should be >= 0")
+	}
+	if s.DialTimeout < 0 {
+		return fmt.Errorf("validate httpclient settings: dial_timeout should be >= 0")
+	}
+	return nil
+}

--- a/pkg/httpclient/settings_test.go
+++ b/pkg/httpclient/settings_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package httpclient
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HTTPClient settings suite")
+}
+
+var _ = Describe("HTTPClient settings", func() {
+	var settings *Settings
+
+	BeforeEach(func() {
+		settings = DefaultSettings()
+	})
+
+	assertValidateError := func(errMessage string) {
+		err := settings.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(errMessage))
+	}
+
+	Describe("Validate", func() {
+		Context("on valid settings", func() {
+			It("should return nil", func() {
+				Expect(settings.Validate()).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("on invalid tls_handshake_timeout", func() {
+			It("should return error", func() {
+				settings.TLSHandshakeTimeout = -1
+				assertValidateError("validate httpclient settings: tls_handshake_timeout should be >= 0")
+			})
+		})
+
+		Context("on invalid dial_timeout", func() {
+			It("should return error", func() {
+				settings.DialTimeout = -1
+				assertValidateError("validate httpclient settings: dial_timeout should be >= 0")
+			})
+		})
+
+		Context("on invalid response_header_timeout", func() {
+			It("should return error", func() {
+				settings.ResponseHeaderTimeout = -1
+				assertValidateError("validate httpclient settings: response_header_timeout should be >= 0")
+			})
+		})
+
+		Context("on invalid idle_conn_timeout", func() {
+			It("should return error", func() {
+				settings.IdleConnTimeout = -1
+				assertValidateError("validate httpclient settings: idle_conn_timeout should be >= 0")
+			})
+		})
+	})
+})

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -2,6 +2,11 @@ server:
   request_timeout: 4000ms
   shutdown_timeout: 4000ms
   port: 1234
+httpclient:
+  response_header_timeout: 10000ms
+  tls_handshake_timeout: 10000ms
+  idle_conn_timeout: 10000ms
+  dial_timeout: 10000ms
 websocket:
   ping_timeout: 6000ms
   write_timeout: 6000ms

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -67,8 +67,9 @@ type TestContextBuilder struct {
 
 	shouldSkipBasicAuthClient bool
 
-	Environment func(f ...func(set *pflag.FlagSet)) env.Environment
-	Servers     map[string]FakeServer
+	Environment    func(f ...func(set *pflag.FlagSet)) env.Environment
+	Servers        map[string]FakeServer
+	TestHttpClient *http.Client
 }
 
 type TestContext struct {
@@ -137,6 +138,19 @@ func NewTestContextBuilder() *TestContextBuilder {
 		tenantTokenClaims:  make(map[string]interface{}, 0),
 		Servers: map[string]FakeServer{
 			"oauth-server": NewOAuthServer(),
+		},
+		TestHttpClient: &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   20 * time.Second,
+					KeepAlive: 20 * time.Second,
+				}).DialContext,
+				MaxIdleConns:          100,
+				IdleConnTimeout:       30 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
 		},
 	}
 }
@@ -255,12 +269,12 @@ func (tcb *TestContextBuilder) BuildWithListener(listener net.Listener) *TestCon
 	oauthServer := tcb.Servers[OauthServer].(*OAuthServer)
 	accessToken := oauthServer.CreateToken(tcb.defaultTokenClaims)
 	SMWithOAuth := SM.Builder(func(req *httpexpect.Request) {
-		req.WithHeader("Authorization", "Bearer "+accessToken)
+		req.WithHeader("Authorization", "Bearer "+accessToken).WithClient(tcb.TestHttpClient)
 	})
 
 	tenantAccessToken := oauthServer.CreateToken(tcb.tenantTokenClaims)
 	SMWithOAuthForTenant := SM.Builder(func(req *httpexpect.Request) {
-		req.WithHeader("Authorization", "Bearer "+tenantAccessToken)
+		req.WithHeader("Authorization", "Bearer "+tenantAccessToken).WithClient(tcb.TestHttpClient)
 	})
 
 	RemoveAllBrokers(SMWithOAuth)
@@ -280,7 +294,7 @@ func (tcb *TestContextBuilder) BuildWithListener(listener net.Listener) *TestCon
 		platform := RegisterPlatformInSM(platformJSON, SMWithOAuth, map[string]string{})
 		SMWithBasic := SM.Builder(func(req *httpexpect.Request) {
 			username, password := platform.Credentials.Basic.Username, platform.Credentials.Basic.Password
-			req.WithBasicAuth(username, password)
+			req.WithBasicAuth(username, password).WithClient(tcb.TestHttpClient)
 		})
 		testContext.SMWithBasic = SMWithBasic
 		testContext.TestPlatform = platform

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -67,9 +67,9 @@ type TestContextBuilder struct {
 
 	shouldSkipBasicAuthClient bool
 
-	Environment    func(f ...func(set *pflag.FlagSet)) env.Environment
-	Servers        map[string]FakeServer
-	TestHttpClient *http.Client
+	Environment func(f ...func(set *pflag.FlagSet)) env.Environment
+	Servers     map[string]FakeServer
+	HttpClient  *http.Client
 }
 
 type TestContext struct {
@@ -139,7 +139,7 @@ func NewTestContextBuilder() *TestContextBuilder {
 		Servers: map[string]FakeServer{
 			"oauth-server": NewOAuthServer(),
 		},
-		TestHttpClient: &http.Client{
+		HttpClient: &http.Client{
 			Transport: &http.Transport{
 				Proxy: http.ProxyFromEnvironment,
 				DialContext: (&net.Dialer{
@@ -269,12 +269,12 @@ func (tcb *TestContextBuilder) BuildWithListener(listener net.Listener) *TestCon
 	oauthServer := tcb.Servers[OauthServer].(*OAuthServer)
 	accessToken := oauthServer.CreateToken(tcb.defaultTokenClaims)
 	SMWithOAuth := SM.Builder(func(req *httpexpect.Request) {
-		req.WithHeader("Authorization", "Bearer "+accessToken).WithClient(tcb.TestHttpClient)
+		req.WithHeader("Authorization", "Bearer "+accessToken).WithClient(tcb.HttpClient)
 	})
 
 	tenantAccessToken := oauthServer.CreateToken(tcb.tenantTokenClaims)
 	SMWithOAuthForTenant := SM.Builder(func(req *httpexpect.Request) {
-		req.WithHeader("Authorization", "Bearer "+tenantAccessToken).WithClient(tcb.TestHttpClient)
+		req.WithHeader("Authorization", "Bearer "+tenantAccessToken).WithClient(tcb.HttpClient)
 	})
 
 	RemoveAllBrokers(SMWithOAuth)
@@ -294,7 +294,7 @@ func (tcb *TestContextBuilder) BuildWithListener(listener net.Listener) *TestCon
 		platform := RegisterPlatformInSM(platformJSON, SMWithOAuth, map[string]string{})
 		SMWithBasic := SM.Builder(func(req *httpexpect.Request) {
 			username, password := platform.Credentials.Basic.Username, platform.Credentials.Basic.Password
-			req.WithBasicAuth(username, password).WithClient(tcb.TestHttpClient)
+			req.WithBasicAuth(username, password).WithClient(tcb.HttpClient)
 		})
 		testContext.SMWithBasic = SMWithBasic
 		testContext.TestPlatform = platform

--- a/test/osb_test/osb_test.go
+++ b/test/osb_test/osb_test.go
@@ -16,9 +16,13 @@
 package osb_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
 
 	"github.com/gofrs/uuid"
 
@@ -69,7 +73,7 @@ func assertMissingBrokerError(req *httpexpect.Response) {
 		Value("description").String().Contains("could not find such broker")
 }
 
-func assertStoppedBrokerError(req *httpexpect.Response) {
+func assertBadBrokerError(req *httpexpect.Response) {
 	req.Status(http.StatusBadGateway).JSON().Object().
 		Value("description").String().Contains("could not reach service broker")
 }
@@ -126,6 +130,8 @@ func queryParameterVerificationHandler(key, value string) http.HandlerFunc {
 }
 
 var _ = Describe("Service Manager OSB API", func() {
+	const timeoutDuration = time.Millisecond * 500
+
 	var (
 		ctx *common.TestContext
 
@@ -148,13 +154,68 @@ var _ = Describe("Service Manager OSB API", func() {
 		failingBrokerID      string
 		smUrlToFailingBroker string
 
-		smUrlToQueryVerificationBroker string
-		headerKey                      string
-		headerValue                    string
+		queryParameterVerificationServer   *common.BrokerServer
+		queryParameterVerificationServerID string
+		smUrlToQueryVerificationBroker     string
+		headerKey                          string
+		headerValue                        string
+
+		timeoutBrokerServer     *common.BrokerServer
+		timeoutBrokerID         string
+		smUrlToTimeoutBroker    string
+		timeoutBrokerReleaseCtx context.Context
+		timeoutBrokerRelease    context.CancelFunc
 	)
 
+	resetBrokersHandlers := func() {
+		validBrokerServer.ResetHandlers()
+		brokerServerWithEmptyCatalog.ResetHandlers()
+		stoppedBrokerServer.ResetHandlers()
+		failingBrokerServer.ResetHandlers()
+		queryParameterVerificationServer.ResetHandlers()
+		timeoutBrokerServer.ResetHandlers()
+
+		failingBrokerServer.ServiceInstanceHandler = failingHandler
+		failingBrokerServer.BindingHandler = failingHandler
+		failingBrokerServer.CatalogHandler = failingHandler
+		failingBrokerServer.ServiceInstanceLastOpHandler = failingHandler
+		failingBrokerServer.BindingLastOpHandler = failingHandler
+		failingBrokerServer.BindingAdaptCredentialsHandler = failingHandler
+
+		queryParameterVerificationServer.ServiceInstanceHandler = queryParameterVerificationHandler(headerKey, headerValue)
+		queryParameterVerificationServer.BindingHandler = queryParameterVerificationHandler(headerKey, headerValue)
+		queryParameterVerificationServer.CatalogHandler = queryParameterVerificationHandler(headerKey, headerValue)
+		queryParameterVerificationServer.ServiceInstanceLastOpHandler = queryParameterVerificationHandler(headerKey, headerValue)
+		queryParameterVerificationServer.BindingLastOpHandler = queryParameterVerificationHandler(headerKey, headerValue)
+
+		timeoutBrokerReleaseCtx, timeoutBrokerRelease = context.WithCancel(context.Background())
+		stoppingHandler := func(rw http.ResponseWriter, req *http.Request) {
+			brokerDelay := timeoutDuration + time.Second // Add some additional time after timeout has been exceeded
+			timeoutContext, _ := context.WithTimeout(timeoutBrokerReleaseCtx, brokerDelay)
+			<-timeoutContext.Done()
+			common.SetResponse(rw, http.StatusTeapot, common.Object{})
+		}
+		timeoutBrokerServer.ServiceInstanceHandler = stoppingHandler
+		timeoutBrokerServer.BindingHandler = stoppingHandler
+		timeoutBrokerServer.CatalogHandler = stoppingHandler
+		timeoutBrokerServer.ServiceInstanceLastOpHandler = stoppingHandler
+		timeoutBrokerServer.BindingLastOpHandler = stoppingHandler
+		timeoutBrokerServer.BindingAdaptCredentialsHandler = stoppingHandler
+	}
+
+	resetBrokersCallHistory := func() {
+		validBrokerServer.ResetCallHistory()
+		brokerServerWithEmptyCatalog.ResetCallHistory()
+		stoppedBrokerServer.ResetCallHistory()
+		failingBrokerServer.ResetCallHistory()
+		queryParameterVerificationServer.ResetCallHistory()
+		timeoutBrokerServer.ResetCallHistory()
+	}
+
 	BeforeSuite(func() {
-		ctx = common.DefaultTestContext()
+		ctx = common.NewTestContextBuilder().WithEnvPreExtensions(func(set *pflag.FlagSet) {
+			Expect(set.Set("httpclient.response_header_timeout", timeoutDuration.String())).ToNot(HaveOccurred())
+		}).Build()
 		validBrokerID, _, validBrokerServer = ctx.RegisterBroker()
 		smUrlToWorkingBroker = validBrokerServer.URL() + "/v1/osb/" + validBrokerID
 
@@ -166,12 +227,6 @@ var _ = Describe("Service Manager OSB API", func() {
 
 		failingBrokerID, _, failingBrokerServer = ctx.RegisterBroker()
 		smUrlToFailingBroker = failingBrokerServer.URL() + "/v1/osb/" + failingBrokerID
-		failingBrokerServer.ServiceInstanceHandler = failingHandler
-		failingBrokerServer.BindingHandler = failingHandler
-		failingBrokerServer.CatalogHandler = failingHandler
-		failingBrokerServer.ServiceInstanceLastOpHandler = failingHandler
-		failingBrokerServer.BindingLastOpHandler = failingHandler
-		failingBrokerServer.BindingAdaptCredentialsHandler = failingHandler
 
 		UUID, err := uuid.NewV4()
 		if err != nil {
@@ -185,21 +240,24 @@ var _ = Describe("Service Manager OSB API", func() {
 		smUrlToStoppedBroker = stoppedBrokerServer.URL() + "/v1/osb/" + stoppedBrokerID
 
 		headerKey, headerValue = generateRandomQueryParam()
-		queryParameterVerificationServerID, _, queryParameterVerificationServer := ctx.RegisterBroker()
-		queryParameterVerificationServer.ServiceInstanceHandler = queryParameterVerificationHandler(headerKey, headerValue)
-		queryParameterVerificationServer.BindingHandler = queryParameterVerificationHandler(headerKey, headerValue)
-		queryParameterVerificationServer.CatalogHandler = queryParameterVerificationHandler(headerKey, headerValue)
-		queryParameterVerificationServer.ServiceInstanceLastOpHandler = queryParameterVerificationHandler(headerKey, headerValue)
-		queryParameterVerificationServer.BindingLastOpHandler = queryParameterVerificationHandler(headerKey, headerValue)
+		queryParameterVerificationServerID, _, queryParameterVerificationServer = ctx.RegisterBroker()
 		smUrlToQueryVerificationBroker = queryParameterVerificationServer.URL() + "/v1/osb/" + queryParameterVerificationServerID
+
+		timeoutBrokerID, _, timeoutBrokerServer = ctx.RegisterBroker()
+		smUrlToTimeoutBroker = timeoutBrokerServer.URL() + "/v1/osb/" + timeoutBrokerID
+	})
+
+	BeforeEach(func() {
+		resetBrokersHandlers()
+		resetBrokersCallHistory()
+	})
+
+	AfterEach(func() {
+		timeoutBrokerRelease()
 	})
 
 	AfterSuite(func() {
 		ctx.Cleanup()
-	})
-
-	AfterEach(func() {
-		validBrokerServer.ResetCallHistory()
 	})
 
 	Describe("Catalog", func() {
@@ -282,6 +340,7 @@ var _ = Describe("Service Manager OSB API", func() {
 	})
 
 	Describe("Provision", func() {
+
 		Context("call to working service broker", func() {
 			It("should succeed", func() {
 				assertWorkingBrokerResponse(
@@ -308,7 +367,7 @@ var _ = Describe("Service Manager OSB API", func() {
 
 		Context("when call to stopped service broker", func() {
 			It("should fail", func() {
-				assertStoppedBrokerError(
+				assertBadBrokerError(
 					ctx.SMWithBasic.PUT(smUrlToStoppedBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
 						WithJSON(getDummyService()).Expect())
 			})
@@ -321,8 +380,17 @@ var _ = Describe("Service Manager OSB API", func() {
 						WithJSON(getDummyService()).WithQuery(headerKey, headerValue).Expect(), http.StatusCreated)
 			})
 		})
+
+		Context("when broker doesn't respond in a timely manner", func() {
+			It("should fail with 502", func() {
+				assertBadBrokerError(ctx.SMWithBasic.PUT(smUrlToTimeoutBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+					WithJSON(getDummyService()).Expect())
+			})
+		})
+
 	})
 	Describe("Deprovision", func() {
+
 		Context("when trying to deprovision existing service", func() {
 			It("should be successfull", func() {
 				ctx.SMWithBasic.DELETE(smUrlToWorkingBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
@@ -349,7 +417,7 @@ var _ = Describe("Service Manager OSB API", func() {
 
 		Context("when call to stopped service broker", func() {
 			It("should fail", func() {
-				assertStoppedBrokerError(ctx.SMWithBasic.DELETE(smUrlToStoppedBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+				assertBadBrokerError(ctx.SMWithBasic.DELETE(smUrlToStoppedBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
 					WithQueryObject(getDummyService()).Expect())
 			})
 		})
@@ -361,9 +429,17 @@ var _ = Describe("Service Manager OSB API", func() {
 						WithJSON(getDummyService()).WithQuery(headerKey, headerValue).Expect(), http.StatusOK)
 			})
 		})
+
+		Context("when broker doesn't respond in a timely manner", func() {
+			It("should fail with 502", func() {
+				assertBadBrokerError(ctx.SMWithBasic.DELETE(smUrlToTimeoutBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+					WithJSON(getDummyService()).Expect())
+			})
+		})
 	})
 
 	Describe("Bind", func() {
+
 		Context("call to working service broker", func() {
 			It("should succeed", func() {
 				assertWorkingBrokerResponse(
@@ -389,7 +465,7 @@ var _ = Describe("Service Manager OSB API", func() {
 
 		Context("when call to stopped service broker", func() {
 			It("should fail", func() {
-				assertStoppedBrokerError(ctx.SMWithBasic.PUT(smUrlToStoppedBroker+"/v2/service_instances/iid/service_bindings/bid").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+				assertBadBrokerError(ctx.SMWithBasic.PUT(smUrlToStoppedBroker+"/v2/service_instances/iid/service_bindings/bid").WithHeader("X-Broker-API-Version", "oidc_authn.13").
 					WithJSON(getDummyService()).Expect())
 			})
 		})
@@ -401,9 +477,17 @@ var _ = Describe("Service Manager OSB API", func() {
 						WithJSON(getDummyService()).WithQuery(headerKey, headerValue).Expect(), http.StatusCreated)
 			})
 		})
+
+		Context("when broker doesn't respond in a timely manner", func() {
+			It("should fail with 502", func() {
+				assertBadBrokerError(ctx.SMWithBasic.PUT(smUrlToTimeoutBroker+"/v2/service_instances/iid/service_bindings/bid").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+					WithJSON(getDummyService()).Expect())
+			})
+		})
 	})
 
 	Describe("Unbind", func() {
+
 		Context("when trying to delete binding", func() {
 			It("should be successful", func() {
 				ctx.SMWithBasic.DELETE(smUrlToWorkingBroker+"/v2/service_instances/iid/service_bindings/bid").WithHeader("X-Broker-API-Version", "oidc_authn.13").
@@ -431,7 +515,7 @@ var _ = Describe("Service Manager OSB API", func() {
 
 		Context("when call to stopped service broker", func() {
 			It("should fail", func() {
-				assertStoppedBrokerError(
+				assertBadBrokerError(
 					ctx.SMWithBasic.DELETE(smUrlToStoppedBroker+"/v2/service_instances/iid/service_bindings/bid").WithHeader("X-Broker-API-Version", "oidc_authn.13").
 						WithQueryObject(getDummyService()).Expect())
 
@@ -445,9 +529,18 @@ var _ = Describe("Service Manager OSB API", func() {
 						WithJSON(getDummyService()).WithQuery(headerKey, headerValue).Expect(), http.StatusOK)
 			})
 		})
+
+		Context("when broker doesn't respond in a timely manner", func() {
+			It("should fail with 502", func() {
+				assertBadBrokerError(ctx.SMWithBasic.DELETE(smUrlToTimeoutBroker+"/v2/service_instances/iid/service_bindings/bid").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+					WithQueryObject(getDummyService()).
+					Expect())
+			})
+		})
 	})
 
 	Describe("Get Service Instance Last Operation", func() {
+
 		Context("when call to working service broker", func() {
 			It("should succeed", func() {
 				assertWorkingBrokerResponse(
@@ -473,7 +566,7 @@ var _ = Describe("Service Manager OSB API", func() {
 
 		Context("when call to stopped service broker", func() {
 			It("should fail", func() {
-				assertStoppedBrokerError(
+				assertBadBrokerError(
 					ctx.SMWithBasic.GET(smUrlToStoppedBroker+"/v2/service_instances/iid/last_operation").WithHeader("X-Broker-API-Version", "oidc_authn.13").Expect())
 			})
 		})
@@ -485,9 +578,17 @@ var _ = Describe("Service Manager OSB API", func() {
 						WithJSON(getDummyService()).WithQuery(headerKey, headerValue).Expect(), http.StatusOK)
 			})
 		})
+
+		Context("when broker doesn't respond in a timely manner", func() {
+			It("should fail with 502", func() {
+				assertBadBrokerError(ctx.SMWithBasic.GET(smUrlToTimeoutBroker+"/v2/service_instances/iid/last_operation").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+					Expect())
+			})
+		})
 	})
 
 	Describe("Get Binding Last Operation", func() {
+
 		Context("when call to working service broker", func() {
 			It("should succeed", func() {
 				assertWorkingBrokerResponse(
@@ -513,7 +614,7 @@ var _ = Describe("Service Manager OSB API", func() {
 
 		Context("when call to stopped service broker", func() {
 			It("should fail", func() {
-				assertStoppedBrokerError(
+				assertBadBrokerError(
 					ctx.SMWithBasic.GET(smUrlToStoppedBroker+"/v2/service_instances/iid/service_bindings/bid/last_operation").WithHeader("X-Broker-API-Version", "oidc_authn.13").Expect())
 			})
 		})
@@ -523,6 +624,13 @@ var _ = Describe("Service Manager OSB API", func() {
 				assertWorkingBrokerResponse(
 					ctx.SMWithBasic.GET(smUrlToQueryVerificationBroker+"/v2/service_instances/iid/service_bindings/bid/last_operation").WithHeader("X-Broker-API-Version", "oidc_authn.13").
 						WithJSON(getDummyService()).WithQuery(headerKey, headerValue).Expect(), http.StatusOK)
+			})
+		})
+
+		Context("when broker doesn't respond in a timely manner", func() {
+			It("should fail with 502", func() {
+				assertBadBrokerError(ctx.SMWithBasic.GET(smUrlToTimeoutBroker+"/v2/service_instances/iid/service_bindings/bid/last_operation").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+					Expect())
 			})
 		})
 	})
@@ -554,7 +662,7 @@ var _ = Describe("Service Manager OSB API", func() {
 
 		Context("when call to stopped service broker", func() {
 			It("should fail", func() {
-				assertStoppedBrokerError(
+				assertBadBrokerError(
 					ctx.SMWithBasic.POST(smUrlToStoppedBroker+"/v2/service_instances/iid/service_bindings/bid/adapt_credentials").WithHeader("X-Broker-API-Version", "oidc_authn.13").WithJSON(&common.Object{}).Expect())
 
 			})
@@ -565,6 +673,13 @@ var _ = Describe("Service Manager OSB API", func() {
 				assertWorkingBrokerResponse(
 					ctx.SMWithBasic.POST(smUrlToQueryVerificationBroker+"/v2/service_instances/iid/service_bindings/bid/adapt_credentials").WithHeader("X-Broker-API-Version", "oidc_authn.13").
 						WithJSON(getDummyService()).WithQuery(headerKey, headerValue).Expect(), http.StatusOK)
+			})
+		})
+
+		Context("when broker doesn't respond in a timely manner", func() {
+			It("should fail with 502", func() {
+				assertBadBrokerError(ctx.SMWithBasic.POST(smUrlToTimeoutBroker+"/v2/service_instances/iid/service_bindings/bid/adapt_credentials").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+					WithJSON(getDummyService()).Expect())
 			})
 		})
 	})


### PR DESCRIPTION
# Add timeout for osb calls

## Motivation

Currently osb calls do not have timeout. This could lead to out of memory if multiple calls hang to a broken broker.

## Approach

Introduce timeout configurations for all outbound communication.

## Pull Request status

* [x] Initial implementation
* [x] Tests
