### PR TITLE
Support max_items query parameter

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -45,20 +45,24 @@ const osbVersion = "2.13"
 
 // Settings type to be loaded from the environment
 type Settings struct {
-	TokenIssuerURL string   `mapstructure:"token_issuer_url" description:"url of the token issuer which to use for validating tokens"`
-	ClientID       string   `mapstructure:"client_id" description:"id of the client from which the token must be issued"`
-	TokenBasicAuth bool     `mapstructure:"token_basic_auth" description:"specifies if client credentials to the authorization server should be sent in the header as basic auth (true) or in the body (false)"`
-	ProctedLabels  []string `mapstructure:"protected_labels" description:"defines labels which cannot be modified/added by REST API requests"`
-	OSBVersion     string   `mapstructure:"-"`
+	TokenIssuerURL  string   `mapstructure:"token_issuer_url" description:"url of the token issuer which to use for validating tokens"`
+	ClientID        string   `mapstructure:"client_id" description:"id of the client from which the token must be issued"`
+	TokenBasicAuth  bool     `mapstructure:"token_basic_auth" description:"specifies if client credentials to the authorization server should be sent in the header as basic auth (true) or in the body (false)"`
+	ProctedLabels   []string `mapstructure:"protected_labels" description:"defines labels which cannot be modified/added by REST API requests"`
+	OSBVersion      string   `mapstructure:"-"`
+	MaxPageSize     int      `mapstructure:"max_page_size" description:"maximum number of items that could be returned in a single page"`
+	DefaultPageSize int      `mapstructure:"default_page_size" description:"default number of items returned in a single page if not specified in request"`
 }
 
 // DefaultSettings returns default values for API settings
 func DefaultSettings() *Settings {
 	return &Settings{
-		TokenIssuerURL: "",
-		ClientID:       "",
-		TokenBasicAuth: true, // RFC 6749 section 2.3.1
-		OSBVersion:     osbVersion,
+		TokenIssuerURL:  "",
+		ClientID:        "",
+		TokenBasicAuth:  true, // RFC 6749 section 2.3.1
+		OSBVersion:      osbVersion,
+		MaxPageSize:     200,
+		DefaultPageSize: 50,
 	}
 }
 
@@ -122,6 +126,7 @@ func New(ctx context.Context, options *Options) (*web.API, error) {
 			bearerAuthnFilter,
 			secfilters.NewRequiredAuthnFilter(),
 			&filters.SelectionCriteria{},
+			filters.NewPagingFilter(options.APISettings.DefaultPageSize, options.APISettings.MaxPageSize),
 			filters.NewProtectedLabelsFilter(options.APISettings.ProctedLabels),
 			&filters.PlatformAwareVisibilityFilter{},
 			&filters.PatchOnlyLabelsFilter{},

--- a/api/filters/paging.go
+++ b/api/filters/paging.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import (
+	"context"
+	"fmt"
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/util"
+	"github.com/Peripli/service-manager/pkg/web"
+	"net/http"
+	"strconv"
+)
+
+// PagingFilterName is the name of the paging filter
+const PagingFilterName = "PagingFilter"
+
+// pagingFilter is filter that adds paging criteria to request
+type pagingFilter struct {
+	DefaultPageSize int
+	MaxPageSize     int
+}
+
+// NewPagingFilter returns new paging filter for given default and max page sizes
+func NewPagingFilter(defaultPageSize, maxPageSize int) web.Filter {
+	return &pagingFilter{
+		DefaultPageSize: defaultPageSize,
+		MaxPageSize:     maxPageSize,
+	}
+}
+
+// Name returns the name of the paging filter
+func (*pagingFilter) Name() string {
+	return PagingFilterName
+}
+
+// Run represents the paging middleware function that processes the request and configures needed criteria.
+func (pf *pagingFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
+	ctx := req.Context()
+	maxItems := req.URL.Query().Get("max_items")
+	limit, err := pf.validateMaxItemsQuery(maxItems)
+	if err != nil {
+		return nil, err
+	}
+	ctx = context.WithValue(ctx, "limit", limit)
+	if limit > 0 {
+		ctx, err = query.AddCriteria(ctx, query.LimitResultBy(limit))
+		if err != nil {
+			return nil, err
+		}
+	}
+	req.Request = req.WithContext(ctx)
+	return next.Handle(req)
+}
+
+func (pf *pagingFilter) validateMaxItemsQuery(maxItems string) (int, error) {
+	limit := pf.DefaultPageSize
+	var err error
+	if maxItems != "" {
+		limit, err = strconv.Atoi(maxItems)
+		if err != nil {
+			return -1, &util.HTTPError{
+				ErrorType:   "InvalidMaxItems",
+				Description: fmt.Sprintf("max_items should be integer: %v", err),
+				StatusCode:  http.StatusBadRequest,
+			}
+		}
+		if limit < 0 {
+			return -1, &util.HTTPError{
+				ErrorType:   "InvalidMaxItems",
+				Description: fmt.Sprintf("max_items cannot be negative"),
+				StatusCode:  http.StatusBadRequest,
+			}
+		}
+		if limit > pf.MaxPageSize {
+			limit = pf.MaxPageSize
+		}
+	}
+	return limit, nil
+}
+
+// FilterMatchers implements the web.Filter interface and returns the conditions on which the filter should be executed.
+func (*pagingFilter) FilterMatchers() []web.FilterMatcher {
+	return []web.FilterMatcher{
+		{
+			Matchers: []web.Matcher{
+				web.Methods(http.MethodGet),
+				web.Path(web.PlatformsURL + "/**"),
+			},
+		},
+		{
+			Matchers: []web.Matcher{
+				web.Methods(http.MethodGet),
+				web.Path(web.ServiceBrokersURL + "/**"),
+			},
+		},
+		{
+			Matchers: []web.Matcher{
+				web.Methods(http.MethodGet),
+				web.Path(web.ServiceOfferingsURL + "/**"),
+			},
+		},
+		{
+			Matchers: []web.Matcher{
+				web.Methods(http.MethodGet),
+				web.Path(web.ServicePlansURL + "/**"),
+			},
+		},
+		{
+			Matchers: []web.Matcher{
+				web.Methods(http.MethodGet),
+				web.Path(web.VisibilitiesURL + "/**"),
+			},
+		},
+	}
+}

--- a/api/filters/paging_test.go
+++ b/api/filters/paging_test.go
@@ -1,0 +1,78 @@
+package filters_test
+
+import (
+	"fmt"
+	"github.com/Peripli/service-manager/api/filters"
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/web"
+	"github.com/Peripli/service-manager/pkg/web/webfakes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+)
+
+var _ = Describe("Paging Filter Test", func() {
+	var filter web.Filter
+	var handler *webfakes.FakeHandler
+	var maxItems string
+	var request *web.Request
+
+	JustBeforeEach(func() {
+		filter = filters.NewPagingFilter(50, 200)
+		handler = &webfakes.FakeHandler{}
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://example.com?max_items=%s", maxItems), nil)
+		Expect(err).ShouldNot(HaveOccurred())
+		request = &web.Request{
+			Request: req,
+		}
+	})
+
+	When("max_items is not a number", func() {
+		BeforeEach(func() {
+			maxItems = "invalid"
+		})
+		It("should return error", func() {
+			_, err := filter.Run(request, handler)
+			Expect(err).Should(HaveOccurred())
+			Expect(handler.HandleCallCount()).To(Equal(0))
+		})
+	})
+	When("max_items is negative", func() {
+		BeforeEach(func() {
+			maxItems = "-1"
+		})
+		It("should return error", func() {
+			_, err := filter.Run(request, handler)
+			Expect(err).Should(HaveOccurred())
+			Expect(handler.HandleCallCount()).To(Equal(0))
+		})
+	})
+	When("max_items is positive", func() {
+		BeforeEach(func() {
+			maxItems = "5"
+		})
+		It("should add limit criteria", func() {
+			_, err := filter.Run(request, handler)
+			Expect(err).ShouldNot(HaveOccurred())
+			actualRequest := handler.HandleArgsForCall(0)
+			Expect(query.CriteriaForContext(actualRequest.Context())).To(ContainElement(query.LimitResultBy(5)))
+			Expect(actualRequest.Context().Value("limit").(int)).To(Equal(5))
+		})
+	})
+	When("max_items is 0", func() {
+		BeforeEach(func() {
+			maxItems = "0"
+		})
+		It("should not add limit criteria", func() {
+			_, err := filter.Run(request, handler)
+			Expect(err).ShouldNot(HaveOccurred())
+			actualRequest := handler.HandleArgsForCall(0)
+			criteria := query.CriteriaForContext(actualRequest.Context())
+			for _, criterion := range criteria {
+				Expect(criterion.LeftOp).ToNot(Equal(query.Limit))
+			}
+			Expect(actualRequest.Context().Value("limit").(int)).To(Equal(0))
+		})
+	})
+
+})

--- a/pkg/query/selection.go
+++ b/pkg/query/selection.go
@@ -230,6 +230,9 @@ func mergeCriteria(c1 []Criterion, c2 []Criterion) ([]Criterion, error) {
 		}
 	}
 	result = append(result, c2...)
+	if err := validateWholeCriteria(result...); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -255,8 +258,11 @@ func CriteriaForContext(ctx context.Context) []Criterion {
 }
 
 // ContextWithCriteria returns a new context with given criteria
-func ContextWithCriteria(ctx context.Context, criteria []Criterion) context.Context {
-	return context.WithValue(ctx, criteriaCtxKey{}, criteria)
+func ContextWithCriteria(ctx context.Context, criteria ...Criterion) (context.Context, error) {
+	if err := validateWholeCriteria(criteria...); err != nil {
+		return nil, err
+	}
+	return context.WithValue(ctx, criteriaCtxKey{}, criteria), nil
 }
 
 // BuildCriteriaFromRequest builds criteria for the given request's query params and returns an error if the query is not valid
@@ -330,6 +336,9 @@ func process(input string, criteriaType CriterionType) ([]Criterion, error) {
 			Message: fmt.Sprintf("%s is not a valid %s", input, criteriaType),
 		}
 	}
+	if err := validateWholeCriteria(c...); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 
@@ -397,4 +406,17 @@ func isNumeric(str string) bool {
 func isDateTime(str string) bool {
 	_, err := time.Parse(time.RFC3339, str)
 	return err == nil
+}
+
+func validateWholeCriteria(criteria ...Criterion) error {
+	isLimited := false
+	for _, criterion := range criteria {
+		if criterion.LeftOp == Limit {
+			if isLimited {
+				return fmt.Errorf("zero/one limit criterion expected but multiple provided")
+			}
+			isLimited = true
+		}
+	}
+	return nil
 }

--- a/pkg/query/selection_test.go
+++ b/pkg/query/selection_test.go
@@ -62,6 +62,12 @@ var _ = Describe("Selection", func() {
 				Expect(err).ToNot(HaveOccurred())
 				addInvalidCriterion(ByField(EqualsOrNilOperator, validCriterion.LeftOp, "right op"))
 			})
+			Specify("Multiple limit criteria", func() {
+				var err error
+				ctx, err = AddCriteria(ctx, LimitResultBy(10))
+				Expect(err).ShouldNot(HaveOccurred())
+				addInvalidCriterion(LimitResultBy(5))
+			})
 		})
 
 		Context("Valid", func() {
@@ -86,7 +92,8 @@ var _ = Describe("Selection", func() {
 		Context("When there are no criteria in the context", func() {
 			It("Adds the new ones", func() {
 				newCriteria := []Criterion{ByField(EqualsOperator, "leftOp", "rightOp")}
-				newContext := ContextWithCriteria(ctx, newCriteria)
+				newContext, err := ContextWithCriteria(ctx, newCriteria...)
+				Expect(err).ShouldNot(HaveOccurred())
 				Expect(CriteriaForContext(newContext)).To(ConsistOf(newCriteria))
 			})
 		})
@@ -94,13 +101,25 @@ var _ = Describe("Selection", func() {
 		Context("When there are criteria already in the context", func() {
 			It("Overrides them", func() {
 				oldCriteria := []Criterion{ByField(EqualsOperator, "leftOp", "rightOp")}
-				oldContext := ContextWithCriteria(ctx, oldCriteria)
+				oldContext, err := ContextWithCriteria(ctx, oldCriteria...)
+				Expect(err).ShouldNot(HaveOccurred())
 
 				newCriteria := []Criterion{ByLabel(NotEqualsOperator, "leftOp1", "rightOp1")}
-				newContext := ContextWithCriteria(oldContext, newCriteria)
+				newContext, err := ContextWithCriteria(oldContext, newCriteria...)
+				Expect(err).ShouldNot(HaveOccurred())
+
 				criteriaForNewContext := CriteriaForContext(newContext)
 				Expect(criteriaForNewContext).To(ConsistOf(newCriteria))
 				Expect(criteriaForNewContext).ToNot(ContainElement(oldCriteria[0]))
+			})
+		})
+
+		Context("When limit is already in the context adding it again", func() {
+			It("should return error", func() {
+				ctx, err := ContextWithCriteria(ctx, LimitResultBy(10), LimitResultBy(5))
+				Expect(err).Should(HaveOccurred())
+				Expect(ctx).Should(BeNil())
+
 			})
 		})
 	})

--- a/storage/encrypting_repository.go
+++ b/storage/encrypting_repository.go
@@ -142,6 +142,10 @@ func (er *encryptingRepository) List(ctx context.Context, objectType types.Objec
 	return objList, nil
 }
 
+func (er *encryptingRepository) Count(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (int, error) {
+	return er.repository.Count(ctx, objectType, criteria...)
+}
+
 func (er *encryptingRepository) Update(ctx context.Context, obj types.Object, labelChanges query.LabelChanges, criteria ...query.Criterion) (types.Object, error) {
 	if err := er.transformCredentials(ctx, obj, er.encrypter.Encrypt); err != nil {
 		return nil, err

--- a/storage/interceptable_repository.go
+++ b/storage/interceptable_repository.go
@@ -121,6 +121,10 @@ func (ir *interceptableRepository) List(ctx context.Context, objectType types.Ob
 	return objectList, nil
 }
 
+func (ir *interceptableRepository) Count(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (int, error) {
+	return ir.repositoryInTransaction.Count(ctx, objectType, criteria...)
+}
+
 func (ir *interceptableRepository) Delete(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (types.ObjectList, error) {
 	deleteObjectFunc := func(ctx context.Context, _ Repository, _ types.ObjectList, deletionCriteria ...query.Criterion) (types.ObjectList, error) {
 		objectList, err := ir.repositoryInTransaction.Delete(ctx, objectType, deletionCriteria...)
@@ -314,6 +318,10 @@ func (itr *InterceptableTransactionalRepository) List(ctx context.Context, objec
 	}
 
 	return objectList, nil
+}
+
+func (itr *InterceptableTransactionalRepository) Count(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (int, error) {
+	return itr.smStorageRepository.Count(ctx, objectType, criteria...)
 }
 
 type finalDeleteObjectInterceptor struct {

--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -151,19 +151,22 @@ func (mf PingFunc) PingContext(ctx context.Context) error {
 }
 
 type Repository interface {
-	// Create stores a broker in SM DB
+	// Create stores an object in SM DB
 	Create(ctx context.Context, obj types.Object) (types.Object, error)
 
-	// Get retrieves a broker using the provided id from SM DB
+	// Get retrieves an object using the provided id from SM DB
 	Get(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (types.Object, error)
 
-	// List retrieves all brokers from SM DB
+	// List retrieves all object from SM DB
 	List(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (types.ObjectList, error)
 
-	// Delete deletes a broker from SM DB
+	// Count retrieves number of objects of particular type in SM DB
+	Count(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (int, error)
+
+	// Delete deletes an object from SM DB
 	Delete(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (types.ObjectList, error)
 
-	// Update updates a broker from SM DB
+	// Update updates an object from SM DB
 	Update(ctx context.Context, obj types.Object, labelChanges query.LabelChanges, criteria ...query.Criterion) (types.Object, error)
 }
 

--- a/storage/postgres/query_builder.go
+++ b/storage/postgres/query_builder.go
@@ -103,6 +103,40 @@ func (pgq *pgQuery) List(ctx context.Context, entity PostgresEntity) (*sqlx.Rows
 	return pgq.db.QueryxContext(ctx, pgq.sql.String(), pgq.queryParams...)
 }
 
+func (pgq *pgQuery) Count(ctx context.Context, entity PostgresEntity) (int, error) {
+	if pgq.err != nil {
+		return 0, pgq.err
+	}
+
+	tableName := entity.TableName()
+	labelsEntity := entity.LabelEntity()
+
+	baseQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s %s", tableName, mainTableAlias)
+
+	if labelsEntity != nil {
+		labelsTableName := labelsEntity.LabelsTableName()
+		referenceKeyColumn := labelsEntity.ReferenceColumn()
+		primaryKeyColumn := labelsEntity.LabelsPrimaryColumn()
+		baseQuery += fmt.Sprintf(` LEFT JOIN %[2]s ON %[1]s.%[3]s = %[2]s.%[4]s`,
+			mainTableAlias, labelsTableName, primaryKeyColumn, referenceKeyColumn)
+	}
+
+	pgq.sql.WriteString(baseQuery)
+
+	pgq.orderByFields = nil
+
+	if err := pgq.finalizeSQL(ctx, entity, false); err != nil {
+		return 0, err
+	}
+
+	count := make([]int, 0, 1)
+	err := pgq.db.SelectContext(ctx, &count, pgq.sql.String(), pgq.queryParams...)
+	if len(count) == 0 {
+		count = append(count, 0)
+	}
+	return count[0], err
+}
+
 func (pgq *pgQuery) Delete(ctx context.Context, entity PostgresEntity) (*sqlx.Rows, error) {
 	if pgq.err != nil {
 		return nil, pgq.err

--- a/storage/postgres/storage.go
+++ b/storage/postgres/storage.go
@@ -227,6 +227,14 @@ func (ps *Storage) List(ctx context.Context, objType types.ObjectType, criteria 
 	return entity.RowsToList(rows)
 }
 
+func (ps *Storage) Count(ctx context.Context, objType types.ObjectType, criteria ...query.Criterion) (int, error) {
+	entity, err := ps.scheme.provide(objType)
+	if err != nil {
+		return 0, err
+	}
+	return ps.queryBuilder.NewQuery().WithCriteria(criteria...).WithLock().Count(ctx, entity)
+}
+
 func (ps *Storage) Delete(ctx context.Context, objType types.ObjectType, criteria ...query.Criterion) (types.ObjectList, error) {
 	entity, err := ps.scheme.provide(objType)
 	if err != nil {

--- a/storage/storagefakes/fake_storage.go
+++ b/storage/storagefakes/fake_storage.go
@@ -21,6 +21,21 @@ type FakeStorage struct {
 	closeReturnsOnCall map[int]struct {
 		result1 error
 	}
+	CountStub        func(context.Context, types.ObjectType, ...query.Criterion) (int, error)
+	countMutex       sync.RWMutex
+	countArgsForCall []struct {
+		arg1 context.Context
+		arg2 types.ObjectType
+		arg3 []query.Criterion
+	}
+	countReturns struct {
+		result1 int
+		result2 error
+	}
+	countReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
 	CreateStub        func(context.Context, types.Object) (types.Object, error)
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
@@ -189,6 +204,71 @@ func (fake *FakeStorage) CloseReturnsOnCall(i int, result1 error) {
 	fake.closeReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeStorage) Count(arg1 context.Context, arg2 types.ObjectType, arg3 ...query.Criterion) (int, error) {
+	fake.countMutex.Lock()
+	ret, specificReturn := fake.countReturnsOnCall[len(fake.countArgsForCall)]
+	fake.countArgsForCall = append(fake.countArgsForCall, struct {
+		arg1 context.Context
+		arg2 types.ObjectType
+		arg3 []query.Criterion
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("Count", []interface{}{arg1, arg2, arg3})
+	fake.countMutex.Unlock()
+	if fake.CountStub != nil {
+		return fake.CountStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.countReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStorage) CountCallCount() int {
+	fake.countMutex.RLock()
+	defer fake.countMutex.RUnlock()
+	return len(fake.countArgsForCall)
+}
+
+func (fake *FakeStorage) CountCalls(stub func(context.Context, types.ObjectType, ...query.Criterion) (int, error)) {
+	fake.countMutex.Lock()
+	defer fake.countMutex.Unlock()
+	fake.CountStub = stub
+}
+
+func (fake *FakeStorage) CountArgsForCall(i int) (context.Context, types.ObjectType, []query.Criterion) {
+	fake.countMutex.RLock()
+	defer fake.countMutex.RUnlock()
+	argsForCall := fake.countArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeStorage) CountReturns(result1 int, result2 error) {
+	fake.countMutex.Lock()
+	defer fake.countMutex.Unlock()
+	fake.CountStub = nil
+	fake.countReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStorage) CountReturnsOnCall(i int, result1 int, result2 error) {
+	fake.countMutex.Lock()
+	defer fake.countMutex.Unlock()
+	fake.CountStub = nil
+	if fake.countReturnsOnCall == nil {
+		fake.countReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.countReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeStorage) Create(arg1 context.Context, arg2 types.Object) (types.Object, error) {
@@ -733,6 +813,8 @@ func (fake *FakeStorage) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
+	fake.countMutex.RLock()
+	defer fake.countMutex.RUnlock()
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
 	fake.deleteMutex.RLock()


### PR DESCRIPTION
## Motivation
SM list API must handle the max_items query parameter to determine the maximum number of items to return.
This max_items parameter must not be greater than an internally configured value.

## Approach
Parameter max_items introduces which means maximum number of items to return in the response.If the client sets max_items to 0, it is assumed that the client is only interested in the total number of items.