### PR TITLE
Kibana formatter

### DIFF
--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -31,8 +31,9 @@ type logKey struct{}
 
 var (
 	supportedFormatters = map[string]logrus.Formatter{
-		"json": &logrus.JSONFormatter{},
-		"text": &logrus.TextFormatter{},
+		"json":   &logrus.JSONFormatter{},
+		"text":   &logrus.TextFormatter{},
+		"kibana": &KibanaFormatter{},
 	}
 	regMutex     = sync.Mutex{}
 	once         = sync.Once{}

--- a/pkg/log/formatter.go
+++ b/pkg/log/formatter.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package log
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"time"
+)
+
+type kibanaEntry struct {
+	WrittenAt        string        `json:"written_at"`
+	WrittenTimestamp string        `json:"written_ts"`
+	ComponentType    string        `json:"component_type"`
+	CorrelationID    string        `json:"correlation_id"`
+	Type             string        `json:"type"`
+	Logger           string        `json:"logger"`
+	Level            string        `json:"level"`
+	Message          string        `json:"msg"`
+	Fields           logrus.Fields `json:"-"`
+}
+
+// MarshalJSON marshals the kibana entry by inlining the logrus fields instead of being nested in the "Fields" tag
+func (k kibanaEntry) MarshalJSON() ([]byte, error) {
+	type Entry kibanaEntry
+	bytes, err := json.Marshal(Entry(k))
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]json.RawMessage
+	if err = json.Unmarshal(bytes, &result); err != nil {
+		return nil, err
+	}
+
+	for k, v := range k.Fields {
+		field, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		result[k] = field
+	}
+
+	return json.Marshal(result)
+}
+
+// KibanaFormatter is a logrus formatter that formats an entry for Kibana
+type KibanaFormatter struct {
+}
+
+// Format formats a logrus entry for Kibana logging
+func (f *KibanaFormatter) Format(e *logrus.Entry) ([]byte, error) {
+	componentName, exists := e.Data[FieldComponentName].(string)
+	if !exists {
+		componentName = "-"
+	}
+	delete(e.Data, FieldComponentName)
+
+	correlationID, exists := e.Data[FieldCorrelationID].(string)
+	if !exists {
+		correlationID = "-"
+	}
+	delete(e.Data, FieldCorrelationID)
+
+	if errorField, exists := e.Data[logrus.ErrorKey].(error); exists {
+		e.Message = e.Message + ": " + errorField.Error()
+	}
+	delete(e.Data, logrus.ErrorKey)
+
+	kibanaEntry := &kibanaEntry{
+		Logger:           componentName,
+		Level:            e.Level.String(),
+		Message:          e.Message,
+		CorrelationID:    correlationID,
+		Type:             "log",
+		ComponentType:    "application",
+		WrittenAt:        e.Time.UTC().Format(time.RFC3339Nano),
+		WrittenTimestamp: fmt.Sprintf("%d", e.Time.UTC().Unix()),
+		Fields:           e.Data,
+	}
+	serialized, err := json.Marshal(kibanaEntry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal fields to JSON: %v", err)
+	}
+	return append(serialized, '\n'), nil
+}

--- a/pkg/log/formatter_test.go
+++ b/pkg/log/formatter_test.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package log
+
+import (
+	"bytes"
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("kibana formatter", func() {
+
+	var buffer *bytes.Buffer
+	var entry *logrus.Entry
+
+	BeforeEach(func() {
+		buffer = &bytes.Buffer{}
+		ctx := configure(&Settings{
+			Level:  "debug",
+			Format: "kibana",
+		})
+		entry = ForContext(ctx)
+		entry.Logger.SetOutput(buffer)
+	})
+
+	When("format is kibana", func() {
+		JustBeforeEach(func() {
+			entry.Debug("test")
+		})
+
+		It("should contain correlation_id", func() {
+			Expect(buffer.String()).To(ContainSubstring(`"correlation_id":`))
+		})
+		It("should contain component_type", func() {
+			Expect(buffer.String()).To(ContainSubstring(`"component_type":`))
+		})
+		It("should contain log level", func() {
+			Expect(buffer.String()).To(ContainSubstring(`"level":"debug"`))
+		})
+		It("should contain logger information", func() {
+			Expect(buffer.String()).To(ContainSubstring(`"logger":`))
+		})
+		It("should contain log type", func() {
+			Expect(buffer.String()).To(ContainSubstring(`"type":"log"`))
+		})
+		It("should contain written_at human readable timestamp", func() {
+			Expect(buffer.String()).To(ContainSubstring(`"written_at":`))
+		})
+		It("should contain written_ts timestamp", func() {
+			Expect(buffer.String()).To(ContainSubstring(`"written_ts":`))
+		})
+		It("should contain the message", func() {
+			Expect(buffer.String()).To(ContainSubstring(`"msg":"test"`))
+		})
+	})
+
+	When("error is logged", func() {
+		It("should append it to the message", func() {
+			err := fmt.Errorf("error message")
+			entry.WithError(err).Errorf("test message")
+
+			Expect(buffer.String()).To(ContainSubstring(`"level":"error"`))
+			Expect(buffer.String()).To(ContainSubstring(`"msg":"test message: ` + err.Error() + `"`))
+		})
+	})
+
+	When("custom field is logged", func() {
+		It("should not be nested", func() {
+			entry.WithField("test_field", "test_value").Debug("test")
+
+			Expect(buffer.String()).To(ContainSubstring(`,"test_field":"test_value",`))
+		})
+	})
+
+})


### PR DESCRIPTION
This PR also enables Kibana log format in SB proxies.

## Motivation
Kibana log formatter reusable by SB proxies is needed.

## Approach

Add kibana log formatter in SM, so it can be used by all dependent components including the SM.

## Pull Request status

* [x] Implementation
* [x] Unit tests
