### PR TITLE
Paging client

### DIFF
--- a/pkg/util/api_test.go
+++ b/pkg/util/api_test.go
@@ -22,18 +22,12 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
-	"testing"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	"github.com/Peripli/service-manager/pkg/util"
-	. "github.com/onsi/gomega"
 )
-
-func TestUtil(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Util test suite")
-}
 
 func validateHTTPErrorOccurred(err error, code int) {
 	Expect(err).Should(HaveOccurred())

--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -78,7 +78,7 @@ func SendRequestWithHeaders(ctx context.Context, doRequest DoRequestFunc, method
 		request.Header.Set(log.CorrelationIDHeaders[0], correlationID)
 	}
 
-	logger.Debugf("Sending a request to %s", request.URL)
+	logger.Debugf("Sending request %s %s", request.Method, request.URL)
 	return doRequest(request)
 }
 

--- a/pkg/util/list.go
+++ b/pkg/util/list.go
@@ -40,7 +40,7 @@ func (li *ListIterator) Next(ctx context.Context, items interface{}, maxItems in
 	}
 
 	if li.done {
-		return false, -1, errors.New("Iteration already complete")
+		return false, -1, errors.New("iteration already complete")
 	}
 
 	params := map[string]string{}

--- a/pkg/util/list.go
+++ b/pkg/util/list.go
@@ -22,9 +22,9 @@ type ListIterator struct {
 }
 
 type listResponse struct {
-	Token    string          `json:"token"`
-	NumItems int64           `json:"num_items"`
-	Items    json.RawMessage `json:"items"`
+	Token    string      `json:"token"`
+	NumItems int64       `json:"num_items"`
+	Items    interface{} `json:"items"`
 }
 
 // Next loads the next page of items
@@ -48,7 +48,6 @@ func (li *ListIterator) Next(ctx context.Context, items interface{}, maxItems in
 
 	method := http.MethodGet
 	url := li.URL
-	var responseBody listResponse
 	response, err := SendRequest(ctx, li.DoRequest, method, url, params, nil)
 	if err != nil {
 		return false, -1, fmt.Errorf("Error sending request %s %s: %s", method, url, err)
@@ -64,15 +63,10 @@ func (li *ListIterator) Next(ctx context.Context, items interface{}, maxItems in
 		return false, -1, fmt.Errorf("error reading response body of request %s %s: %s",
 			method, url, err)
 	}
+	responseBody := listResponse{Items: items}
 	if err = json.Unmarshal(body, &responseBody); err != nil {
 		return false, -1, fmt.Errorf("error parsing response body of request %s %s: %s",
 			method, url, err)
-	}
-	if items != nil {
-		if err = json.Unmarshal(responseBody.Items, items); err != nil {
-			return false, -1, fmt.Errorf("error parsing response items of request %s %s: %s",
-				method, url, err)
-		}
 	}
 
 	li.next = responseBody.Token

--- a/pkg/util/list.go
+++ b/pkg/util/list.go
@@ -1,0 +1,109 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strconv"
+)
+
+// ListIterator lists the objects from the given url by loading one page at a time
+type ListIterator struct {
+	// DoRequest function executes the HTTP request, it is responsible for authentication
+	DoRequest DoRequestFunc
+	// URL is the address of the resource to list
+	URL string
+
+	next string
+	done bool
+}
+
+type listResponse struct {
+	Token    string          `json:"token"`
+	NumItems int64           `json:"num_items"`
+	Items    json.RawMessage `json:"items"`
+}
+
+// Next loads the next page of items
+// items should be a pointer to a slice, that will be populated with the items from the current page,
+// if nil, only the total number is returned
+// maxItems is the maximum numbe of items to load with the next page, -1 - use server default, 0 - just get the count
+// more is true if there are more items
+// count is the total number of items, -1 if not available
+func (li *ListIterator) Next(ctx context.Context, items interface{}, maxItems int) (more bool, count int64, err error) {
+	if li.done {
+		return false, -1, errors.New("Iteration already complete")
+	}
+
+	params := map[string]string{}
+	if maxItems >= 0 {
+		params["max_items"] = strconv.Itoa(maxItems)
+	}
+	if li.next != "" {
+		params["token"] = li.next
+	}
+
+	method := http.MethodGet
+	url := li.URL
+	var responseBody listResponse
+	response, err := SendRequest(ctx, li.DoRequest, method, url, params, nil)
+	if err != nil {
+		return false, -1, fmt.Errorf("Error sending request %s %s: %s", method, url, err)
+	}
+	if response.Request != nil {
+		url = response.Request.URL.String() // should include also the query params
+	}
+	if response.StatusCode != http.StatusOK {
+		return false, -1, HandleResponseError(response)
+	}
+	body, err := BodyToBytes(response.Body)
+	if err != nil {
+		return false, -1, fmt.Errorf("error reading response body of request %s %s: %s",
+			method, url, err)
+	}
+	if err = json.Unmarshal(body, &responseBody); err != nil {
+		return false, -1, fmt.Errorf("error parsing response body of request %s %s: %s",
+			method, url, err)
+	}
+	if items != nil {
+		if err = json.Unmarshal(responseBody.Items, items); err != nil {
+			return false, -1, fmt.Errorf("error parsing response items of request %s %s: %s",
+				method, url, err)
+		}
+	}
+
+	li.next = responseBody.Token
+	li.done = li.next == ""
+	return !li.done, responseBody.NumItems, nil
+}
+
+// ListAll retrieves all the objects from the given url by loading all the pages
+// items should be a pointer to a slice, that will be populated with all the items
+// doRequest function executes the HTTP request, it is responsible for authentication
+func ListAll(ctx context.Context, doRequest DoRequestFunc, url string, items interface{}) error {
+	itemsType := reflect.TypeOf(items)
+	if !(itemsType.Kind() == reflect.Ptr && itemsType.Elem().Kind() == reflect.Slice) {
+		return fmt.Errorf("items should be a pointer to a slice, but got %v", itemsType)
+	}
+
+	allItems := reflect.MakeSlice(itemsType.Elem(), 0, 0)
+	iter := ListIterator{
+		URL:       url,
+		DoRequest: doRequest,
+	}
+	more := true
+	for more {
+		var err error
+		pageSlice := reflect.New(itemsType.Elem())
+		more, _, err = iter.Next(ctx, pageSlice.Interface(), -1)
+		if err != nil {
+			return err
+		}
+		allItems = reflect.AppendSlice(allItems, pageSlice.Elem())
+	}
+	reflect.ValueOf(items).Elem().Set(allItems)
+	return nil
+}

--- a/pkg/util/list.go
+++ b/pkg/util/list.go
@@ -34,6 +34,11 @@ type listResponse struct {
 // more is true if there are more items
 // count is the total number of items, -1 if not available
 func (li *ListIterator) Next(ctx context.Context, items interface{}, maxItems int) (more bool, count int64, err error) {
+	itemsType := reflect.TypeOf(items)
+	if itemsType != nil && (itemsType.Kind() != reflect.Ptr || itemsType.Elem().Kind() != reflect.Slice) {
+		return false, -1, fmt.Errorf("items should be nil or a pointer to a slice, but got %v", itemsType)
+	}
+
 	if li.done {
 		return false, -1, errors.New("Iteration already complete")
 	}
@@ -79,7 +84,7 @@ func (li *ListIterator) Next(ctx context.Context, items interface{}, maxItems in
 // doRequest function executes the HTTP request, it is responsible for authentication
 func ListAll(ctx context.Context, doRequest DoRequestFunc, url string, items interface{}) error {
 	itemsType := reflect.TypeOf(items)
-	if !(itemsType.Kind() == reflect.Ptr && itemsType.Elem().Kind() == reflect.Slice) {
+	if itemsType.Kind() != reflect.Ptr || itemsType.Elem().Kind() != reflect.Slice {
 		return fmt.Errorf("items should be a pointer to a slice, but got %v", itemsType)
 	}
 

--- a/pkg/util/list_test.go
+++ b/pkg/util/list_test.go
@@ -18,6 +18,7 @@ package util_test
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/Peripli/service-manager/pkg/util"
@@ -33,12 +34,15 @@ var _ = Describe("List Utils", func() {
 		expectations common.HTTPExpectations
 		ctx          context.Context
 	)
-	const URL = "http://some.host/resource"
+	const url = "http://some.host/resource"
 
 	BeforeEach(func() {
 		ctx = context.TODO()
 		reaction = common.HTTPReaction{Status: http.StatusOK}
-		expectations = common.HTTPExpectations{URL: URL}
+		expectations = common.HTTPExpectations{
+			URL:    url,
+			Params: map[string]string{},
+		}
 		requestFunc = common.DoHTTP(&reaction, &expectations)
 	})
 
@@ -48,25 +52,170 @@ var _ = Describe("List Utils", func() {
 		BeforeEach(func() {
 			it = util.ListIterator{
 				DoRequest: requestFunc,
-				URL:       URL,
+				URL:       url,
 			}
 		})
 
-		It("Returns the items from the response", func() {
-			reaction.Body = `{
-				"num_items": 2,
-				"items":["aaa","bbb"]
-			}`
-			var items []string
-			more, count, err := it.Next(ctx, items, -1)
-			Expect(err).To(BeNil())
-			Expect(more).To(BeFalse())
-			Expect(count).To(Equal(2))
+		When("Requesting only the count", func() {
+			It("Returns only the count", func() {
+				reaction.Body = `{
+					"num_items": 2,
+					"items":["aaa","bbb"]
+				}`
+				more, count, err := it.Next(ctx, nil, -1)
+				Expect(err).To(BeNil())
+				Expect(more).To(BeFalse())
+				Expect(count).To(Equal(int64(2)))
+			})
+		})
+
+		When("There is only one page of items", func() {
+			It("Returns the items from the response", func() {
+				reaction.Body = `{
+					"num_items": 2,
+					"items":["aaa","bbb"]
+				}`
+				var items []string
+				more, count, err := it.Next(ctx, &items, -1)
+				Expect(err).To(BeNil())
+				Expect(more).To(BeFalse())
+				Expect(count).To(Equal(int64(2)))
+				Expect(items).To(Equal([]string{"aaa", "bbb"}))
+			})
+		})
+
+		When("There are multiple pages of items", func() {
+			It("Requests next page with proper token", func() {
+				var items []string
+
+				By("Requesting the first page")
+				reaction.Body = `{
+					"num_items": 3,
+					"token": "page2",
+					"items":["aaa","bbb"]
+				}`
+				more, count, err := it.Next(ctx, &items, -1)
+				Expect(err).To(BeNil())
+				Expect(more).To(BeTrue())
+				Expect(count).To(Equal(int64(3)))
+
+				By("Requesting the next page - the last one")
+				expectations.Params["token"] = "page2"
+				reaction.Body = `{
+					"num_items": 3,
+					"items":["ccc"]
+				}`
+				more, count, err = it.Next(ctx, &items, -1)
+				Expect(err).To(BeNil())
+				Expect(more).To(BeFalse())
+				Expect(count).To(Equal(int64(3)))
+
+				By("Requesting the next page after the last one")
+				_, _, err = it.Next(ctx, &items, -1)
+				Expect(err.Error()).To(Equal("Iteration already complete"))
+			})
+		})
+
+		When("The page size is provided", func() {
+			It("Sets the max_items parameter", func() {
+				expectations.Params["max_items"] = "5"
+				reaction.Body = `{
+					"num_items": 2,
+					"items":["aaa","bbb"]
+				}`
+				var items []string
+				_, _, err := it.Next(ctx, &items, 5)
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("There is a network error", func() {
+			It("Returns an error", func() {
+				reaction.Err = errors.New("Network error")
+				_, _, err := it.Next(ctx, nil, -1)
+				Expect(err.Error()).To(ContainSubstring("Network error"))
+				Expect(err.Error()).To(ContainSubstring("GET " + url))
+			})
+		})
+
+		When("There the server returns error status", func() {
+			It("Returns an error", func() {
+				reaction.Status = 500
+				_, _, err := it.Next(ctx, nil, -1)
+				Expect(err.Error()).To(ContainSubstring("500"))
+				Expect(err.Error()).To(ContainSubstring("GET " + url))
+			})
+		})
+
+		When("There the response body is invalid JSON", func() {
+			It("Returns an error", func() {
+				reaction.Body = `{`
+				_, _, err := it.Next(ctx, nil, -1)
+				Expect(err.Error()).To(ContainSubstring("error parsing response body"))
+				Expect(err.Error()).To(ContainSubstring("GET " + url))
+			})
 		})
 	})
 
 	Describe("ListAll", func() {
+		When("items is not a pointer to a slice", func() {
+			It("Returns an error", func() {
+				var items string
+				err := util.ListAll(ctx, requestFunc, url, &items)
+				Expect(err.Error()).To(ContainSubstring("items should be a pointer to a slice"))
+			})
+		})
 
+		When("There the server returns error status", func() {
+			It("Returns an error", func() {
+				reaction.Status = 500
+				var items []string
+				err := util.ListAll(ctx, requestFunc, url, &items)
+				Expect(err.Error()).To(ContainSubstring("500"))
+				Expect(err.Error()).To(ContainSubstring("GET " + url))
+			})
+		})
+
+		When("There is a single page", func() {
+			It("Returns all the items", func() {
+				reaction.Body = `{
+					"num_items": 2,
+					"items":["aaa","bbb"]
+				}`
+				var items []string
+				err := util.ListAll(ctx, requestFunc, url, &items)
+				Expect(err).To(BeNil())
+				Expect(items).To(Equal([]string{"aaa", "bbb"}))
+			})
+		})
+
+		When("There are multiple pages", func() {
+			It("Returns all the items", func() {
+				sequence := []common.HTTPCouple{
+					{
+						Reaction: &common.HTTPReaction{
+							Body: `{
+								"num_items": 3,
+								"token": "page2",
+								"items":["aaa","bbb"]
+							}`,
+						},
+					},
+					{
+						Reaction: &common.HTTPReaction{
+							Body: `{
+								"num_items": 3,
+								"items":["ccc"]
+							}`,
+						},
+					},
+				}
+				var items []string
+				err := util.ListAll(ctx, common.DoHTTPSequence(sequence), url, &items)
+				Expect(err).To(BeNil())
+				Expect(items).To(Equal([]string{"aaa", "bbb", "ccc"}))
+			})
+		})
 	})
 
 })

--- a/pkg/util/list_test.go
+++ b/pkg/util/list_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package util_test
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Peripli/service-manager/pkg/util"
+	"github.com/Peripli/service-manager/test/common"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("List Utils", func() {
+	var (
+		requestFunc  func(*http.Request) (*http.Response, error)
+		reaction     common.HTTPReaction
+		expectations common.HTTPExpectations
+		ctx          context.Context
+	)
+	const URL = "http://some.host/resource"
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		reaction = common.HTTPReaction{Status: http.StatusOK}
+		expectations = common.HTTPExpectations{URL: URL}
+		requestFunc = common.DoHTTP(&reaction, &expectations)
+	})
+
+	Describe("ListIterator", func() {
+		var it util.ListIterator
+
+		BeforeEach(func() {
+			it = util.ListIterator{
+				DoRequest: requestFunc,
+				URL:       URL,
+			}
+		})
+
+		It("Returns the items from the response", func() {
+			reaction.Body = `{
+				"num_items": 2,
+				"items":["aaa","bbb"]
+			}`
+			var items []string
+			more, count, err := it.Next(ctx, items, -1)
+			Expect(err).To(BeNil())
+			Expect(more).To(BeFalse())
+			Expect(count).To(Equal(2))
+		})
+	})
+
+	Describe("ListAll", func() {
+
+	})
+
+})

--- a/pkg/util/list_test.go
+++ b/pkg/util/list_test.go
@@ -56,6 +56,14 @@ var _ = Describe("List Utils", func() {
 			}
 		})
 
+		When("items is not a pointer to a slice", func() {
+			It("Returns an error", func() {
+				var items string
+				_, _, err := it.Next(ctx, &items, -1)
+				Expect(err.Error()).To(ContainSubstring("*string"))
+			})
+		})
+
 		When("Requesting only the count", func() {
 			It("Returns only the count", func() {
 				reaction.Body = `{

--- a/pkg/util/list_test.go
+++ b/pkg/util/list_test.go
@@ -120,7 +120,7 @@ var _ = Describe("List Utils", func() {
 
 				By("Requesting the next page after the last one")
 				_, _, err = it.Next(ctx, &items, -1)
-				Expect(err.Error()).To(Equal("Iteration already complete"))
+				Expect(err.Error()).To(Equal("iteration already complete"))
 			})
 		})
 

--- a/pkg/util/list_test.go
+++ b/pkg/util/list_test.go
@@ -194,6 +194,7 @@ var _ = Describe("List Utils", func() {
 				sequence := []common.HTTPCouple{
 					{
 						Reaction: &common.HTTPReaction{
+							Status: http.StatusOK,
 							Body: `{
 								"num_items": 3,
 								"token": "page2",
@@ -203,6 +204,7 @@ var _ = Describe("List Utils", func() {
 					},
 					{
 						Reaction: &common.HTTPReaction{
+							Status: http.StatusOK,
 							Body: `{
 								"num_items": 3,
 								"items":["ccc"]

--- a/pkg/util/util_suite_test.go
+++ b/pkg/util/util_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util test suite")
+}

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -434,3 +434,17 @@ func DoHTTP(reaction *HTTPReaction, checks *HTTPExpectations) func(*http.Request
 		}, reaction.Err
 	}
 }
+
+type HTTPCouple struct {
+	Expectations *HTTPExpectations
+	Reaction     *HTTPReaction
+}
+
+func DoHTTPSequence(sequence []HTTPCouple) func(*http.Request) (*http.Response, error) {
+	i := 0
+	return func(request *http.Request) (*http.Response, error) {
+		r, err := DoHTTP(sequence[i].Reaction, sequence[i].Expectations)(request)
+		i++
+		return r, err
+	}
+}


### PR DESCRIPTION
## Motivation

Common client utility for iterating through pages

## Approach

Two usages are supported:
* iterator - load one page at a time, do not keep all the items in memory
* load all items - load all the items in memory by iterating through all the pages
 
## Pull Request status
* [x] Initial implementation
* [x] Unit tests