### PR TITLE
Allow settings ssl when connecting with notificator

### DIFF
--- a/storage/postgres/notification_connection.go
+++ b/storage/postgres/notification_connection.go
@@ -32,12 +32,17 @@ type notificationConnectionCreator interface {
 
 type notificationConnectionCreatorImpl struct {
 	storageURI           string
+	skipSSSLValidation   bool
 	minReconnectInterval time.Duration
 	maxReconnectInterval time.Duration
 }
 
 func (ncci *notificationConnectionCreatorImpl) NewConnection(eventCallback func(isRunning bool, err error)) notificationConnection.NotificationConnection {
-	return pq.NewListener(ncci.storageURI, ncci.minReconnectInterval, ncci.maxReconnectInterval, func(event pq.ListenerEventType, err error) {
+	sslModeParam := ""
+	if ncci.skipSSSLValidation {
+		sslModeParam = "?sslmode=disable"
+	}
+	return pq.NewListener(ncci.storageURI+sslModeParam, ncci.minReconnectInterval, ncci.maxReconnectInterval, func(event pq.ListenerEventType, err error) {
 		switch event {
 		case pq.ListenerEventConnected, pq.ListenerEventReconnected:
 			eventCallback(true, err)

--- a/storage/postgres/notification_connection.go
+++ b/storage/postgres/notification_connection.go
@@ -32,14 +32,14 @@ type notificationConnectionCreator interface {
 
 type notificationConnectionCreatorImpl struct {
 	storageURI           string
-	skipSSSLValidation   bool
+	skipSSLValidation    bool
 	minReconnectInterval time.Duration
 	maxReconnectInterval time.Duration
 }
 
 func (ncci *notificationConnectionCreatorImpl) NewConnection(eventCallback func(isRunning bool, err error)) notificationConnection.NotificationConnection {
 	sslModeParam := ""
-	if ncci.skipSSSLValidation {
+	if ncci.skipSSLValidation {
 		sslModeParam = "?sslmode=disable"
 	}
 	return pq.NewListener(ncci.storageURI+sslModeParam, ncci.minReconnectInterval, ncci.maxReconnectInterval, func(event pq.ListenerEventType, err error) {

--- a/storage/postgres/notificator.go
+++ b/storage/postgres/notificator.go
@@ -69,7 +69,7 @@ type Notificator struct {
 func NewNotificator(st storage.Storage, settings *storage.Settings) (*Notificator, error) {
 	ns, err := NewNotificationStorage(st)
 	connectionCreator := &notificationConnectionCreatorImpl{
-		skipSSSLValidation:   settings.SkipSSLValidation,
+		skipSSLValidation:    settings.SkipSSLValidation,
 		storageURI:           settings.URI,
 		minReconnectInterval: settings.Notification.MinReconnectInterval,
 		maxReconnectInterval: settings.Notification.MaxReconnectInterval,

--- a/storage/postgres/notificator.go
+++ b/storage/postgres/notificator.go
@@ -69,6 +69,7 @@ type Notificator struct {
 func NewNotificator(st storage.Storage, settings *storage.Settings) (*Notificator, error) {
 	ns, err := NewNotificationStorage(st)
 	connectionCreator := &notificationConnectionCreatorImpl{
+		skipSSSLValidation:   settings.SkipSSLValidation,
 		storageURI:           settings.URI,
 		minReconnectInterval: settings.Notification.MinReconnectInterval,
 		maxReconnectInterval: settings.Notification.MaxReconnectInterval,


### PR DESCRIPTION
## Prerequisites

The following error occurs when connecting to postgres for notifications: 

level=error msg="DB connection for notifications closed" component="postgres/notificator.go:108" correlation_id=- error="pq: SSL is not enabled on the server"

## Approach

Allow settings the connection to be without ssl if configured as such.
