### PR TITLE
Remove too verbose filter logs

### DIFF
--- a/pkg/web/filter.go
+++ b/pkg/web/filter.go
@@ -158,20 +158,7 @@ func (fs Filters) Chain(h Handler) Handler {
 	for i := len(fs) - 1; i >= 0; i-- {
 		i := i
 		wrappedFilters[i] = HandlerFunc(func(r *Request) (*Response, error) {
-			params := map[string]interface{}{
-				"path":                 r.URL.Path,
-				"method":               r.Method,
-				log.FieldCorrelationID: log.CorrelationIDForRequest(r.Request),
-			}
-
-			resp, err := fs[i].Run(r, wrappedFilters[i+1])
-
-			params["err"] = err
-			if resp != nil {
-				params["statusCode"] = resp.StatusCode
-			}
-
-			return resp, err
+			return fs[i].Run(r, wrappedFilters[i+1])
 		})
 	}
 

--- a/pkg/web/filter.go
+++ b/pkg/web/filter.go
@@ -163,8 +163,6 @@ func (fs Filters) Chain(h Handler) Handler {
 				"method":               r.Method,
 				log.FieldCorrelationID: log.CorrelationIDForRequest(r.Request),
 			}
-			logger := log.C(r.Context())
-			logger.WithFields(params).Debug("Entering Filter: ", fs[i].Name())
 
 			resp, err := fs[i].Run(r, wrappedFilters[i+1])
 
@@ -172,8 +170,6 @@ func (fs Filters) Chain(h Handler) Handler {
 			if resp != nil {
 				params["statusCode"] = resp.StatusCode
 			}
-
-			logger.WithFields(params).Debug("Exiting Filter: ", fs[i].Name())
 
 			return resp, err
 		})


### PR DESCRIPTION
## Motivation

With log elevel on _debug_ a typical OSB request log looks likes this:
```
	October 17th 2019, 11:27:44.627	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:176	Exiting Filter: AuthAuditLogFilter
	October 17th 2019, 11:27:44.627	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	auditlog/common.go:76	User context contains a name, considering basic authentication
	October 17th 2019, 11:27:44.627	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:176	Exiting Filter: DELETE-BasicAuthzFilter@/v1/osb/**
	October 17th 2019, 11:27:44.627	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:176	Exiting Filter: BasicAuthnFilter
	October 17th 2019, 11:27:44.627	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:176	Exiting Filter: LoggingFilter
	October 17th 2019, 11:27:44.627	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	auditlog/common.go:37	Header X-Forwarded-For is present in request
	October 17th 2019, 11:27:44.627	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:176	Exiting Filter: RequiredAuthenticationFilter
	October 17th 2019, 11:27:44.627	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:176	Exiting Filter: OSBAuditLogFilter
	October 17th 2019, 11:27:44.627	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:176	Exiting Filter: CriteriaFilter
	October 17th 2019, 11:27:44.627	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:176	Exiting Filter: RequiredAuthorizationFilter
	October 17th 2019, 11:27:44.626	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	INFO	osb/osb_controller.go:173	Service broker service-fabrik-broker replied with status 200
	October 17th 2019, 11:27:44.626	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:176	Exiting Filter: ResponseHeaderStripperFilter
	October 17th 2019, 11:27:43.277	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	INFO	osb/osb_controller.go:170	Forwarded OSB request to service broker service-fabrik-broker at https://service-fabrik-internal.cf.eu10.hana.ondemand.com/cf/v2/service_instances/656d18f9-8502-47c1-8c0f-15b33dddb374/service_bindings/8e0d20bc-8e46-4ab9-9635-b2dd861e72c4?plan_id=839cda72-d816-4c32-a954-bd3758b79ea0&service_id=3c266123-8e6e-4034-a2aa-e48e13fbf893
	October 17th 2019, 11:27:43.277	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	osb/osb_controller.go:80	Fetched broker e4eec026-b9a0-4357-a947-39b9e00851f7 with id service-fabrik-broker accessible at https://service-fabrik-internal.cf.eu10.hana.ondemand.com/cf
	October 17th 2019, 11:27:43.242	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:167	Entering Filter: RequiredAuthorizationFilter
	October 17th 2019, 11:27:43.242	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	osb/osb_controller.go:74	Obtained path parameter [brokerID = e4eec026-b9a0-4357-a947-39b9e00851f7] from path params
	October 17th 2019, 11:27:43.242	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	postgres/query_builder.go:199	Executing postgres query: SELECT t.*, broker_labels.id "broker_labels.id", broker_labels.key "broker_labels.key", broker_labels.val "broker_labels.val", broker_labels.created_at "broker_labels.created_at", broker_labels.updated_at "broker_labels.updated_at", broker_labels.broker_id "broker_labels.broker_id" FROM brokers t LEFT JOIN broker_labels ON t.id = broker_labels.broker_id WHERE t.id::text = $1 ORDER BY t.created_at ASC;
	October 17th 2019, 11:27:43.242	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	authz/authz_filter.go:73	Authentication is Basic. No authorization required...
	October 17th 2019, 11:27:43.242	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:167	Entering Filter: RequiredAuthenticationFilter
	October 17th 2019, 11:27:43.242	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:167	Entering Filter: ResponseHeaderStripperFilter
	October 17th 2019, 11:27:43.242	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:167	Entering Filter: OSBAuditLogFilter
	October 17th 2019, 11:27:43.242	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:167	Entering Filter: CriteriaFilter
	October 17th 2019, 11:27:43.242	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:167	Entering Filter: DELETE-BasicAuthzFilter@/v1/osb/**
	October 17th 2019, 11:27:43.242	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	osb/osb_controller.go:64	Executing OSB operation: /v1/osb/e4eec026-b9a0-4357-a947-39b9e00851f7/v2/service_instances/656d18f9-8502-47c1-8c0f-15b33dddb374/service_bindings/8e0d20bc-8e46-4ab9-9635-b2dd861e72c4
	October 17th 2019, 11:27:43.240	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	postgres/query_builder.go:199	Executing postgres query: SELECT t.*, platform_labels.id "platform_labels.id", platform_labels.key "platform_labels.key", platform_labels.val "platform_labels.val", platform_labels.created_at "platform_labels.created_at", platform_labels.updated_at "platform_labels.updated_at", platform_labels.platform_id "platform_labels.platform_id" FROM platforms t LEFT JOIN platform_labels ON t.id = platform_labels.platform_id WHERE t.username::text = $1 ORDER BY t.created_at ASC;
	October 17th 2019, 11:27:43.240	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:167	Entering Filter: BasicAuthnFilter
	October 17th 2019, 11:27:43.240	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:167	Entering Filter: AuthAuditLogFilter
	October 17th 2019, 11:27:43.240	service-manager-new	5549006d-b6e5-4103-7122-8edfbd850324	DEBUG	web/filter.go:167	Entering Filter: LoggingFilter
```
Based on Kibana stats "Entering Filter:" and "Exiting Filter:" messages are about 37% of all logs.
With error level on _debug_ at peak loads about 10% of the messages are dropped from the log.

## Approach

Remove "Entering Filter:" and "Exiting Filter:" logs as they bring more noise than value. If any filter takes some action, it should log it.

## Pull Request status

* [x] Initial implementation
* [x] Unit tests
