### PR TITLE
Dynamic log switching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY --from=builder /main /app/
 
 # Copy migration scripts
 COPY --from=builder /go/src/github.com/Peripli/service-manager/storage/postgres/migrations/ /app/
+COPY --from=builder /go/src/github.com/Peripli/service-manager/application.yml /app/
 
 # If one wants to use migrations scripts from somewhere else, overriding this env var would override the scripts from the image
 ENV STORAGE_MIGRATIONS_URL=file:///app

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -282,12 +282,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:96df5bdca983e4b8c62682af5b67100b187d582ac6db0968d8af52e84138d1e6"
   name = "github.com/onrik/logrus"
   packages = ["filename"]
   pruneopts = "UT"
   revision = "94ad747c51752e8dfa69cfd0335b8c76bf1ae592"
+  version = "v0.4.1"
 
 [[projects]]
   digest = "1:b013cb97ec8147b033199dfc5360d410130e1fc5d74dd6f08c4d777fe49b5c37"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -125,12 +125,12 @@
   version = "v3.5.1"
 
 [[projects]]
-  digest = "1:318f1c959a8a740366fce4b1e1eb2fd914036b4af58fbd0a003349b305f118ad"
+  digest = "1:573ca21d3669500ff845bdebee890eb7fc7f0f50c59f2132f2a0c6b03d85086a"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   pruneopts = "UT"
-  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
-  version = "v1.3.1"
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
 
 [[projects]]
   digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
@@ -218,7 +218,7 @@
   revision = "38398a30ed8516ffda617a04c822de09df8a3ec5"
 
 [[projects]]
-  digest = "1:589fb1a525a9596f15cf90064ad57cfad5de59b3579e91f272f470ab49051647"
+  digest = "1:836838f1466d370fc7678c927e5b7473f38ba12c2e571f8eca957bd0a102c2db"
   name = "github.com/klauspost/compress"
   packages = [
     "flate",
@@ -226,8 +226,8 @@
     "zlib",
   ]
   pruneopts = "UT"
-  revision = "05d6922103c7275c684bd5df6608b25577b10521"
-  version = "v1.7.0"
+  revision = "53fd0299b54f91f5d91c50ee5f4d5e0393e45eb8"
+  version = "v1.7.5"
 
 [[projects]]
   digest = "1:923c4d7194b42e054b2eb8a6c62824ac55e23ececc1c7e48d4da69c971c55954"
@@ -247,7 +247,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2abaafc9cb59897a71c84f1daf4131d59c0dd349c671206274ace759730fc1a0"
+  digest = "1:ee780c2838219eedc4146248ddf9b82bb6a4a344425ee1aeb9f0d6eb8435614d"
   name = "github.com/lib/pq"
   packages = [
     ".",
@@ -255,7 +255,7 @@
     "scram",
   ]
   pruneopts = "UT"
-  revision = "2ff3cb3adc01768e0a552b3a02575a6df38a9bea"
+  revision = "78223426e7c66d631117c0a9da1b7f3fde4d23a5"
 
 [[projects]]
   digest = "1:5a0ef768465592efca0412f7e838cdc0826712f8447e70e6ccc52eb441e9ab13"
@@ -287,7 +287,7 @@
   name = "github.com/onrik/logrus"
   packages = ["filename"]
   pruneopts = "UT"
-  revision = "0331655e8b9ec13423e2b31914d0a2154b13474e"
+  revision = "94ad747c51752e8dfa69cfd0335b8c76bf1ae592"
 
 [[projects]]
   digest = "1:b013cb97ec8147b033199dfc5360d410130e1fc5d74dd6f08c4d777fe49b5c37"
@@ -418,12 +418,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:59e7dceb53b4a1e57eb1eb0bf9951ff0c25912df7660004a789b62b4e8cdca3b"
+  digest = "1:11118bd196646c6515fea3d6c43f66162833c6ae4939bfb229b9956d91c6cf17"
   name = "github.com/spf13/viper"
   packages = ["."]
   pruneopts = "UT"
-  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
-  version = "v1.0.2"
+  revision = "b5bf975e5823809fb22c7644d008757f78a4259e"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:5da8ce674952566deae4dbc23d07c85caafc6cfa815b0b3e03e41979cedb8750"
@@ -437,12 +437,12 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:7df351557a6d5c30804e7d6f7ed87f2fccb0619c08fcc84869a93f22bec96c11"
+  digest = "1:46aea6ffe39c3d95c13640c2515236ed3c5cdffc3c78c6c0ed4edec2caf7a0dc"
   name = "github.com/tidwall/gjson"
   packages = ["."]
   pruneopts = "UT"
-  revision = "eee0b6226f0d1db2675a176fdfaa8419bcad4ca8"
-  version = "v1.2.1"
+  revision = "c5e72cdf74dff23857243dd662c465b810891c21"
+  version = "v1.3.2"
 
 [[projects]]
   digest = "1:8453ddbed197809ee8ca28b06bd04e127bec9912deb4ba451fea7a1eca578328"
@@ -489,11 +489,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f4e5276a3b356f4692107047fd2890f2fe534f4feeb6b1fd2f6dfbd87f1ccf54"
+  digest = "1:d9464a87e24a9703fd6b9b27b3592559eb7f5886285d724cb0acd62d00a5ddbf"
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
   pruneopts = "UT"
-  revision = "4e3ac2762d5f479393488629ee9370b50873b3a6"
+  revision = "df4f5c81cb3b310899c091852a576ea7d178aedb"
 
 [[projects]]
   branch = "master"
@@ -540,7 +540,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:b8fa1ff0fc20983395978b3f771bb10438accbfe19326b02e236c1d4bf1c91b2"
+  digest = "1:5cdf4eb6946922ebe638b90e548e1a86085b778d9daf0889951b39f44e6bbe6c"
   name = "golang.org/x/crypto"
   packages = [
     "ed25519",
@@ -548,11 +548,11 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "f99c8df09eb5bff426315721bfa5f16a99cad32c"
+  revision = "4def268fd1a49955bfb3dda92fe3db4f924f2285"
 
 [[projects]]
   branch = "master"
-  digest = "1:a3618b1fc378635b02a2e0eef5694311e1e29137c562210ad46999d8f3e0cc2c"
+  digest = "1:f6e2a855d736113a66b672f84d411ec89f4d2a870faa37cf50d20f1a62278624"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -564,7 +564,7 @@
     "publicsuffix",
   ]
   pruneopts = "UT"
-  revision = "461777fb6f67e8cb9d70cda16573678d085a74cf"
+  revision = "74dc4d7220e7acc4e100824340f3e66577424772"
 
 [[projects]]
   branch = "master"
@@ -579,11 +579,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8f5108406bc43c7669b0d67d282e40d05c9f268615fcaf8c1f0f76965aa3f09f"
+  digest = "1:47844666be86089349a441f5f0ece22f42a87a8cb8c9a31294c593f43209ad19"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "1e42afee0f762ed3d76e6dd942e4181855fd1849"
+  revision = "fde4db37ae7ad8191b03d30d27f258b5291ae4e3"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"
@@ -684,6 +684,7 @@
     "github.com/cloudfoundry-community/go-cfenv",
     "github.com/coreos/go-oidc",
     "github.com/fatih/structs",
+    "github.com/fsnotify/fsnotify",
     "github.com/gavv/httpexpect",
     "github.com/gbrlsnchs/jwt",
     "github.com/gobwas/glob",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,7 +39,7 @@
 
 [[constraint]]
   name = "github.com/spf13/viper"
-  version = "=1.0.2"
+  version = "=1.4.0"
 
 [[constraint]]
   name = "github.com/lib/pq"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,7 +19,7 @@
 
 [[constraint]]
  name = "github.com/onrik/logrus"
- branch = "master"
+ version = "=0.4.1"
 
 [[constraint]]
   name = "github.com/onsi/ginkgo"

--- a/api/api.go
+++ b/api/api.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Peripli/service-manager/api/configuration"
+
 	"github.com/Peripli/service-manager/pkg/query"
 
 	"github.com/Peripli/service-manager/pkg/util"
@@ -113,6 +115,7 @@ func New(ctx context.Context, options *Options) (*web.API, error) {
 					return br.(*types.ServiceBroker), nil
 				},
 			},
+			&configuration.Controller{},
 		},
 		// Default filters - more filters can be registered using the relevant API methods
 		Filters: []web.Filter{

--- a/api/configuration/logging_controller.go
+++ b/api/configuration/logging_controller.go
@@ -2,7 +2,6 @@ package configuration
 
 import (
 	"net/http"
-	"os"
 
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/util"
@@ -32,18 +31,14 @@ func (c *Controller) getLoggingConfiguration(r *web.Request) (*web.Response, err
 
 func (c *Controller) setLoggingConfiguration(r *web.Request) (*web.Response, error) {
 	ctx := r.Context()
-	loggingConfig := &log.Settings{
-		Output: os.Stdout,
-	}
+	loggingConfig := log.Configuration()
 	body := &LoggingConfig{
-		Format: "kibana",
+		Level:  loggingConfig.Format,
+		Format: loggingConfig.Level,
 	}
 	if err := util.BytesToObject(r.Body, body); err != nil {
 		return nil, err
 	}
-
-	loggingConfig.Format = body.Format
-	loggingConfig.Level = body.Level
 
 	log.C(ctx).Infof("Attempting to set logging configuration with level: %s and format: %s", loggingConfig.Level, loggingConfig.Format)
 	ctx = log.Configure(ctx, loggingConfig)

--- a/api/configuration/logging_controller.go
+++ b/api/configuration/logging_controller.go
@@ -1,0 +1,74 @@
+package configuration
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/Peripli/service-manager/pkg/log"
+	"github.com/Peripli/service-manager/pkg/util"
+	"github.com/Peripli/service-manager/pkg/web"
+)
+
+// LoggingConfig struct represents the configurable logger properties
+type LoggingConfig struct {
+	Level  string `json:"level,omitempty"`
+	Format string `json:"format,omitempty"`
+}
+
+// Controller logging configuration controller
+type Controller struct {
+}
+
+func (c *Controller) getLoggingConfiguration(r *web.Request) (*web.Response, error) {
+	ctx := r.Context()
+	logCfg := log.Configuration()
+	log.C(ctx).Debugf("Obtaining log configuration: %+v", logCfg)
+
+	return util.NewJSONResponse(http.StatusOK, &LoggingConfig{
+		Level:  logCfg.Level,
+		Format: logCfg.Format,
+	})
+}
+
+func (c *Controller) setLoggingConfiguration(r *web.Request) (*web.Response, error) {
+	ctx := r.Context()
+	loggingConfig := &log.Settings{
+		Output: os.Stdout,
+	}
+	body := &LoggingConfig{
+		Format: "kibana",
+	}
+	if err := util.BytesToObject(r.Body, body); err != nil {
+		return nil, err
+	}
+
+	loggingConfig.Format = body.Format
+	loggingConfig.Level = body.Level
+
+	log.C(ctx).Infof("Attempting to set logging configuration with level: %s and format: %s", loggingConfig.Level, loggingConfig.Format)
+	ctx = log.Configure(ctx, loggingConfig)
+	r.Request = r.WithContext(ctx)
+	log.C(ctx).Infof("Successfully set logging configuration with level: %s and format: %s", loggingConfig.Level, loggingConfig.Format)
+
+	return util.NewJSONResponse(http.StatusOK, map[string]string{})
+}
+
+// Routes provides endpoints for modifying and obtaining the logging configuration
+func (c *Controller) Routes() []web.Route {
+	return []web.Route{
+		{
+			Endpoint: web.Endpoint{
+				Method: http.MethodGet,
+				Path:   web.LoggingConfigURL,
+			},
+			Handler: c.getLoggingConfiguration,
+		},
+		{
+			Endpoint: web.Endpoint{
+				Method: http.MethodPut,
+				Path:   web.LoggingConfigURL,
+			},
+			Handler: c.setLoggingConfiguration,
+		},
+	}
+}

--- a/api/filters/logging.go
+++ b/api/filters/logging.go
@@ -17,11 +17,8 @@
 package filters
 
 import (
-	"fmt"
-
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/web"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -42,13 +39,6 @@ func (*Logging) Name() string {
 func (l *Logging) Run(req *web.Request, next web.Handler) (*web.Response, error) {
 	ctx := req.Context()
 	entry := log.C(ctx)
-	if level := req.Header.Get("X-Logging-Level"); level != "" {
-		parsedLevel, err := logrus.ParseLevel(level)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing log level %s provided by request header X-Logging-Level: %s", level, err)
-		}
-		entry.Logger.SetLevel(parsedLevel)
-	}
 	if correlationID := log.CorrelationIDForRequest(req.Request); correlationID != "" {
 		entry = entry.WithField(log.FieldCorrelationID, correlationID)
 	}

--- a/api/filters/logging.go
+++ b/api/filters/logging.go
@@ -17,8 +17,11 @@
 package filters
 
 import (
+	"fmt"
+
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/web"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -39,6 +42,13 @@ func (*Logging) Name() string {
 func (l *Logging) Run(req *web.Request, next web.Handler) (*web.Response, error) {
 	ctx := req.Context()
 	entry := log.C(ctx)
+	if level := req.Header.Get("X-Logging-Level"); level != "" {
+		parsedLevel, err := logrus.ParseLevel(level)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing log level %s provided by request header X-Logging-Level: %s", level, err)
+		}
+		entry.Logger.SetLevel(parsedLevel)
+	}
 	if correlationID := log.CorrelationIDForRequest(req.Request); correlationID != "" {
 		entry = entry.WithField(log.FieldCorrelationID, correlationID)
 	}

--- a/api/filters/oidc_authentication.go
+++ b/api/filters/oidc_authentication.go
@@ -53,6 +53,7 @@ func oidcAuthnMatchers() []web.FilterMatcher {
 					web.ServiceOfferingsURL+"/**",
 					web.ServicePlansURL+"/**",
 					web.VisibilitiesURL+"/**",
+					web.LoggingConfigURL+"/**",
 				),
 			},
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Peripli/service-manager/pkg/httpclient"
@@ -59,8 +60,8 @@ func DefaultSettings() *Settings {
 }
 
 // New creates a configuration from the default env
-func New() (*Settings, error) {
-	env, err := env.Default(AddPFlags)
+func New(ctx context.Context) (*Settings, error) {
+	env, err := env.Default(ctx, AddPFlags)
 	if err != nil {
 		return nil, fmt.Errorf("error loading default env: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	cfg, err := config.New()
+	cfg, err := config.New(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/env/cf_test.go
+++ b/pkg/env/cf_test.go
@@ -17,8 +17,8 @@
 package env
 
 import (
+	"context"
 	"os"
-	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -52,11 +52,6 @@ const VCAP_SERVICES_VALUE = `{ "postgresql": [
   ]
  }`
 
-func TestApi(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "CF Env Suite")
-}
-
 var _ = Describe("CF Env", func() {
 	var (
 		environment Environment
@@ -69,7 +64,7 @@ var _ = Describe("CF Env", func() {
 		Expect(os.Setenv("STORAGE_NAME", "smdb")).ShouldNot(HaveOccurred())
 		Expect(os.Unsetenv("STORAGE_URI")).ShouldNot(HaveOccurred())
 
-		environment, err = New(EmptyFlagSet())
+		environment, err = New(context.TODO(), EmptyFlagSet())
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -169,7 +169,7 @@ func Default(ctx context.Context, additionalPFlags ...func(set *pflag.FlagSet)) 
 
 	dynamicLogHandler := func(env Environment) func(event fsnotify.Event) {
 		return func(event fsnotify.Event) {
-			if strings.Contains(event.String(), "WRITE") {
+			if strings.Contains(event.String(), "WRITE") || strings.Contains(event.String(), "CREATE") {
 				logLevel := env.Get("log.level").(string)
 				logFormat := env.Get("log.format").(string)
 

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -177,7 +177,7 @@ func Default(ctx context.Context, additionalPFlags ...func(set *pflag.FlagSet)) 
 				ctx = log.Configure(ctx, &log.Settings{
 					Level:  logLevel,
 					Format: logFormat,
-					Output: os.Stdout,
+					Output: os.Stdout.Name(),
 				})
 			}
 		}

--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -106,7 +106,12 @@ func Configure(ctx context.Context, settings *Settings) context.Context {
 	defaultEntry = logrus.NewEntry(logger)
 	defaultEntry = defaultEntry.WithField(FieldCorrelationID, "-")
 
-	return ContextWithLogger(ctx, defaultEntry)
+	entry := ctx.Value(logKey{})
+	if entry == nil {
+		return ContextWithLogger(ctx, copyEntry(defaultEntry))
+	}
+
+	return ContextWithLogger(ctx, entry.(*logrus.Entry))
 }
 
 func Configuration() *Settings {
@@ -122,9 +127,9 @@ func ForContext(ctx context.Context) *logrus.Entry {
 	defer mutex.RUnlock()
 	entry := ctx.Value(logKey{})
 	if entry == nil {
-		entry = defaultEntry
+		return copyEntry(defaultEntry)
 	}
-	return copyEntry(entry.(*logrus.Entry))
+	return entry.(*logrus.Entry)
 }
 
 // Default returns the default logger

--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -187,11 +187,20 @@ func copyEntry(entry *logrus.Entry) *logrus.Entry {
 	for k, v := range entry.Data {
 		entryData[k] = v
 	}
-	newEntry := logrus.NewEntry(entry.Logger)
+	newLogger := &logrus.Logger{
+		Out:          entry.Logger.Out,
+		Hooks:        entry.Logger.Hooks,
+		Formatter:    entry.Logger.Formatter,
+		ReportCaller: entry.Logger.ReportCaller,
+		Level:        entry.Logger.Level,
+		ExitFunc:     entry.Logger.ExitFunc,
+	}
+	newEntry := logrus.NewEntry(newLogger)
 	newEntry.Level = entry.Level
 	newEntry.Data = entryData
 	newEntry.Time = entry.Time
 	newEntry.Message = entry.Message
 	newEntry.Buffer = entry.Buffer
+
 	return newEntry
 }

--- a/pkg/log/context_test.go
+++ b/pkg/log/context_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"sync"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -139,6 +138,5 @@ func expectOutput(substring string, logFormat string) {
 }
 
 func configure(settings *Settings) context.Context {
-	once = sync.Once{}
 	return Configure(context.TODO(), settings)
 }

--- a/pkg/log/context_test.go
+++ b/pkg/log/context_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// TestServiceManager tests servermanager package
+// TestLog tests logging package
 func TestLog(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Log Suite")

--- a/pkg/log/context_test.go
+++ b/pkg/log/context_test.go
@@ -56,7 +56,7 @@ func TestMultipleGoroutinesMixedLog(t *testing.T) {
 }
 
 var _ = Describe("log", func() {
-	FDescribe("SetupLogging", func() {
+	Describe("SetupLogging", func() {
 
 		Context("with invalid log level", func() {
 			It("should panic", func() {

--- a/pkg/log/context_test.go
+++ b/pkg/log/context_test.go
@@ -56,13 +56,14 @@ func TestMultipleGoroutinesMixedLog(t *testing.T) {
 }
 
 var _ = Describe("log", func() {
-	Describe("SetupLogging", func() {
+	FDescribe("SetupLogging", func() {
 
 		Context("with invalid log level", func() {
 			It("should panic", func() {
 				expectPanic(&Settings{
 					Level:  "invalid",
 					Format: "text",
+					Output: os.Stderr.Name(),
 				})
 			})
 		})
@@ -72,6 +73,17 @@ var _ = Describe("log", func() {
 				expectPanic(&Settings{
 					Level:  "debug",
 					Format: "invalid",
+					Output: os.Stderr.Name(),
+				})
+			})
+		})
+
+		Context("with invalid log format", func() {
+			It("should panic", func() {
+				expectPanic(&Settings{
+					Level:  "debug",
+					Format: "text",
+					Output: "invalid",
 				})
 			})
 		})
@@ -117,17 +129,17 @@ func (wr *MyWriter) Write(p []byte) (n int, err error) {
 }
 
 func expectPanic(settings *Settings) {
-	wrapper := func() {
-		configure(settings)
-	}
-	Expect(wrapper).To(Panic())
+	Expect(func() {
+		Configure(context.TODO(), settings)
+	}).To(Panic())
 }
 
 func expectOutput(substring string, logFormat string) {
 	w := &MyWriter{}
-	ctx := configure(&Settings{
+	ctx := Configure(context.TODO(), &Settings{
 		Level:  "debug",
 		Format: logFormat,
+		Output: os.Stderr.Name(),
 	})
 	entry := ForContext(ctx)
 	entry.Logger.SetOutput(w)
@@ -135,8 +147,4 @@ func expectOutput(substring string, logFormat string) {
 	entry.Debug("Test")
 	fmt.Println(w.Data)
 	Expect(w.Data).To(ContainSubstring(substring))
-}
-
-func configure(settings *Settings) context.Context {
-	return Configure(context.TODO(), settings)
 }

--- a/pkg/security/filters/required_authn.go
+++ b/pkg/security/filters/required_authn.go
@@ -58,6 +58,7 @@ func (raf *requiredAuthnFilter) FilterMatchers() []web.FilterMatcher {
 					web.ServicePlansURL+"/**",
 					web.VisibilitiesURL+"/**",
 					web.NotificationsURL+"/**",
+					web.LoggingConfigURL+"/**",
 				),
 			},
 		},

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -29,4 +29,10 @@ const (
 
 	// InfoURL is the path of the info endpoint
 	InfoURL = "/" + apiVersion + "/info"
+
+	// ConfigURL is the Configuration API base URL path
+	ConfigURL = "/" + apiVersion + "/config"
+
+	// LoggingConfigURL is the Logging Configuration API URL path
+	LoggingConfigURL = ConfigURL + "/logging"
 )

--- a/storage/notification_cleaner.go
+++ b/storage/notification_cleaner.go
@@ -50,7 +50,7 @@ func (nc *NotificationCleaner) Start(ctx context.Context, group *sync.WaitGroup)
 			group.Done()
 		}()
 		cleanInterval := nc.Settings.Notification.CleanInterval
-		log.C(ctx).Infof("Scheduling notification cleaning every %s", cleanInterval.String())
+		log.D().Infof("Scheduling notification cleaning every %s", cleanInterval.String())
 		for {
 			select {
 			case <-ctx.Done():

--- a/storage/postgres/notificator.go
+++ b/storage/postgres/notificator.go
@@ -111,7 +111,7 @@ func (n *Notificator) Start(ctx context.Context, group *sync.WaitGroup) error {
 	}))
 	util.StartInWaitGroupWithContext(ctx, func(c context.Context) {
 		<-c.Done()
-		log.C(c).Info("context cancelled, stopping Notificator...")
+		log.D().Info("context cancelled, stopping Notificator...")
 		n.stopConnection()
 	}, group)
 	return nil

--- a/storage/registry.go
+++ b/storage/registry.go
@@ -33,7 +33,7 @@ func InitializeWithSafeTermination(ctx context.Context, s Storage, settings *Set
 
 	util.StartInWaitGroupWithContext(ctx, func(c context.Context) {
 		<-c.Done()
-		log.C(c).Debug("Context cancelled. Closing storage...")
+		log.D().Debug("Context cancelled. Closing storage...")
 		if err := s.Close(); err != nil {
 			log.D().Error(err)
 		}

--- a/test/auth_test/auth_test.go
+++ b/test/auth_test/auth_test.go
@@ -191,6 +191,17 @@ var _ = Describe("Service Manager Authentication", func() {
 			{"Invalid authorization schema", "DELETE", "/v1/visibilities/999", "Basic abc"},
 			{"Missing token in authorization header", "DELETE", "/v1/visibilities/999", "Bearer "},
 			{"Invalid token in authorization header", "DELETE", "/v1/visibilities/999", "Bearer abc"},
+
+			// LOGGING CONFIG
+			{"Missing authorization header", "GET", "/v1/config/logging", ""},
+			{"Invalid authorization schema", "GET", "/v1/config/logging", "Basic abc"},
+			{"Missing token in authorization header", "GET", "/v1/config/logging", "Bearer "},
+			{"Invalid token in authorization header", "GET", "/v1/config/logging", "Bearer abc"},
+
+			{"Missing authorization header", "PUT", "/v1/config/logging", ""},
+			{"Invalid authorization schema", "PUT", "/v1/config/logging", "Basic abc"},
+			{"Missing token in authorization header", "PUT", "/v1/config/logging", "Bearer "},
+			{"Invalid token in authorization header", "PUT", "/v1/config/logging", "Bearer abc"},
 		}
 
 		for _, request := range authRequests {

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -192,7 +192,7 @@ func TestEnv(additionalFlagFuncs ...func(set *pflag.FlagSet)) env.Environment {
 
 	additionalFlagFuncs = append(additionalFlagFuncs, f)
 
-	env, _ := env.Default(append([]func(set *pflag.FlagSet){config.AddPFlags}, additionalFlagFuncs...)...)
+	env, _ := env.Default(context.TODO(), append([]func(set *pflag.FlagSet){config.AddPFlags}, additionalFlagFuncs...)...)
 	return env
 }
 

--- a/test/log_test/log_test.go
+++ b/test/log_test/log_test.go
@@ -1,1 +1,0 @@
-package log_test

--- a/test/log_test/log_test.go
+++ b/test/log_test/log_test.go
@@ -1,0 +1,1 @@
+package log_test

--- a/test/logging_test/logging_test.go
+++ b/test/logging_test/logging_test.go
@@ -1,0 +1,74 @@
+package log_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/Peripli/service-manager/pkg/log"
+
+	"github.com/Peripli/service-manager/pkg/web"
+
+	"github.com/Peripli/service-manager/test/common"
+
+	. "github.com/onsi/ginkgo"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestLogging tests the Logging Config API
+func TestLogging(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OSB API Tests Suite")
+}
+
+var _ = Describe("Service Manager Logging Config API", func() {
+	var (
+		ctx *common.TestContext
+	)
+
+	BeforeSuite(func() {
+		ctx = common.NewTestContextBuilder().Build()
+	})
+
+	AfterSuite(func() {
+		ctx.Cleanup()
+	})
+
+	BeforeEach(func() {
+		log.Configure(context.TODO(), &log.Settings{
+			Level:  "error",
+			Format: "json",
+			Output: os.Stdout,
+		})
+	})
+
+	Context("GET", func() {
+		It("returns the correct logging configuration", func() {
+			ctx.SMWithOAuth.GET(web.LoggingConfigURL).
+				Expect().
+				Status(http.StatusOK).JSON().Object().ContainsMap(map[string]string{
+				"level":  "error",
+				"format": "json",
+			})
+		})
+	})
+
+	Context("PUT", func() {
+		It("successfully modifies the logging configuration", func() {
+			ctx.SMWithOAuth.PUT(web.LoggingConfigURL).
+				WithJSON(common.Object{
+					"level":  "panic",
+					"format": "text",
+				}).Expect().Status(http.StatusOK)
+
+			ctx.SMWithOAuth.GET(web.LoggingConfigURL).
+				Expect().
+				Status(http.StatusOK).JSON().Object().ContainsMap(map[string]string{
+				"level":  "panic",
+				"format": "text",
+			})
+		})
+	})
+})

--- a/test/sm_test/sm_test.go
+++ b/test/sm_test/sm_test.go
@@ -18,10 +18,11 @@ package sm_test
 
 import (
 	"context"
-	"github.com/Peripli/service-manager/config"
-	"github.com/Peripli/service-manager/pkg/env"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/Peripli/service-manager/config"
+	"github.com/Peripli/service-manager/pkg/env"
 
 	"github.com/gavv/httpexpect"
 	. "github.com/onsi/ginkgo"
@@ -61,7 +62,7 @@ var _ = Describe("SM", func() {
 	Describe("New", func() {
 		Context("when validating config fails", func() {
 			It("should return error", func() {
-				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
+				env, err := env.Default(context.TODO(), config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", oauthServer.URL())
 				env.Set("log.level", "invalid")
@@ -77,7 +78,7 @@ var _ = Describe("SM", func() {
 
 		Context("when setting up storage with invalid uri", func() {
 			It("should throw error during migrations setup", func() {
-				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
+				env, err := env.Default(context.TODO(), config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", oauthServer.URL())
 				env.Set("storage.uri", "invalid")
@@ -93,7 +94,7 @@ var _ = Describe("SM", func() {
 
 		Context("when setting up API fails", func() {
 			It("should return error", func() {
-				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
+				env, err := env.Default(context.TODO(), config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", "")
 
@@ -107,7 +108,7 @@ var _ = Describe("SM", func() {
 
 		Context("when no API extensions are registered", func() {
 			It("should return working service manager", func() {
-				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
+				env, err := env.Default(context.TODO(), config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", oauthServer.URL())
 
@@ -123,7 +124,7 @@ var _ = Describe("SM", func() {
 
 		Context("when additional filter is registered", func() {
 			It("should return working service manager with a new filter", func() {
-				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
+				env, err := env.Default(context.TODO(), config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", oauthServer.URL())
 
@@ -145,7 +146,7 @@ var _ = Describe("SM", func() {
 
 		Context("when additional controller is registered", func() {
 			It("should return working service manager with additional controller", func() {
-				env, err := env.Default(config.AddPFlags, common.SetTestFileLocation)
+				env, err := env.Default(context.TODO(), config.AddPFlags, common.SetTestFileLocation)
 				Expect(err).ToNot(HaveOccurred())
 				env.Set("api.token_issuer_url", oauthServer.URL())
 


### PR DESCRIPTION
# Pull Request Template

## Motivation

Allows dynamically switching log levels of SM's loggers without requiring app restart.

## Approach

Two ways to dynamically switch the application log level are introduced:
1. a new PUT API /v1/config/logging that accepts  a logging configuration (log format and log level). The input from the API is used to reconfigure the loggers
2. File watchers on the application.yml (meaning if one changes the application.yml (or whatever config file is used), the application loggers will be reconfigured

## Pull Request status

For example:

* [x] Initial implementation
* [x] Refactoring
* [x] Unit tests
* [x] Integration tests