### PR TITLE
Unify response for list operations

### DIFF
--- a/api/base_controller.go
+++ b/api/base_controller.go
@@ -193,12 +193,18 @@ func (c *BaseController) ListObjects(r *web.Request) (*web.Response, error) {
 		return nil, util.HandleStorageError(err, string(c.objectType))
 	}
 
-	for i := 0; i < objectList.Len(); i++ {
-		obj := objectList.ItemAt(i)
-		stripCredentials(ctx, obj)
+	page := types.ObjectPage{
+		Items: make([]types.Object, 0, objectList.Len()),
 	}
 
-	return util.NewJSONResponse(http.StatusOK, objectList)
+	for i := 0; i < objectList.Len(); i++ {
+		page.ItemsCount++
+		obj := objectList.ItemAt(i)
+		stripCredentials(ctx, obj)
+		page.Items = append(page.Items, obj)
+	}
+
+	return util.NewJSONResponse(http.StatusOK, page)
 }
 
 // PatchObject handles the update of the object with the id specified in the request

--- a/pkg/types/interfaces.go
+++ b/pkg/types/interfaces.go
@@ -52,3 +52,9 @@ type ObjectList interface {
 	ItemAt(index int) Object
 	Len() int
 }
+
+// ObjectPage is the DTO for a given page of resources when listing
+type ObjectPage struct {
+	ItemsCount int      `json:"num_items"`
+	Items      []Object `json:"items"`
+}

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -842,7 +842,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							ctx.SMWithOAuth.GET("/v1/service_brokers").
 								Expect().
 								Status(http.StatusOK).
-								JSON().Object().Value("service_brokers").Array().First().Object().
+								JSON().Object().Value("items").Array().First().Object().
 								ContainsMap(expectedBrokerResponse)
 
 							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
@@ -906,7 +906,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON().
-								Path("$.service_offerings[*].catalog_id").Array().NotContains(anotherServiceID)
+								Path("$.items[*].catalog_id").Array().NotContains(anotherServiceID)
 							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + brokerID).
 								WithJSON(common.Object{}).
 								Expect().
@@ -922,11 +922,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON()
-							servicesJsonResp.Path("$.service_offerings[*].catalog_id").Array().Contains(anotherServiceID)
-							servicesJsonResp.Path("$.service_offerings[*].broker_id").Array().Contains(brokerID)
+							servicesJsonResp.Path("$.items[*].catalog_id").Array().Contains(anotherServiceID)
+							servicesJsonResp.Path("$.items[*].broker_id").Array().Contains(brokerID)
 
 							var soID string
-							for _, so := range servicesJsonResp.Object().Value("service_offerings").Array().Iter() {
+							for _, so := range servicesJsonResp.Object().Value("items").Array().Iter() {
 								sbID := so.Object().Value("broker_id").String().Raw()
 								Expect(sbID).ToNot(BeEmpty())
 
@@ -944,8 +944,8 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON()
-							plansJsonResp.Path("$.service_plans[*].catalog_id").Array().Contains(existingPlanID)
-							plansJsonResp.Path("$.service_plans[*].service_offering_id").Array().Contains(soID)
+							plansJsonResp.Path("$.items[*].catalog_id").Array().Contains(existingPlanID)
+							plansJsonResp.Path("$.items[*].service_offering_id").Array().Contains(soID)
 
 							assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 						})
@@ -980,7 +980,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON().
-								Path("$.service_offerings[*].catalog_id").Array().NotContains(anotherServiceID)
+								Path("$.items[*].catalog_id").Array().NotContains(anotherServiceID)
 							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + brokerID).
 								WithJSON(common.Object{}).
 								Expect().
@@ -989,11 +989,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON()
-							servicesJsonResp.Path("$.service_offerings[*].catalog_id").Array().Contains(anotherServiceID)
-							servicesJsonResp.Path("$.service_offerings[*].broker_id").Array().Contains(brokerID)
+							servicesJsonResp.Path("$.items[*].catalog_id").Array().Contains(anotherServiceID)
+							servicesJsonResp.Path("$.items[*].broker_id").Array().Contains(brokerID)
 
 							var soID string
-							for _, so := range servicesJsonResp.Object().Value("service_offerings").Array().Iter() {
+							for _, so := range servicesJsonResp.Object().Value("items").Array().Iter() {
 								sbID := so.Object().Value("broker_id").String().Raw()
 								Expect(sbID).ToNot(BeEmpty())
 
@@ -1011,8 +1011,8 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON()
-							plansJsonResp.Path("$.service_plans[*].catalog_id").Array().Contains(anotherPlanID)
-							plansJsonResp.Path("$.service_plans[*].service_offering_id").Array().Contains(soID)
+							plansJsonResp.Path("$.items[*].catalog_id").Array().Contains(anotherPlanID)
+							plansJsonResp.Path("$.items[*].service_offering_id").Array().Contains(soID)
 
 							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
 						})
@@ -1092,7 +1092,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON().
-								Path("$.service_offerings[*].catalog_id").Array().NotContains(anotherServiceID)
+								Path("$.items[*].catalog_id").Array().NotContains(anotherServiceID)
 
 							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + brokerID).
 								WithJSON(common.Object{}).
@@ -1103,8 +1103,8 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON()
-							jsonResp.Path("$.service_offerings[*].catalog_id").Array().Contains(anotherServiceID)
-							jsonResp.Path("$.service_offerings[*].broker_id").Array().Contains(brokerID)
+							jsonResp.Path("$.items[*].catalog_id").Array().Contains(anotherServiceID)
+							jsonResp.Path("$.items[*].broker_id").Array().Contains(brokerID)
 
 							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
 						})
@@ -1125,7 +1125,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							serviceOfferings := ctx.SMWithOAuth.GET("/v1/service_offerings").
 								Expect().
 								Status(http.StatusOK).
-								JSON().Object().Value("service_offerings").Array().Iter()
+								JSON().Object().Value("items").Array().Iter()
 
 							for _, so := range serviceOfferings {
 								sbID := so.Object().Value("broker_id").String().Raw()
@@ -1149,7 +1149,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							plans := ctx.SMWithOAuth.GET("/v1/service_plans").
 								Expect().
 								Status(http.StatusOK).
-								JSON().Object().Value("service_plans").Array().Iter()
+								JSON().Object().Value("items").Array().Iter()
 
 							var planIDsForService []interface{}
 							for _, plan := range plans {
@@ -1170,12 +1170,12 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							ctx.SMWithOAuth.GET("/v1/service_offerings").
 								Expect().
 								Status(http.StatusOK).
-								JSON().Path("$.service_offerings[*].id").Array().NotContains(serviceOfferingID)
+								JSON().Path("$.items[*].id").Array().NotContains(serviceOfferingID)
 
 							ctx.SMWithOAuth.GET("/v1/service_plans").
 								Expect().
 								Status(http.StatusOK).
-								JSON().Path("$.service_plans[*].id").Array().NotContains(planIDsForService)
+								JSON().Path("$.items[*].id").Array().NotContains(planIDsForService)
 
 							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
 						})
@@ -1262,7 +1262,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							serviceOfferings := ctx.SMWithOAuth.GET("/v1/service_offerings").
 								Expect().
 								Status(http.StatusOK).
-								JSON().Object().Value("service_offerings").Array().Iter()
+								JSON().Object().Value("items").Array().Iter()
 
 							for _, so := range serviceOfferings {
 								sbID := so.Object().Value("broker_id").String().Raw()
@@ -1287,7 +1287,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON().
-								Path("$.service_plans[*].catalog_id").Array().NotContains(anotherPlanID)
+								Path("$.items[*].catalog_id").Array().NotContains(anotherPlanID)
 
 							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + brokerID).
 								WithJSON(common.Object{}).
@@ -1298,8 +1298,8 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON()
-							jsonResp.Path("$.service_plans[*].catalog_id").Array().Contains(anotherPlanID)
-							jsonResp.Path("$.service_plans[*].service_offering_id").Array().Contains(serviceOfferingID)
+							jsonResp.Path("$.items[*].catalog_id").Array().Contains(anotherPlanID)
+							jsonResp.Path("$.items[*].service_offering_id").Array().Contains(serviceOfferingID)
 
 							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
 						})
@@ -1325,7 +1325,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							ctx.SMWithOAuth.GET("/v1/service_plans").
 								Expect().
 								Status(http.StatusOK).
-								JSON().Path("$.service_plans[*].catalog_id").Array().Contains(removedPlanCatalogID)
+								JSON().Path("$.items[*].catalog_id").Array().Contains(removedPlanCatalogID)
 
 							ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + brokerID).
 								WithJSON(common.Object{}).
@@ -1335,7 +1335,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							ctx.SMWithOAuth.GET("/v1/service_plans").
 								Expect().
 								Status(http.StatusOK).
-								JSON().Path("$.service_plans[*].catalog_id").Array().NotContains(removedPlanCatalogID)
+								JSON().Path("$.items[*].catalog_id").Array().NotContains(removedPlanCatalogID)
 
 							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
 						})

--- a/test/delete_list.go
+++ b/test/delete_list.go
@@ -400,8 +400,6 @@ func DescribeDeleteListFor(ctx *common.TestContext, t TestCase) bool {
 	}
 
 	verifyDeleteListOpHelperWithAuth := func(deleteListOpEntry deleteOpEntry, query string, auth *httpexpect.Expect) {
-		jsonArrayKey := strings.Replace(t.API, "/v1/", "", 1)
-
 		expectedAfterOpIDs := make([]string, 0)
 		unexpectedAfterOpIDs := make([]string, 0)
 
@@ -426,7 +424,7 @@ func DescribeDeleteListFor(ctx *common.TestContext, t TestCase) bool {
 			By(fmt.Sprintf("[TEST]: Verifying expected %s before operation are present", t.API))
 			beforeOpArray := ctx.SMWithOAuth.GET(t.API).
 				Expect().
-				Status(http.StatusOK).JSON().Object().Value(jsonArrayKey).Array()
+				Status(http.StatusOK).JSON().Object().Value("items").Array()
 
 			for _, v := range beforeOpArray.Iter() {
 				obj := v.Object().Raw()
@@ -457,7 +455,7 @@ func DescribeDeleteListFor(ctx *common.TestContext, t TestCase) bool {
 		} else {
 			afterOpArray := ctx.SMWithOAuth.GET(t.API).
 				Expect().
-				Status(http.StatusOK).JSON().Object().Value(jsonArrayKey).Array()
+				Status(http.StatusOK).JSON().Object().Value("items").Array()
 
 			for _, v := range afterOpArray.Iter() {
 				obj := v.Object().Raw()

--- a/test/interceptors_test/interceptors_test.go
+++ b/test/interceptors_test/interceptors_test.go
@@ -309,7 +309,7 @@ var _ = Describe("Interceptors", func() {
 				By("should be left with the created platform and the test one only")
 				ctx.SMWithOAuth.GET(web.PlatformsURL).
 					Expect().JSON().Object().
-					Value("platforms").Array().
+					Value("items").Array().
 					Length().Equal(2)
 			})
 		})
@@ -365,7 +365,7 @@ var _ = Describe("Interceptors", func() {
 			It("Should call interceptors in right order", func() {
 				platform := ctx.RegisterPlatform() // Post /v1/platforms
 				ctx.RegisterBroker()
-				plans := ctx.SMWithBasic.GET(web.ServicePlansURL).Expect().JSON().Object().Value("service_plans").Array()
+				plans := ctx.SMWithBasic.GET(web.ServicePlansURL).Expect().JSON().Object().Value("items").Array()
 				planID := plans.First().Object().Value("id").String().Raw()
 				clearStacks()
 				visibility := types.Visibility{
@@ -413,7 +413,7 @@ var _ = Describe("Interceptors", func() {
 				createEntryFunc: func() string {
 					platform := ctx.RegisterPlatform() // Post /v1/platforms
 					ctx.RegisterBroker()
-					plans := ctx.SMWithBasic.GET(web.ServicePlansURL).Expect().JSON().Object().Value("service_plans").Array()
+					plans := ctx.SMWithBasic.GET(web.ServicePlansURL).Expect().JSON().Object().Value("items").Array()
 					planID := plans.First().Object().Value("id").String().Raw()
 					visibility := types.Visibility{
 						PlatformID:    platform.ID,

--- a/test/list.go
+++ b/test/list.go
@@ -309,12 +309,10 @@ func DescribeListTestsFor(ctx *common.TestContext, t TestCase) bool {
 		expectedAfterOpIDs = common.ExtractResourceIDs(listOpEntry.resourcesToExpectAfterOp)
 		unexpectedAfterOpIDs = common.ExtractResourceIDs(listOpEntry.resourcesNotToExpectAfterOp)
 
-		jsonArrayKey := strings.Replace(t.API, "/v1/", "", 1)
-
 		By(fmt.Sprintf("[TEST]: Verifying expected %s before operation after present", t.API))
 		beforeOpArray := ctx.SMWithOAuth.GET(t.API).
 			Expect().
-			Status(http.StatusOK).JSON().Object().Value(jsonArrayKey).Array()
+			Status(http.StatusOK).JSON().Object().Value("items").Array()
 
 		for _, v := range beforeOpArray.Iter() {
 			obj := v.Object().Raw()
@@ -353,7 +351,7 @@ func DescribeListTestsFor(ctx *common.TestContext, t TestCase) bool {
 
 			resp.JSON().Object().Keys().Contains("error", "description")
 		} else {
-			array := resp.JSON().Object().Value(jsonArrayKey).Array()
+			array := resp.JSON().Object().Value("items").Array()
 			for _, v := range array.Iter() {
 				obj := v.Object().Raw()
 				delete(obj, "created_at")

--- a/test/notification_test/notification_test.go
+++ b/test/notification_test/notification_test.go
@@ -175,11 +175,11 @@ var _ = Describe("Notifications Suite", func() {
 				object := ctx.SMWithOAuth.GET("/v1/service_offerings").WithQuery("fieldQuery", "broker_id = "+id).
 					Expect()
 
-				so := object.Status(http.StatusOK).JSON().Object().Value("service_offerings").Array().First()
+				so := object.Status(http.StatusOK).JSON().Object().Value("items").Array().First()
 
 				servicePlanID := ctx.SMWithOAuth.GET("/v1/service_plans").WithQuery("fieldQuery", fmt.Sprintf("service_offering_id = %s", so.Object().Value("id").String().Raw())).
 					Expect().
-					Status(http.StatusOK).JSON().Object().Value("service_plans").Array().First().Object().Value("id").String().Raw()
+					Status(http.StatusOK).JSON().Object().Value("items").Array().First().Object().Value("id").String().Raw()
 				visReqBody["service_plan_id"] = servicePlanID
 
 				platformID := ctx.SMWithOAuth.POST("/v1/platforms").WithJSON(common.GenerateRandomPlatform()).

--- a/test/public_plans_interceptor_test/public_plans_test.go
+++ b/test/public_plans_interceptor_test/public_plans_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Service Manager Public Plans Interceptor", func() {
 	findOneVisibilityForServicePlanID := func(servicePlanID string) map[string]interface{} {
 		vs := ctx.SMWithOAuth.GET("/v1/visibilities").WithQuery("fieldQuery", "service_plan_id = "+servicePlanID).
 			Expect().
-			Status(http.StatusOK).JSON().Object().Value("visibilities").Array()
+			Status(http.StatusOK).JSON().Object().Value("items").Array()
 
 		vs.Length().Equal(1)
 		return vs.First().Object().Raw()
@@ -79,7 +79,7 @@ var _ = Describe("Service Manager Public Plans Interceptor", func() {
 	verifyZeroVisibilityForServicePlanID := func(servicePlanID string) {
 		vs := ctx.SMWithOAuth.GET("/v1/visibilities").WithQuery("fieldQuery", "service_plan_id = "+servicePlanID).
 			Expect().
-			Status(http.StatusOK).JSON().Object().Value("visibilities").Array()
+			Status(http.StatusOK).JSON().Object().Value("items").Array()
 
 		vs.Length().Equal(0)
 	}
@@ -87,7 +87,7 @@ var _ = Describe("Service Manager Public Plans Interceptor", func() {
 	findDatabaseIDForServicePlanByCatalogName := func(catalogServicePlanName string) string {
 		planID := ctx.SMWithOAuth.GET("/v1/service_plans").WithQuery("fieldQuery", "catalog_name = "+catalogServicePlanName).
 			Expect().
-			Status(http.StatusOK).JSON().Object().Value("service_plans").Array().First().Object().Value("id").String().Raw()
+			Status(http.StatusOK).JSON().Object().Value("items").Array().First().Object().Value("id").String().Raw()
 
 		Expect(planID).ToNot(BeEmpty())
 		return planID
@@ -111,7 +111,7 @@ var _ = Describe("Service Manager Public Plans Interceptor", func() {
 
 		ctx.SMWithOAuth.GET("/v1/service_plans").
 			Expect().
-			Status(http.StatusOK).JSON().Path("$.service_plans[*].catalog_id").Array().NotContains(newPublicPlanCatalogID, newPaidPlanCatalogID)
+			Status(http.StatusOK).JSON().Path("$.items[*].catalog_id").Array().NotContains(newPublicPlanCatalogID, newPaidPlanCatalogID)
 		c := common.NewEmptySBCatalog()
 
 		oldPublicPlan := common.GenerateFreeTestPlan()
@@ -223,7 +223,7 @@ var _ = Describe("Service Manager Public Plans Interceptor", func() {
 		It("creates the plan and creates a public visibility for it", func() {
 			ctx.SMWithOAuth.GET("/v1/service_plans").
 				Expect().
-				Status(http.StatusOK).JSON().Path("$.service_plans[*].catalog_id").Array().NotContains(newPublicPlanCatalogID)
+				Status(http.StatusOK).JSON().Path("$.items[*].catalog_id").Array().NotContains(newPublicPlanCatalogID)
 
 			ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + existingBrokerID).
 				WithJSON(common.Object{}).
@@ -248,7 +248,7 @@ var _ = Describe("Service Manager Public Plans Interceptor", func() {
 		It("creates the plan and does not create a new public visibility for it", func() {
 			ctx.SMWithOAuth.GET("/v1/service_plans").
 				Expect().
-				Status(http.StatusOK).JSON().Path("$.service_plans[*].catalog_id").Array().NotContains(newPaidPlanCatalogID)
+				Status(http.StatusOK).JSON().Path("$.items[*].catalog_id").Array().NotContains(newPaidPlanCatalogID)
 
 			ctx.SMWithOAuth.PATCH("/v1/service_brokers/" + existingBrokerID).
 				WithJSON(common.Object{}).
@@ -277,9 +277,9 @@ var _ = Describe("Service Manager Public Plans Interceptor", func() {
 				Expect().
 				Status(http.StatusOK).JSON()
 
-			plan.Path("$.service_plans[*].free").Array().Contains(true)
-			plan.Object().Value("service_plans").Array().Length().Equal(1)
-			planID := plan.Object().Value("service_plans").Array().First().Object().Value("id").String().Raw()
+			plan.Path("$.items[*].free").Array().Contains(true)
+			plan.Object().Value("items").Array().Length().Equal(1)
+			planID := plan.Object().Value("items").Array().First().Object().Value("id").String().Raw()
 			Expect(planID).ToNot(BeEmpty())
 
 			visibilities := findOneVisibilityForServicePlanID(planID)
@@ -326,8 +326,8 @@ var _ = Describe("Service Manager Public Plans Interceptor", func() {
 				Expect().
 				Status(http.StatusOK).JSON()
 
-			plan.Path("$.service_plans[*].free").Array().Contains(false)
-			plan.Object().Value("service_plans").Array().Length().Equal(1)
+			plan.Path("$.items[*].free").Array().Contains(false)
+			plan.Object().Value("items").Array().Length().Equal(1)
 
 			visibilities := findOneVisibilityForServicePlanID(planID)
 			Expect(visibilities["platform_id"]).To(Equal(platformID))

--- a/test/service_offering_test/service_offering_test.go
+++ b/test/service_offering_test/service_offering_test.go
@@ -349,7 +349,7 @@ func blueprint(ctx *common.TestContext, auth *httpexpect.Expect) common.Object {
 
 	so := auth.GET(web.ServiceOfferingsURL).WithQuery("fieldQuery", "broker_id = "+id).
 		Expect().
-		Status(http.StatusOK).JSON().Object().Value("service_offerings").Array().First()
+		Status(http.StatusOK).JSON().Object().Value("items").Array().First()
 
 	return so.Object().Raw()
 }

--- a/test/service_plan_test/service_plan_test.go
+++ b/test/service_plan_test/service_plan_test.go
@@ -349,11 +349,11 @@ func blueprint(ctx *common.TestContext, auth *httpexpect.Expect) common.Object {
 
 	so := auth.GET(web.ServiceOfferingsURL).WithQuery("fieldQuery", "broker_id = "+id).
 		Expect().
-		Status(http.StatusOK).JSON().Object().Value("service_offerings").Array().First()
+		Status(http.StatusOK).JSON().Object().Value("items").Array().First()
 
 	sp := auth.GET(web.ServicePlansURL).WithQuery("fieldQuery", fmt.Sprintf("service_offering_id = %s", so.Object().Value("id").String().Raw())).
 		Expect().
-		Status(http.StatusOK).JSON().Object().Value("service_plans").Array().First()
+		Status(http.StatusOK).JSON().Object().Value("items").Array().First()
 
 	return sp.Object().Raw()
 }

--- a/test/visibility_test/visibility_test.go
+++ b/test/visibility_test/visibility_test.go
@@ -70,7 +70,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 				existingPlanIDs = ctx.SMWithOAuth.GET(web.ServicePlansURL).
 					Expect().Status(http.StatusOK).
-					JSON().Path("$.service_plans[*].id").Array().Raw()
+					JSON().Path("$.items[*].id").Array().Raw()
 				length := len(existingPlanIDs)
 				Expect(length).Should(BeNumerically(">=", 2))
 
@@ -148,7 +148,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				Context("with missing platform id field", func() {
 					It("returns 201 if no visibilities for the plan exist", func() {
 						ctx.SMWithOAuth.GET(web.VisibilitiesURL).
-							Expect().Status(http.StatusOK).JSON().Path("$.visibilities[*].id").Array().NotContains(existingPlanIDs[1])
+							Expect().Status(http.StatusOK).JSON().Path("$.items[*].id").Array().NotContains(existingPlanIDs[1])
 
 						ctx.SMWithOAuth.POST(web.VisibilitiesURL).
 							WithJSON(common.Object{
@@ -168,7 +168,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							Expect().Status(http.StatusCreated)
 
 						ctx.SMWithOAuth.GET(web.VisibilitiesURL).
-							Expect().Status(http.StatusOK).JSON().Path("$.visibilities[*].service_plan_id").Array().Contains(existingPlanIDs[0])
+							Expect().Status(http.StatusOK).JSON().Path("$.items[*].service_plan_id").Array().Contains(existingPlanIDs[0])
 
 						ctx.SMWithOAuth.POST(web.VisibilitiesURL).
 							WithJSON(common.Object{
@@ -752,11 +752,11 @@ func blueprint(setNullFieldsValues bool) func(ctx *common.TestContext, auth *htt
 		object := auth.GET(web.ServiceOfferingsURL).WithQuery("fieldQuery", "broker_id = "+id).
 			Expect()
 
-		so := object.Status(http.StatusOK).JSON().Object().Value("service_offerings").Array().First()
+		so := object.Status(http.StatusOK).JSON().Object().Value("items").Array().First()
 
 		servicePlanID := auth.GET(web.ServicePlansURL).WithQuery("fieldQuery", fmt.Sprintf("service_offering_id = %s", so.Object().Value("id").String().Raw())).
 			Expect().
-			Status(http.StatusOK).JSON().Object().Value("service_plans").Array().First().Object().Value("id").String().Raw()
+			Status(http.StatusOK).JSON().Object().Value("items").Array().First().Object().Value("id").String().Raw()
 		visReqBody["service_plan_id"] = servicePlanID
 		if setNullFieldsValues {
 			platformID := auth.POST(web.PlatformsURL).WithJSON(common.GenerateRandomPlatform()).


### PR DESCRIPTION
## Motivation
All List operations must return the same response scheme

## Approach
```
{
    "num_items": <the number of items returned>,
    "items": [
         { ... }
    ]
}
```