### PR TITLE
Manage platform status during ping/pong flow

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,15 +9,15 @@
   revision = "852fc940e4b9b895dc144b88ee8f6e39228127b0"
 
 [[projects]]
-  digest = "1:12156f9d8523585d9d875a03c4b5c6c6374f7370716cd814aa6781732ac942c5"
+  digest = "1:43ac38976d1da4ea8bbb37da4e6baca6127b1c19860104b7e84c28d112f3134c"
   name = "github.com/InVisionApp/go-health"
   packages = [
     ".",
     "checkers",
   ]
   pruneopts = "UT"
-  revision = "06e1878ab5a8acf6e841861c6cbfcc4d3036add0"
-  version = "v2.1.0"
+  revision = "a4a89dc763c320ee165018886368a202bdcffb87"
+  version = "v2.1.2"
 
 [[projects]]
   digest = "1:be2deb3cba3d2526b3692d80483f59df6462aabc875aace2db263f2664f30670"
@@ -229,7 +229,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2c7f9e2e9c7729a1785f57f95e0bbfddc384f11073e8213994d11113210644a0"
+  digest = "1:a9f806e41fa14a1c88641efeecaffdb05f1728a4ed423c3233cdd4fd1f6d2801"
   name = "github.com/jmoiron/sqlx"
   packages = [
     ".",
@@ -237,7 +237,7 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "38398a30ed8516ffda617a04c822de09df8a3ec5"
+  revision = "d7d95172beb5a538ff08c50a6e98aee6e7c41f40"
 
 [[projects]]
   digest = "1:caa1da085cc12cd39d3ddb267434902f621050e1b46f7e9477b2b933df680193"
@@ -248,8 +248,8 @@
     "zlib",
   ]
   pruneopts = "UT"
-  revision = "7a422a2abf4b2f2905a961d3b6926e4e21dab4bb"
-  version = "v1.8.0"
+  revision = "29f61c4f7dec01b2cc59c562f290fe1cc441eaef"
+  version = "v1.8.5"
 
 [[projects]]
   digest = "1:923c4d7194b42e054b2eb8a6c62824ac55e23ececc1c7e48d4da69c971c55954"
@@ -277,7 +277,7 @@
     "scram",
   ]
   pruneopts = "UT"
-  revision = "78223426e7c66d631117c0a9da1b7f3fde4d23a5"
+  revision = "931b5ae4c24e6810c8c82ab4734904de3df1c3dc"
 
 [[projects]]
   digest = "1:5a0ef768465592efca0412f7e838cdc0826712f8447e70e6ccc52eb441e9ab13"
@@ -312,7 +312,7 @@
   version = "v0.4.1"
 
 [[projects]]
-  digest = "1:bb964139623533b324969bf9c50bf30e5be0206f6d6e75f2f7c1c4b3c8407337"
+  digest = "1:264ad793409edc174dc6c54b8049835d182c634e0ffa700854dde98f6d23e67f"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -336,8 +336,8 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "7e8b50db0c6d0a15ac0eb015d4ca64e7e7e2c88c"
-  version = "v1.9.0"
+  revision = "72b6ab036f78c4bf1a9748c3941dd7c3de54917a"
+  version = "v1.10.2"
 
 [[projects]]
   digest = "1:e42321c3ec0ff36c0644da60c2c1469886b214134286f4610199b704619e11a3"
@@ -362,12 +362,12 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:93131d8002d7025da13582877c32d1fc302486775a1b06f62241741006428c5e"
+  digest = "1:bbd3997f0121200f72b64d7a3826eb8a0b910d6a4c19894c9fe2852b9e5eaf3b"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
   pruneopts = "UT"
-  revision = "728039f679cbcd4f6a54e080d2219a4c4928c546"
-  version = "v1.4.0"
+  revision = "8fe62057ea2d46ce44254c98e84e810044dbe197"
+  version = "v1.5.0"
 
 [[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
@@ -511,11 +511,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d9464a87e24a9703fd6b9b27b3592559eb7f5886285d724cb0acd62d00a5ddbf"
+  digest = "1:87fe9bca786484cef53d52adeec7d1c52bc2bfbee75734eddeb75fc5c7023871"
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
   pruneopts = "UT"
-  revision = "df4f5c81cb3b310899c091852a576ea7d178aedb"
+  revision = "02993c407bfbf5f6dae44c4f4b1cf6a39b5fc5bb"
 
 [[projects]]
   branch = "master"
@@ -570,11 +570,11 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "60c769a6c58655dab1b9adac0d58967dd517cfba"
+  revision = "34f69633bfdcf9db92f698f8487115767eebef81"
 
 [[projects]]
   branch = "master"
-  digest = "1:f6e2a855d736113a66b672f84d411ec89f4d2a870faa37cf50d20f1a62278624"
+  digest = "1:79d53f788fe8dddfeb6dcece31eee1bc8cda60b6c8250819e8892bcccc123774"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -586,7 +586,7 @@
     "publicsuffix",
   ]
   pruneopts = "UT"
-  revision = "74dc4d7220e7acc4e100824340f3e66577424772"
+  revision = "d66e71096ffb9f08f36d9aefcae80ce319de6d68"
 
 [[projects]]
   branch = "master"
@@ -601,11 +601,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:47844666be86089349a441f5f0ece22f42a87a8cb8c9a31294c593f43209ad19"
+  digest = "1:7c927f17d868be652a4cfe7de23e4292dea5b14d974a1d536e3b7cb7e79fd695"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "fb81701db80f1745f51259b1f286de3fe2ec80c8"
+  revision = "06d7bd2c5f4f4a6cc6e910b611851044253bd7d1"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"
@@ -645,7 +645,7 @@
   version = "v0.3.2"
 
 [[projects]]
-  digest = "1:6eb6e3b6d9fffb62958cf7f7d88dbbe1dd6839436b0802e194c590667a40412a"
+  digest = "1:e0a1881f9e0564bebdeac98c75e59f07acdde6ed3a5396e0e613eaad31194866"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -657,8 +657,8 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
-  version = "v1.6.1"
+  revision = "971852bfffca25b069c31162ae8f247a3dba083b"
+  version = "v1.6.5"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
@@ -690,12 +690,12 @@
   revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
-  digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
+  digest = "1:59f10c1537d2199d9115d946927fe31165959a95190849c82ff11e05803528b0"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
-  version = "v2.2.2"
+  revision = "f221b8435cfb71e54062f6c6e99e9ade30b124d5"
+  version = "v2.2.4"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/api/api.go
+++ b/api/api.go
@@ -75,7 +75,7 @@ func (s *Settings) Validate() error {
 }
 
 type Options struct {
-	Repository  storage.Repository
+	Repository  storage.TransactionalRepository
 	APISettings *Settings
 	WSSettings  *ws.Settings
 	Notificator storage.Notificator

--- a/api/notifications/notification_controller.go
+++ b/api/notifications/notification_controller.go
@@ -30,7 +30,7 @@ import (
 // Controller implements api.Controller by providing service plans API logic
 type Controller struct {
 	baseCtx    context.Context
-	repository storage.Repository
+	repository storage.TransactionalRepository
 
 	wsSettings  *ws.Settings
 	notificator storage.Notificator
@@ -50,7 +50,7 @@ func (c *Controller) Routes() []web.Route {
 }
 
 // NewController creates new notifications controller
-func NewController(baseCtx context.Context, repository storage.Repository, wsSettings *ws.Settings, notificator storage.Notificator) *Controller {
+func NewController(baseCtx context.Context, repository storage.TransactionalRepository, wsSettings *ws.Settings, notificator storage.Notificator) *Controller {
 	return &Controller{
 		baseCtx:     baseCtx,
 		repository:  repository,

--- a/api/notifications/notifications.go
+++ b/api/notifications/notifications.go
@@ -138,12 +138,10 @@ func (c *Controller) readLoop(ctx context.Context, repository storage.Transactio
 		// currently we don't expect to receive something else from the proxies
 		_, _, err := conn.ReadMessage()
 		if err != nil {
-			if storageErr := updatePlatformStatus(ctx, repository, platform.ID, false); storageErr != nil {
-				log.C(ctx).WithError(storageErr).Error("could not update platform status")
-				return
-			}
-
 			log.C(ctx).WithError(err).Error("ws: could not read")
+			if err = updatePlatformStatus(ctx, repository, platform.ID, false); err != nil {
+				log.C(ctx).WithError(err).Error("could not update platform status")
+			}
 			return
 		}
 	}

--- a/api/notifications/notifications.go
+++ b/api/notifications/notifications.go
@@ -202,7 +202,7 @@ func updatePlatformStatus(ctx context.Context, repository storage.TransactionalR
 
 		if platform.Active != desiredStatus {
 			platform.Active = desiredStatus
-			if desiredStatus == false {
+			if !platform.Active {
 				platform.LastActive = time.Now()
 			}
 

--- a/api/notifications/notifications.go
+++ b/api/notifications/notifications.go
@@ -75,7 +75,7 @@ func (c *Controller) handleWS(req *web.Request) (*web.Response, error) {
 		responseHeaders.Add(LastKnownRevisionHeader, strconv.FormatInt(lastKnownToSMRevision, 10))
 	}
 
-	conn, err := c.upgrade(c.repository, platform, rw, req.Request, responseHeaders)
+	conn, err := c.upgrade(childCtx, c.repository, platform, rw, req.Request, responseHeaders)
 	if err != nil {
 		c.unregisterConsumer(ctx, notificationQueue)
 		return nil, err

--- a/api/notifications/notifications.go
+++ b/api/notifications/notifications.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Peripli/service-manager/pkg/query"
 	"net/http"
 	"strconv"
 	"time"
@@ -74,7 +75,7 @@ func (c *Controller) handleWS(req *web.Request) (*web.Response, error) {
 		responseHeaders.Add(LastKnownRevisionHeader, strconv.FormatInt(lastKnownToSMRevision, 10))
 	}
 
-	conn, err := c.upgrade(rw, req.Request, responseHeaders)
+	conn, err := c.upgrade(c.repository, platform, rw, req.Request, responseHeaders)
 	if err != nil {
 		c.unregisterConsumer(ctx, notificationQueue)
 		return nil, err
@@ -84,7 +85,7 @@ func (c *Controller) handleWS(req *web.Request) (*web.Response, error) {
 
 	go c.closeConn(childCtx, childCtxCancel, conn, done)
 	go c.writeLoop(childCtx, conn, notificationQueue, done)
-	go c.readLoop(childCtx, conn, done)
+	go c.readLoop(childCtx, c.repository, platform, conn, done)
 
 	return &web.Response{}, nil
 }
@@ -121,7 +122,7 @@ func (c *Controller) writeLoop(ctx context.Context, conn *websocket.Conn, q stor
 	}
 }
 
-func (c *Controller) readLoop(ctx context.Context, conn *websocket.Conn, done chan<- struct{}) {
+func (c *Controller) readLoop(ctx context.Context, repository storage.TransactionalRepository, platform *types.Platform, conn *websocket.Conn, done chan<- struct{}) {
 	defer func() {
 		if err := recover(); err != nil {
 			log.C(ctx).Errorf("recovered from panic while reading from websocket connection: %s", err)
@@ -137,6 +138,15 @@ func (c *Controller) readLoop(ctx context.Context, conn *websocket.Conn, done ch
 		// currently we don't expect to receive something else from the proxies
 		_, _, err := conn.ReadMessage()
 		if err != nil {
+			storageErr := updatePlatform(ctx, repository, platform.ID, func(p *types.Platform) {
+				p.Active = false
+				p.LastActive = time.Now()
+			})
+			if storageErr != nil {
+				log.C(ctx).WithError(storageErr).Error("could not update platform status")
+				return
+			}
+
 			log.C(ctx).WithError(err).Error("ws: could not read")
 			return
 		}
@@ -177,4 +187,30 @@ func newContextWithCorrelationID(baseCtx context.Context, correlationID string) 
 	entry := log.C(baseCtx).WithField(log.FieldCorrelationID, correlationID)
 	newCtx := log.ContextWithLogger(baseCtx, entry)
 	return context.WithCancel(newCtx)
+}
+
+func updatePlatform(ctx context.Context, repository storage.TransactionalRepository, platformID string, updatePlatformFunc func(p *types.Platform)) error {
+	if err := repository.InTransaction(ctx, func(ctx context.Context, storage storage.Repository) error {
+		idCriteria := query.Criterion{
+			LeftOp:   "id",
+			Operator: query.EqualsOperator,
+			RightOp:  []string{platformID},
+			Type:     query.FieldQuery,
+		}
+		obj, err := storage.Get(ctx, types.PlatformType, idCriteria)
+		if err != nil {
+			return err
+		}
+
+		platform := obj.(*types.Platform)
+		updatePlatformFunc(platform)
+
+		if _, err := storage.Update(ctx, platform, nil); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/api/notifications/ws_connection.go
+++ b/api/notifications/ws_connection.go
@@ -2,6 +2,8 @@ package notifications
 
 import (
 	"context"
+	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/Peripli/service-manager/storage"
 	"net"
 	"net/http"
 	"time"
@@ -16,7 +18,7 @@ const (
 	MaxPingPeriodHeader = "max_ping_period"
 )
 
-func (c *Controller) upgrade(rw http.ResponseWriter, req *http.Request, header http.Header) (*websocket.Conn, error) {
+func (c *Controller) upgrade(repository storage.TransactionalRepository, platform *types.Platform, rw http.ResponseWriter, req *http.Request, header http.Header) (*websocket.Conn, error) {
 	if header == nil {
 		header = http.Header{}
 	}
@@ -36,12 +38,12 @@ func (c *Controller) upgrade(rw http.ResponseWriter, req *http.Request, header h
 	if err != nil {
 		return nil, err
 	}
-	c.configureConn(req.Context(), conn)
+	c.configureConn(req.Context(), repository, platform, conn)
 
 	return conn, nil
 }
 
-func (c *Controller) configureConn(ctx context.Context, conn *websocket.Conn) {
+func (c *Controller) configureConn(ctx context.Context, repository storage.TransactionalRepository, platform *types.Platform, conn *websocket.Conn) {
 	if err := conn.SetReadDeadline(time.Now().Add(c.wsSettings.PingTimeout)); err != nil {
 		log.C(ctx).WithError(err).Error("Could not set read deadline")
 	}
@@ -51,8 +53,23 @@ func (c *Controller) configureConn(ctx context.Context, conn *websocket.Conn) {
 			return err
 		}
 
-		err := conn.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(c.wsSettings.WriteTimeout))
+		err := updatePlatform(ctx, repository, platform.ID, func(p *types.Platform) {
+			p.Active = true
+		})
 		if err != nil {
+			return err
+		}
+
+		err = conn.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(c.wsSettings.WriteTimeout))
+		if err != nil {
+			storageErr := updatePlatform(ctx, repository, platform.ID, func(p *types.Platform) {
+				p.Active = false
+				p.LastActive = time.Now()
+			})
+			if storageErr != nil {
+				return storageErr
+			}
+
 			log.C(ctx).WithError(err).Error("Could not send pong message")
 			if err == websocket.ErrCloseSent {
 				return nil

--- a/api/notifications/ws_connection.go
+++ b/api/notifications/ws_connection.go
@@ -53,20 +53,13 @@ func (c *Controller) configureConn(ctx context.Context, repository storage.Trans
 			return err
 		}
 
-		err := updatePlatform(ctx, repository, platform.ID, func(p *types.Platform) {
-			p.Active = true
-		})
-		if err != nil {
+		if err := updatePlatformStatus(ctx, repository, platform.ID, true); err != nil {
 			return err
 		}
 
-		err = conn.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(c.wsSettings.WriteTimeout))
+		err := conn.WriteControl(websocket.PongMessage, []byte(message), time.Now().Add(c.wsSettings.WriteTimeout))
 		if err != nil {
-			storageErr := updatePlatform(ctx, repository, platform.ID, func(p *types.Platform) {
-				p.Active = false
-				p.LastActive = time.Now()
-			})
-			if storageErr != nil {
+			if storageErr := updatePlatformStatus(ctx, repository, platform.ID, false); storageErr != nil {
 				return storageErr
 			}
 

--- a/api/notifications/ws_connection.go
+++ b/api/notifications/ws_connection.go
@@ -18,7 +18,7 @@ const (
 	MaxPingPeriodHeader = "max_ping_period"
 )
 
-func (c *Controller) upgrade(repository storage.TransactionalRepository, platform *types.Platform, rw http.ResponseWriter, req *http.Request, header http.Header) (*websocket.Conn, error) {
+func (c *Controller) upgrade(ctx context.Context, repository storage.TransactionalRepository, platform *types.Platform, rw http.ResponseWriter, req *http.Request, header http.Header) (*websocket.Conn, error) {
 	if header == nil {
 		header = http.Header{}
 	}
@@ -38,7 +38,7 @@ func (c *Controller) upgrade(repository storage.TransactionalRepository, platfor
 	if err != nil {
 		return nil, err
 	}
-	c.configureConn(req.Context(), repository, platform, conn)
+	c.configureConn(ctx, repository, platform, conn)
 
 	return conn, nil
 }

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -114,7 +114,7 @@ func New(ctx context.Context, cancel context.CancelFunc, cfg *config.Settings) (
 	// Setup core API
 	log.C(ctx).Info("Setting up Service Manager core API...")
 
-	pgNotificator, err := postgres.NewNotificator(smStorage, interceptableRepository, cfg.Storage)
+	pgNotificator, err := postgres.NewNotificator(smStorage, cfg.Storage)
 	if err != nil {
 		return nil, fmt.Errorf("could not create notificator: %v", err)
 	}

--- a/pkg/ws/settings.go
+++ b/pkg/ws/settings.go
@@ -13,8 +13,8 @@ type Settings struct {
 // DefaultSettings return the default values for ws server
 func DefaultSettings() *Settings {
 	return &Settings{
-		PingTimeout:  time.Second * 5,
-		WriteTimeout: time.Second * 5,
+		PingTimeout:  time.Second * 30,
+		WriteTimeout: time.Second * 30,
 	}
 }
 

--- a/storage/postgres/notificator.go
+++ b/storage/postgres/notificator.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/Peripli/service-manager/pkg/query"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -67,7 +66,7 @@ type Notificator struct {
 }
 
 // NewNotificator returns new Notificator based on a given NotificatorStorage and desired queue size
-func NewNotificator(st storage.Storage, repository storage.TransactionalRepository, settings *storage.Settings) (*Notificator, error) {
+func NewNotificator(st storage.Storage, settings *storage.Settings) (*Notificator, error) {
 	ns, err := NewNotificationStorage(st)
 	connectionCreator := &notificationConnectionCreatorImpl{
 		storageURI:           settings.URI,
@@ -83,9 +82,8 @@ func NewNotificator(st storage.Storage, repository storage.TransactionalReposito
 		connectionMutex: &sync.Mutex{},
 		consumersMutex:  &sync.Mutex{},
 		consumers: &consumers{
-			repository: repository,
-			queues:     make(map[string][]storage.NotificationQueue),
-			platforms:  make([]*types.Platform, 0),
+			queues:    make(map[string][]storage.NotificationQueue),
+			platforms: make([]*types.Platform, 0),
 		},
 		storage:           ns,
 		connectionCreator: connectionCreator,
@@ -101,7 +99,6 @@ func (n *Notificator) Start(ctx context.Context, group *sync.WaitGroup) error {
 		return errors.New("notificator already started")
 	}
 	n.ctx = ctx
-	n.consumers.ctx = ctx
 	n.setConnection(n.connectionCreator.NewConnection(func(isConnected bool, err error) {
 		if isConnected {
 			atomic.StoreInt32(&n.isConnected, aTrue)
@@ -148,9 +145,7 @@ func (n *Notificator) addConsumer(platform *types.Platform, queue storage.Notifi
 	}
 	n.consumersMutex.Lock()
 	defer n.consumersMutex.Unlock()
-	if err := n.consumers.Add(platform, queue); err != nil {
-		return types.InvalidRevision, err
-	}
+	n.consumers.Add(platform, queue)
 	return atomic.LoadInt64(&n.lastKnownRevision), nil
 }
 
@@ -264,9 +259,7 @@ func (n *Notificator) UnregisterConsumer(queue storage.NotificationQueue) error 
 	if n.consumers.Len() == 0 {
 		return nil // Consumer already unregistered
 	}
-	if err := n.consumers.Delete(queue); err != nil {
-		return err
-	}
+	n.consumers.Delete(queue)
 	if n.consumers.Len() == 0 {
 		log.C(n.ctx).Debugf("No notification consumers left. Stop listening to channel %s", postgresChannel)
 		n.stopProcessing() // stop processing notifications as there are no consumers
@@ -426,10 +419,8 @@ func (n *Notificator) stopConnection() {
 }
 
 type consumers struct {
-	repository storage.TransactionalRepository
-	ctx        context.Context
-	queues     map[string][]storage.NotificationQueue
-	platforms  []*types.Platform
+	queues    map[string][]storage.NotificationQueue
+	platforms []*types.Platform
 }
 
 func (c *consumers) find(queueID string) (string, int) {
@@ -452,10 +443,10 @@ func (c *consumers) ReplaceQueue(queueID string, newQueue storage.NotificationQu
 	return nil
 }
 
-func (c *consumers) Delete(queue storage.NotificationQueue) error {
+func (c *consumers) Delete(queue storage.NotificationQueue) {
 	platformIDToDelete, queueIndex := c.find(queue.ID())
 	if queueIndex == -1 {
-		return nil
+		return
 	}
 	platformConsumers := c.queues[platformIDToDelete]
 	c.queues[platformIDToDelete] = append(platformConsumers[:queueIndex], platformConsumers[queueIndex+1:]...)
@@ -465,32 +456,17 @@ func (c *consumers) Delete(queue storage.NotificationQueue) error {
 		for index, platform := range c.platforms {
 			if platform.ID == platformIDToDelete {
 				c.platforms = append(c.platforms[:index], c.platforms[index+1:]...)
-				err := c.updatePlatform(platform.ID, func(p *types.Platform) {
-					p.Active = false
-					p.LastActive = time.Now()
-				})
-				if err != nil {
-					return err
-				}
 				break
 			}
 		}
 	}
-	return nil
 }
 
-func (c *consumers) Add(platform *types.Platform, queue storage.NotificationQueue) error {
+func (c *consumers) Add(platform *types.Platform, queue storage.NotificationQueue) {
 	if len(c.queues[platform.ID]) == 0 {
 		c.platforms = append(c.platforms, platform)
-		err := c.updatePlatform(platform.ID, func(p *types.Platform) {
-			p.Active = true
-		})
-		if err != nil {
-			return err
-		}
 	}
 	c.queues[platform.ID] = append(c.queues[platform.ID], queue)
-	return nil
 }
 
 func (c *consumers) Clear() map[string][]storage.NotificationQueue {
@@ -515,30 +491,4 @@ func (c *consumers) GetPlatform(platformID string) *types.Platform {
 
 func (c *consumers) GetQueuesForPlatform(platformID string) []storage.NotificationQueue {
 	return c.queues[platformID]
-}
-
-func (c *consumers) updatePlatform(platformID string, updatePlatformFunc func(p *types.Platform)) error {
-	if err := c.repository.InTransaction(c.ctx, func(ctx context.Context, storage storage.Repository) error {
-		idCriteria := query.Criterion{
-			LeftOp:   "id",
-			Operator: query.EqualsOperator,
-			RightOp:  []string{platformID},
-			Type:     query.FieldQuery,
-		}
-		obj, err := storage.Get(ctx, types.PlatformType, idCriteria)
-		if err != nil {
-			return err
-		}
-
-		platform := obj.(*types.Platform)
-		updatePlatformFunc(platform)
-
-		if _, err := storage.Update(ctx, platform, nil); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	return nil
 }

--- a/storage/postgres/notificator_test.go
+++ b/storage/postgres/notificator_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/Peripli/service-manager/storage/storagefakes"
 	"sync"
 	"time"
 
@@ -53,7 +52,6 @@ var _ = Describe("Notificator", func() {
 		ctx                        context.Context
 		cancel                     context.CancelFunc
 		wg                         *sync.WaitGroup
-		fakeStorage                *storagefakes.FakeStorage
 		fakeNotificationStorage    *postgresfakes.FakeNotificationStorage
 		fakeConnectionCreator      *postgresfakes.FakeNotificationConnectionCreator
 		testNotificator            storage.Notificator
@@ -97,9 +95,8 @@ var _ = Describe("Notificator", func() {
 			connectionMutex: &sync.Mutex{},
 			consumersMutex:  &sync.Mutex{},
 			consumers: &consumers{
-				repository: fakeStorage,
-				queues:     make(map[string][]storage.NotificationQueue),
-				platforms:  make([]*types.Platform, 0),
+				queues:    make(map[string][]storage.NotificationQueue),
+				platforms: make([]*types.Platform, 0),
 			},
 			storage:           fakeNotificationStorage,
 			connectionCreator: fakeConnectionCreator,
@@ -152,7 +149,6 @@ var _ = Describe("Notificator", func() {
 				ID: "platformID",
 			},
 		}
-		fakeStorage = &storagefakes.FakeStorage{}
 		fakeNotificationStorage = &postgresfakes.FakeNotificationStorage{}
 		fakeNotificationStorage.GetLastRevisionReturns(defaultLastRevision, nil)
 		fakeNotificationConnection = &notificationConnectionFakes.FakeNotificationConnection{}

--- a/test/ws_notification_test/ws_notification_test.go
+++ b/test/ws_notification_test/ws_notification_test.go
@@ -292,7 +292,7 @@ var _ = Describe("WS", func() {
 				By(fmt.Sprintf("Ping received and active status is true, then when %v ping timeout passes, active status should be set to false", pingTimeout))
 
 				ctx, _ := context.WithTimeout(context.TODO(), pingTimeout+time.Second)
-				ticker := time.NewTicker(500 * time.Millisecond)
+				ticker := time.NewTicker(pingTimeout / 3)
 				for {
 					select {
 					case <-ticker.C:

--- a/test/ws_notification_test/ws_notification_test.go
+++ b/test/ws_notification_test/ws_notification_test.go
@@ -289,7 +289,7 @@ var _ = Describe("WS", func() {
 				Eventually(pongCh).Should(BeClosed()) // wait for a pong message
 				assertPlatformIsActive()
 
-				By(fmt.Sprintf("Ping received and active status is true if %v ping timeout pass active status should be set to false", pingTimeout))
+				By(fmt.Sprintf("Ping received and active status is true, then when %v ping timeout passes, active status should be set to false", pingTimeout))
 
 				ctx, _ := context.WithTimeout(context.TODO(), pingTimeout+time.Second)
 				ticker := time.NewTicker(500 * time.Millisecond)


### PR DESCRIPTION
# Manage platform status during ping/pong flow

## Motivation

Currently managing platform status is done when WS connection is established and terminated with a platform (proxy agent). This leads to health check problems during B/G deployment when Service Manager runs on multiple nodes.

## Approach

Stop managing platform statuses on WS connection establishment/termination and instead manage statuses during ping/pong flow.

## Pull Request status


* [x] Initial implementation
* [x] Tests
