### PR TITLE
Osb responses to include the broker name if an error occurs

### DIFF
--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -140,7 +140,7 @@ func (c *Controller) proxy(r *web.Request, logger *logrus.Entry, broker *types.S
 		recorder.Header().Set("Content-Type", "application/json")
 		description := gjson.GetBytes(brokerResponseBody, "description").String()
 		if description == "" {
-			description = ""
+			description = "{}"
 		}
 		responseBody, err = sjson.SetBytes(brokerResponseBody, "description", fmt.Sprintf("Broker with name %s failed with: %s", broker.Name, description))
 		if err != nil {

--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -177,8 +177,3 @@ func buildProxy(targetBrokerURL *url.URL, logger *logrus.Entry, broker *types.Se
 	}
 	return proxy
 }
-
-type brokerError struct {
-	Description string `json:"description"`
-	Error       string `json:"error"`
-}

--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -135,14 +135,14 @@ func (c *Controller) proxy(r *web.Request, logger *logrus.Entry, broker *types.S
 
 	if !gjson.ValidBytes(brokerResponseBody) {
 		recorder.Header().Set("Content-Type", "application/json")
-		responseBody = []byte(fmt.Sprintf(`{"description": "Broker with name %s response is not a valid json: %s"}`, broker.Name, brokerResponseBody))
+		responseBody = []byte(fmt.Sprintf(`{"description": "Service broker %s responded with invalid JSON: %s"}`, broker.Name, brokerResponseBody))
 	} else if recorder.Code > 399 || recorder.Code < 100 {
 		recorder.Header().Set("Content-Type", "application/json")
 		description := gjson.GetBytes(brokerResponseBody, "description").String()
 		if description == "" {
 			description = "{}"
 		}
-		responseBody, err = sjson.SetBytes(brokerResponseBody, "description", fmt.Sprintf("Broker with name %s failed with: %s", broker.Name, description))
+		responseBody, err = sjson.SetBytes(brokerResponseBody, "description", fmt.Sprintf("Service broker %s failed with: %s", broker.Name, description))
 		if err != nil {
 			return nil, err
 		}
@@ -168,7 +168,7 @@ func buildProxy(targetBrokerURL *url.URL, logger *logrus.Entry, broker *types.Se
 		return nil
 	}
 	proxy.ErrorHandler = func(writer http.ResponseWriter, request *http.Request, e error) {
-		logger.WithError(e).Errorf("Error while forwarding request to service broker %s", broker.Name)
+		logger.WithError(e).Errorf("ErrorЧ while forwarding request to service broker %s", broker.Name)
 		util.WriteError(request.Context(), &util.HTTPError{
 			ErrorType:   "ServiceBrokerErr",
 			Description: fmt.Sprintf("could not reach service broker %s at %s", broker.Name, request.URL),

--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -140,7 +140,7 @@ func (c *Controller) proxy(r *web.Request, logger *logrus.Entry, broker *types.S
 		recorder.Header().Set("Content-Type", "application/json")
 		description := gjson.GetBytes(brokerResponseBody, "description").String()
 		if description == "" {
-			description = "{}"
+			description = string(brokerResponseBody)
 		}
 		responseBody, err = sjson.SetBytes(brokerResponseBody, "description", fmt.Sprintf("Service broker %s failed with: %s", broker.Name, description))
 		if err != nil {

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -1,12 +1,12 @@
 server:
-  request_timeout: 4000ms
+  request_timeout: 60000ms
   shutdown_timeout: 4000ms
   port: 1234
 httpclient:
-  response_header_timeout: 10000ms
-  tls_handshake_timeout: 10000ms
-  idle_conn_timeout: 10000ms
-  dial_timeout: 10000ms
+  response_header_timeout: 60000ms
+  tls_handshake_timeout: 60000ms
+  idle_conn_timeout: 60000ms
+  dial_timeout: 60000ms
 websocket:
   ping_timeout: 6000ms
   write_timeout: 6000ms

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -1,12 +1,12 @@
 server:
-  request_timeout: 60000ms
+  request_timeout: 4000ms
   shutdown_timeout: 4000ms
   port: 1234
 httpclient:
-  response_header_timeout: 60000ms
-  tls_handshake_timeout: 60000ms
-  idle_conn_timeout: 60000ms
-  dial_timeout: 60000ms
+  response_header_timeout: 10000ms
+  tls_handshake_timeout: 10000ms
+  idle_conn_timeout: 10000ms
+  dial_timeout: 10000ms
 websocket:
   ping_timeout: 6000ms
   write_timeout: 6000ms

--- a/test/osb_test/osb_test.go
+++ b/test/osb_test/osb_test.go
@@ -65,7 +65,7 @@ func TestOSB(t *testing.T) {
 
 func assertFailingBrokerError(req *httpexpect.Response) {
 	req.Status(http.StatusNotAcceptable).JSON().Object().
-		Value("description").String().Match("Broker with name .* failed with: .*Failing service broker error")
+		Value("description").String().Match("Service broker .* failed with: .*Failing service broker error")
 }
 
 func assertMissingBrokerError(req *httpexpect.Response) {
@@ -736,18 +736,18 @@ var _ = Describe("Service Manager OSB API", func() {
 					rw.Write([]byte("[not a json]"))
 				}
 				ctx.SMWithBasic.PUT(smUrlToFailingBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
-					WithJSON(getDummyService()).Expect().Status(http.StatusCreated).JSON().Object().Value("description").String().Match("Broker with name .* response is not a valid json: \\[not a json\\]")
+					WithJSON(getDummyService()).Expect().Status(http.StatusCreated).JSON().Object().Value("description").String().Match("Service broker .* responded with invalid JSON: \\[not a json\\]")
 			})
 		})
 
-		Context("when broker response error description is empty but", func() {
+		Context("when broker response error description is empty", func() {
 			It("should assing default description", func() {
 				failingBrokerServer.ServiceInstanceHandler = func(rw http.ResponseWriter, _ *http.Request) {
 					rw.WriteHeader(http.StatusBadRequest)
 					rw.Write([]byte(`{"error": "ErrorType"}`))
 				}
 				ctx.SMWithBasic.PUT(smUrlToFailingBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
-					WithJSON(getDummyService()).Expect().Status(http.StatusBadRequest).JSON().Object().Value("description").String().Match("Broker with name .* failed with: {}")
+					WithJSON(getDummyService()).Expect().Status(http.StatusBadRequest).JSON().Object().Value("description").String().Match("Service broker .* failed with: {}")
 			})
 		})
 	})

--- a/test/osb_test/osb_test.go
+++ b/test/osb_test/osb_test.go
@@ -747,7 +747,7 @@ var _ = Describe("Service Manager OSB API", func() {
 		},
 		Entry("when broker response is not a valid json, should return an OSB compliant error", http.StatusCreated, "[not a json]", "Service broker %s responded with invalid JSON: [not a json]"),
 		Entry("when broker returns a valid json which is not an object, should return the broker's response", http.StatusBadRequest, "3", "Service broker %s failed with: 3"),
-		Entry("when broker response error without description, should assing broker's response body as description", http.StatusBadRequest, `{"error": "ErrorType"}`, `Service broker %s failed with: {"error": "ErrorType"}`),
+		Entry("when broker returns error without description, should assing broker's response body as description", http.StatusBadRequest, `{"error": "ErrorType"}`, `Service broker %s failed with: {"error": "ErrorType"}`),
 		Entry("when broker response is JSON array, should return it in description", http.StatusBadRequest, `[1,2,3]`, `Service broker %s failed with: [1,2,3]`),
 	)
 })

--- a/test/osb_test/osb_test.go
+++ b/test/osb_test/osb_test.go
@@ -65,7 +65,7 @@ func TestOSB(t *testing.T) {
 
 func assertFailingBrokerError(req *httpexpect.Response) {
 	req.Status(http.StatusNotAcceptable).JSON().Object().
-		Value("description").String().Contains("Failing service broker error")
+		Value("description").String().Match("Broker with name .* failed with: .*Failing service broker error")
 }
 
 func assertMissingBrokerError(req *httpexpect.Response) {
@@ -723,6 +723,21 @@ var _ = Describe("Service Manager OSB API", func() {
 		})
 	})
 
+	Describe("Malfunctioning broker", func() {
+		Context("when broker response is not a valid json", func() {
+			BeforeEach(func() {
+				failingBrokerServer.ServiceInstanceHandler = func(rw http.ResponseWriter, _ *http.Request) {
+					rw.WriteHeader(http.StatusBadRequest)
+					rw.Write([]byte("[not a json]"))
+				}
+			})
+
+			It("should return an OSB compliant error", func() {
+				ctx.SMWithBasic.PUT(smUrlToFailingBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+					WithJSON(getDummyService()).Expect().Status(http.StatusBadRequest).JSON().Object().Value("description").String().Match("Broker with name .* response is not a valid json: \\[not a json\\]")
+			})
+		})
+	})
 })
 
 type prefixedBrokerHandler struct {

--- a/test/osb_test/osb_test.go
+++ b/test/osb_test/osb_test.go
@@ -17,6 +17,7 @@ package osb_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -32,6 +33,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 )
 
@@ -155,6 +157,7 @@ var _ = Describe("Service Manager OSB API", func() {
 
 		failingBrokerServer  *common.BrokerServer
 		failingBrokerID      string
+		failingBrokerName    string
 		smUrlToFailingBroker string
 
 		queryParameterVerificationServer   *common.BrokerServer
@@ -223,7 +226,9 @@ var _ = Describe("Service Manager OSB API", func() {
 		simpleBrokerCatalogID, _, brokerServerWithSimpleCatalog := ctx.RegisterBrokerWithCatalog(simpleCatalog)
 		smUrlToSimpleBrokerCatalogBroker = brokerServerWithSimpleCatalog.URL() + "/v1/osb/" + simpleBrokerCatalogID
 
-		failingBrokerID, _, failingBrokerServer = ctx.RegisterBroker()
+		var failingBrokerObject common.Object
+		failingBrokerID, failingBrokerObject, failingBrokerServer = ctx.RegisterBroker()
+		failingBrokerName = failingBrokerObject["name"].(string)
 		smUrlToFailingBroker = failingBrokerServer.URL() + "/v1/osb/" + failingBrokerID
 
 		UUID, err := uuid.NewV4()
@@ -728,42 +733,23 @@ var _ = Describe("Service Manager OSB API", func() {
 		})
 	})
 
-	Describe("Malfunctioning broker", func() {
-		Context("when broker response is not a valid json", func() {
-			It("should return an OSB compliant error", func() {
-				failingBrokerServer.ServiceInstanceHandler = func(rw http.ResponseWriter, _ *http.Request) {
-					rw.WriteHeader(http.StatusCreated)
-					rw.Write([]byte("[not a json]"))
-				}
-				ctx.SMWithBasic.PUT(smUrlToFailingBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
-					WithJSON(getDummyService()).Expect().Status(http.StatusCreated).JSON().Object().Value("description").String().Match("Service broker .* responded with invalid JSON: \\[not a json\\]")
-			})
-		})
-
-		Context("when broker returns a valid json with no description", func() {
-			It("should return the broker's response", func() {
-				failingBrokerServer.ServiceInstanceHandler = func(rw http.ResponseWriter, _ *http.Request) {
-					rw.WriteHeader(http.StatusBadRequest)
-					rw.Write([]byte("3"))
-				}
-				ctx.SMWithBasic.PUT(smUrlToFailingBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
-					WithJSON(getDummyService()).Expect().Status(http.StatusBadRequest).JSON().Object().Value("description").String().Match("Service broker .* failed with: 3")
-			})
-		})
-
-		Context("when broker response error description is empty", func() {
-			It("should assing default description", func() {
-				failingBrokerServer.ServiceInstanceHandler = func(rw http.ResponseWriter, _ *http.Request) {
-					rw.WriteHeader(http.StatusBadRequest)
-					rw.Write([]byte(`{"error": "ErrorType"}`))
-				}
-				response := ctx.SMWithBasic.PUT(smUrlToFailingBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
-					WithJSON(getDummyService()).Expect().Status(http.StatusBadRequest).JSON().Object()
-				response.Value("description").String().Match("Service broker .* failed with: {}")
-				response.Value("error").String().Match("ErrorType")
-			})
-		})
-	})
+	DescribeTable("Malfunctioning broker",
+		func(statusCode int, responseBody, expectedDescriptionPattern string) {
+			failingBrokerServer.ServiceInstanceHandler = func(rw http.ResponseWriter, _ *http.Request) {
+				rw.Header().Set("Content-Type", "application/json")
+				rw.WriteHeader(statusCode)
+				rw.Write([]byte(responseBody))
+			}
+			expectedDescription := fmt.Sprintf(expectedDescriptionPattern, failingBrokerName)
+			ctx.SMWithBasic.PUT(smUrlToFailingBroker+"/v2/service_instances/12345").WithHeader("X-Broker-API-Version", "oidc_authn.13").
+				WithJSON(getDummyService()).Expect().Status(statusCode).JSON().Object().
+				Value("description").String().Equal(expectedDescription)
+		},
+		Entry("when broker response is not a valid json, should return an OSB compliant error", http.StatusCreated, "[not a json]", "Service broker %s responded with invalid JSON: [not a json]"),
+		Entry("when broker returns a valid json which is not an object, should return the broker's response", http.StatusBadRequest, "3", "Service broker %s failed with: 3"),
+		Entry("when broker response error without description, should assing broker's response body as description", http.StatusBadRequest, `{"error": "ErrorType"}`, `Service broker %s failed with: {"error": "ErrorType"}`),
+		Entry("when broker response is JSON array, should return it in description", http.StatusBadRequest, `[1,2,3]`, `Service broker %s failed with: [1,2,3]`),
+	)
 })
 
 type prefixedBrokerHandler struct {


### PR DESCRIPTION
# Pull Request Template

## Motivation

Sometimes it is hard to know whether the problem for certain OSB calls is because of the Service Manager or the broker itself. This change sends also the name of the broker and its response to the user.