### PR TITLE
Store correlation id in notification

### DIFF
--- a/pkg/log/context.go
+++ b/pkg/log/context.go
@@ -137,6 +137,17 @@ func RegisterFormatter(name string, formatter logrus.Formatter) error {
 	return nil
 }
 
+// CorrelationIDFromContext returns the correlation id associated with the context logger or empty string if none exists
+func CorrelationIDFromContext(ctx context.Context) string {
+	correlationID, exists := C(ctx).Data[FieldCorrelationID]
+	if exists {
+		if id, ok := correlationID.(string); ok {
+			return id
+		}
+	}
+	return ""
+}
+
 // AddHook adds a hook to all loggers
 func AddHook(hook logrus.Hook) {
 	defaultEntry.Logger.AddHook(hook)

--- a/pkg/types/notification.go
+++ b/pkg/types/notification.go
@@ -44,11 +44,12 @@ const (
 // Notification struct
 type Notification struct {
 	Base
-	Resource   ObjectType      `json:"resource"`
-	Type       OperationType   `json:"type"`
-	PlatformID string          `json:"platform_id,omitempty"`
-	Revision   int64           `json:"revision"`
-	Payload    json.RawMessage `json:"payload"`
+	Resource      ObjectType      `json:"resource"`
+	Type          OperationType   `json:"type"`
+	PlatformID    string          `json:"platform_id,omitempty"`
+	Revision      int64           `json:"revision"`
+	Payload       json.RawMessage `json:"payload"`
+	CorrelationID string          `json:"correlation_id"`
 }
 
 // Validate implements InputValidator and verifies all mandatory fields are populated

--- a/storage/interceptors/notifications_interceptor.go
+++ b/storage/interceptors/notifications_interceptor.go
@@ -191,10 +191,11 @@ func CreateNotification(ctx context.Context, repository storage.Repository, op t
 			UpdatedAt: currentTime,
 			Labels:    map[string][]string{},
 		},
-		Resource:   resource,
-		Type:       op,
-		PlatformID: platformID,
-		Payload:    payloadBytes,
+		Resource:      resource,
+		Type:          op,
+		PlatformID:    platformID,
+		Payload:       payloadBytes,
+		CorrelationID: log.CorrelationIDFromContext(ctx),
 	}
 
 	notificationID, err := repository.Create(ctx, notification)

--- a/storage/interceptors/notifications_interceptor.go
+++ b/storage/interceptors/notifications_interceptor.go
@@ -198,11 +198,11 @@ func CreateNotification(ctx context.Context, repository storage.Repository, op t
 		CorrelationID: log.CorrelationIDFromContext(ctx),
 	}
 
-	notificationID, err := repository.Create(ctx, notification)
+	createdNotification, err := repository.Create(ctx, notification)
 	if err != nil {
 		return err
 	}
-	log.C(ctx).Debugf("Successfully created notification with id %s of type %s for resource type %s", notificationID, notification.Type, notification.Resource)
+	log.C(ctx).Debugf("Successfully created notification with id %s of type %s for resource type %s", createdNotification.GetID(), notification.Type, notification.Resource)
 
 	return nil
 }

--- a/storage/postgres/keystore_test.go
+++ b/storage/postgres/keystore_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Secured Storage", func() {
 		mock.ExpectQuery(`SELECT CURRENT_DATABASE()`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("mock"))
 		mock.ExpectQuery(`SELECT COUNT(1)*`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("1"))
 		mock.ExpectExec("SELECT pg_advisory_lock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("11,false"))
+		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20190816162000,false"))
 		mock.ExpectExec("SELECT pg_advisory_unlock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 		options := storage.DefaultSettings()
 		options.EncryptionKey = string(envEncryptionKey)

--- a/storage/postgres/migrations/20190816162000_notifications_corr_id.down.sql
+++ b/storage/postgres/migrations/20190816162000_notifications_corr_id.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE notifications DROP COLUMN correlation_id;
+
+COMMIT;

--- a/storage/postgres/migrations/20190816162000_notifications_corr_id.up.sql
+++ b/storage/postgres/migrations/20190816162000_notifications_corr_id.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE notifications ADD COLUMN correlation_id varchar(40);
+
+COMMIT;

--- a/storage/postgres/notification.go
+++ b/storage/postgres/notification.go
@@ -28,11 +28,12 @@ import (
 //go:generate smgen storage notification github.com/Peripli/service-manager/pkg/types:Notification
 type Notification struct {
 	BaseEntity
-	Resource   string             `db:"resource"`
-	Type       string             `db:"type"`
-	PlatformID sql.NullString     `db:"platform_id"`
-	Revision   int64              `db:"revision,auto_increment"`
-	Payload    sqlxtypes.JSONText `db:"payload"`
+	Resource      string             `db:"resource"`
+	Type          string             `db:"type"`
+	PlatformID    sql.NullString     `db:"platform_id"`
+	Revision      int64              `db:"revision,auto_increment"`
+	Payload       sqlxtypes.JSONText `db:"payload"`
+	CorrelationID sql.NullString     `db:"correlation_id"`
 }
 
 func (n *Notification) ToObject() types.Object {
@@ -43,11 +44,12 @@ func (n *Notification) ToObject() types.Object {
 			UpdatedAt: n.UpdatedAt,
 			Labels:    map[string][]string{},
 		},
-		Resource:   types.ObjectType(n.Resource),
-		Type:       types.OperationType(n.Type),
-		PlatformID: n.PlatformID.String,
-		Revision:   n.Revision,
-		Payload:    getJSONRawMessage(n.Payload),
+		Resource:      types.ObjectType(n.Resource),
+		Type:          types.OperationType(n.Type),
+		PlatformID:    n.PlatformID.String,
+		Revision:      n.Revision,
+		Payload:       getJSONRawMessage(n.Payload),
+		CorrelationID: n.CorrelationID.String,
 	}
 }
 
@@ -73,6 +75,10 @@ func (*Notification) FromObject(object types.Object) (storage.Entity, bool) {
 		PlatformID: platformID,
 		Revision:   notification.Revision, // when creating new Notification, Revision will be set by DB
 		Payload:    getJSONText(notification.Payload),
+		CorrelationID: sql.NullString{
+			String: notification.CorrelationID,
+			Valid:  notification.CorrelationID != "",
+		},
 	}
 	return n, true
 }

--- a/storage/postgres/notification.go
+++ b/storage/postgres/notification.go
@@ -59,26 +59,18 @@ func (*Notification) FromObject(object types.Object) (storage.Entity, bool) {
 		return nil, false
 	}
 
-	platformID := sql.NullString{
-		String: notification.PlatformID,
-		Valid:  notification.PlatformID != "",
-	}
-
 	n := &Notification{
 		BaseEntity: BaseEntity{
 			ID:        notification.ID,
 			CreatedAt: notification.CreatedAt,
 			UpdatedAt: notification.UpdatedAt,
 		},
-		Resource:   string(notification.Resource),
-		Type:       string(notification.Type),
-		PlatformID: platformID,
-		Revision:   notification.Revision, // when creating new Notification, Revision will be set by DB
-		Payload:    getJSONText(notification.Payload),
-		CorrelationID: sql.NullString{
-			String: notification.CorrelationID,
-			Valid:  notification.CorrelationID != "",
-		},
+		Resource:      string(notification.Resource),
+		Type:          string(notification.Type),
+		PlatformID:    toNullString(notification.PlatformID),
+		Revision:      notification.Revision, // when creating new Notification, Revision will be set by DB
+		Payload:       getJSONText(notification.Payload),
+		CorrelationID: toNullString(notification.CorrelationID),
 	}
 	return n, true
 }


### PR DESCRIPTION
For better traceability, notifications should carry the correlation-id of the request that created the notification. This way a call to "register service broker" can be traced to the respective platform.