### PR TITLE
Trim down interceptable repository code

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -277,7 +277,7 @@
     "scram",
   ]
   pruneopts = "UT"
-  revision = "931b5ae4c24e6810c8c82ab4734904de3df1c3dc"
+  revision = "f91d3411e481ed313eeab65ebfe9076466c39d01"
 
 [[projects]]
   digest = "1:5a0ef768465592efca0412f7e838cdc0826712f8447e70e6ccc52eb441e9ab13"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -248,8 +248,8 @@
     "zlib",
   ]
   pruneopts = "UT"
-  revision = "29f61c4f7dec01b2cc59c562f290fe1cc441eaef"
-  version = "v1.8.5"
+  revision = "da9470192e5d0ad619defde5ded583e5e907d3e8"
+  version = "v1.8.6"
 
 [[projects]]
   digest = "1:923c4d7194b42e054b2eb8a6c62824ac55e23ececc1c7e48d4da69c971c55954"
@@ -570,7 +570,7 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "34f69633bfdcf9db92f698f8487115767eebef81"
+  revision = "87dc89f01550277dc22b74ffcf4cd89fa2f40f4c"
 
 [[projects]]
   branch = "master"
@@ -586,7 +586,7 @@
     "publicsuffix",
   ]
   pruneopts = "UT"
-  revision = "d66e71096ffb9f08f36d9aefcae80ce319de6d68"
+  revision = "da9a3fd4c5820e74b24a6cb7fb438dc9b0dd377c"
 
 [[projects]]
   branch = "master"
@@ -605,7 +605,7 @@
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "06d7bd2c5f4f4a6cc6e910b611851044253bd7d1"
+  revision = "b09406accb4736d857a32bf9444cd7edae2ffa79"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"

--- a/api/base_controller.go
+++ b/api/base_controller.go
@@ -293,7 +293,7 @@ func (c *BaseController) PatchObject(r *web.Request) (*web.Response, error) {
 	labels, _, _ := query.ApplyLabelChangesToLabels(labelChanges, objFromDB.GetLabels())
 	objFromDB.SetLabels(labels)
 
-	object, err := c.repository.Update(ctx, objFromDB, labelChanges)
+	object, err := c.repository.Update(ctx, objFromDB, labelChanges, criteria...)
 	if err != nil {
 		return nil, util.HandleStorageError(err, string(c.objectType))
 	}

--- a/storage/interceptable_repository.go
+++ b/storage/interceptable_repository.go
@@ -469,17 +469,18 @@ func (itr *InterceptableTransactionalRepository) validateDeleteProviders(objectT
 }
 
 func validateProviderOrder(order InterceptorOrder, existingProviderNames []string, providerName string) {
-	positionAroundTx, aroundTxName := order.AroundTxPosition.PositionType, order.AroundTxPosition.Name
-	positionTx, nameTx := order.OnTxPosition.PositionType, order.OnTxPosition.Name
 	if providerWithNameExists(existingProviderNames, providerName) {
 		log.D().Panicf("%s create interceptor provider is already registered", providerName)
 	}
 
+	positionAroundTx, aroundTxName := order.AroundTxPosition.PositionType, order.AroundTxPosition.Name
 	if positionAroundTx != PositionNone {
 		if !providerWithNameExists(existingProviderNames, aroundTxName) {
 			log.D().Panicf("could not find interceptor with name %s", aroundTxName)
 		}
 	}
+
+	positionTx, nameTx := order.OnTxPosition.PositionType, order.OnTxPosition.Name
 	if positionTx != PositionNone {
 		if !providerWithNameExists(existingProviderNames, nameTx) {
 			log.D().Panicf("could not find interceptor with name %s", nameTx)

--- a/storage/interceptable_repository.go
+++ b/storage/interceptable_repository.go
@@ -343,7 +343,7 @@ func (itr *InterceptableTransactionalRepository) Update(ctx context.Context, obj
 
 		if err = itr.smStorageRepository.InTransaction(ctx, func(ctx context.Context, txStorage Repository) error {
 			interceptableRepository := newInterceptableRepository(txStorage, providedCreateInterceptors, providedUpdateInterceptors, providedDeleteInterceptors)
-			result, err = interceptableRepository.Update(ctx, obj, labelChanges)
+			result, err = interceptableRepository.Update(ctx, obj, labelChanges, criteria...)
 			if err != nil {
 				return err
 			}

--- a/storage/interceptable_repository.go
+++ b/storage/interceptable_repository.go
@@ -50,7 +50,6 @@ func newInterceptableRepository(repository Repository,
 	}
 }
 
-// InterceptableTransactionalRepository wraps a TransactionalRepository and holds sets of ordered interceptor providers for each object type
 type InterceptableTransactionalRepository struct {
 	smStorageRepository TransactionalRepository
 

--- a/storage/interceptable_repository.go
+++ b/storage/interceptable_repository.go
@@ -59,7 +59,7 @@ type InterceptableTransactionalRepository struct {
 }
 
 // interceptableRepository wraps a Repository to be used throughout a transaction (in all OnTx interceptors).
-// It also holds sets of interceptors for each object type to run inside the transaction lifecycle
+// It also holds sets of interceptors for each object type to run inside the transaction lifecycle.
 type interceptableRepository struct {
 	repositoryInTransaction Repository
 

--- a/storage/interceptable_repository.go
+++ b/storage/interceptable_repository.go
@@ -59,7 +59,8 @@ type InterceptableTransactionalRepository struct {
 	deleteProviders map[types.ObjectType][]OrderedDeleteInterceptorProvider
 }
 
-// interceptableRepository wraps a Repository to be used throughout a transaction (in all OnTx interceptors); it also holds sets of interceptors for each object types to run inside the transaction lifecycle
+// interceptableRepository wraps a Repository to be used throughout a transaction (in all OnTx interceptors).
+// It also holds sets of interceptors for each object type to run inside the transaction lifecycle
 type interceptableRepository struct {
 	repositoryInTransaction Repository
 
@@ -427,6 +428,7 @@ func providerWithNameExists(existingNames []string, orderedRelativeTo string) bo
 	return false
 }
 
+// provideInterceptors generates Create/Update/DeleteInterceptorChains from the provided OrderedCreate/Update/DeleteInterceptorProviders
 func (itr *InterceptableTransactionalRepository) provideInterceptors() (map[types.ObjectType]CreateInterceptor, map[types.ObjectType]UpdateInterceptor, map[types.ObjectType]DeleteInterceptor) {
 	providedCreateInterceptors := make(map[types.ObjectType]CreateInterceptor)
 	for objectType, providers := range itr.createProviders {

--- a/storage/interceptors_create.go
+++ b/storage/interceptors_create.go
@@ -23,6 +23,8 @@ import (
 	"github.com/Peripli/service-manager/pkg/types"
 )
 
+// CreateInterceptorChain holds a mapping of aroundTx and onTx funcs with their respective names.
+// Using the ordered string slices aroundTxNames and onTxNames the funcs in the two maps can be wrapped in the correct order.
 type CreateInterceptorChain struct {
 	aroundTxNames []string
 	aroundTxFuncs map[string]func(InterceptCreateAroundTxFunc) InterceptCreateAroundTxFunc
@@ -35,6 +37,7 @@ func (c *CreateInterceptorChain) Name() string {
 	return "CreateInterceptorChain"
 }
 
+// AroundTxCreate wraps the provided InterceptCreateAroundTxFunc into all the existing aroundTx funcs
 func (c *CreateInterceptorChain) AroundTxCreate(f InterceptCreateAroundTxFunc) InterceptCreateAroundTxFunc {
 	for i := range c.aroundTxNames {
 		f = c.aroundTxFuncs[c.aroundTxNames[len(c.aroundTxNames)-1-i]](f)
@@ -42,6 +45,7 @@ func (c *CreateInterceptorChain) AroundTxCreate(f InterceptCreateAroundTxFunc) I
 	return f
 }
 
+// OnTxCreate wraps the provided InterceptCreateOnTxFunc into all the existing onTx funcs
 func (c *CreateInterceptorChain) OnTxCreate(f InterceptCreateOnTxFunc) InterceptCreateOnTxFunc {
 	for i := range c.onTxNames {
 		f = c.onTxFuncs[c.onTxNames[len(c.onTxNames)-1-i]](f)
@@ -89,6 +93,8 @@ type CreateInterceptor interface {
 	OnTxCreate(f InterceptCreateOnTxFunc) InterceptCreateOnTxFunc
 }
 
+// insertName inserts the given newInterceptorName into it's the expected position.
+// The resulting names slice can then be used to wrap all interceptors into the right order
 func insertName(names []string, positionType PositionType, name, newInterceptorName string) []string {
 	if positionType == PositionNone {
 		names = append(names, newInterceptorName)

--- a/storage/postgres/storage.go
+++ b/storage/postgres/storage.go
@@ -255,7 +255,7 @@ func (ps *Storage) Delete(ctx context.Context, objType types.ObjectType, criteri
 	return objectList, nil
 }
 
-func (ps *Storage) Update(ctx context.Context, obj types.Object, labelChanges query.LabelChanges, criteria ...query.Criterion) (types.Object, error) {
+func (ps *Storage) Update(ctx context.Context, obj types.Object, labelChanges query.LabelChanges, _ ...query.Criterion) (types.Object, error) {
 	entity, err := ps.scheme.convert(obj)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Trim down interceptable repository code

## Motivation

The implementation of _InterceptableTransactionalRepository_ is similar to _interceptableRepository_, but it still differed in some subtle ways, like introducing intermediary structs like * finalCreateObjectInterceptor*. This PR eliminates the intermediary structs and tries to make both repository implementations more similar.

Also added some docs to some package and public structs as I thought it would be beneficial for later on.

## Approach

Refactor _InterceptableTransactionalRepository_ to be similar to _interceptableRepository_ by removing unnecessary code.

## Pull Request status

For example:

* [x] Initial implementation
* [x] Refactoring