### PR TITLE
Fix panic: index out of range

### DIFF
--- a/pkg/query/selection.go
+++ b/pkg/query/selection.go
@@ -18,6 +18,7 @@ package query
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -137,11 +138,15 @@ func NewCriterion(leftOp string, operator Operator, rightOp []string, criteriaTy
 
 // Validate the criterion fields
 func (c Criterion) Validate() error {
+	if len(c.RightOp) == 0 {
+		return errors.New("missing right operand")
+	}
+
 	if c.Type == ResultQuery {
 		if c.LeftOp == Limit {
 			limit, err := strconv.Atoi(c.RightOp[0])
 			if err != nil {
-				return fmt.Errorf("could not cast string to int: %s", err.Error())
+				return fmt.Errorf("could not convert string to int: %s", err.Error())
 			}
 			if limit < 0 {
 				return &util.UnsupportedQueryError{Message: fmt.Sprintf("limit (%d) is invalid. Limit should be positive number", limit)}
@@ -149,11 +154,8 @@ func (c Criterion) Validate() error {
 		}
 
 		if c.LeftOp == OrderBy {
-			if len(c.RightOp) < 1 {
-				return &util.UnsupportedQueryError{Message: "order by result expects field and order type, but has none"}
-			}
 			if len(c.RightOp) < 2 {
-				return &util.UnsupportedQueryError{Message: fmt.Sprintf(`order by result for field "%s" expects order type, but has none`, c.RightOp[0])}
+				return &util.UnsupportedQueryError{Message: "order by result expects field name and order type"}
 			}
 		}
 

--- a/storage/postgres/query_builder_test.go
+++ b/storage/postgres/query_builder_test.go
@@ -193,7 +193,7 @@ ORDER BY id DESC, created_at ASC;`)))
 						}).
 						List(ctx)
 					Expect(err).Should(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring(`order by result for field "id" expects order type, but has none`))
+					Expect(err.Error()).To(ContainSubstring("order by result expects field name and order type"))
 				})
 			})
 
@@ -207,7 +207,7 @@ ORDER BY id DESC, created_at ASC;`)))
 						}).
 						List(ctx)
 					Expect(err).Should(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("order by result expects field and order type, but has none"))
+					Expect(err.Error()).To(ContainSubstring("missing right operand"))
 				})
 			})
 		})
@@ -390,8 +390,8 @@ FROM visibilities ;`)))
 					Count(ctx)
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(executedQuery).Should(Equal(trim(`
-SELECT COUNT(DISTINCT visibilities.id) 
-FROM visibilities 
+SELECT COUNT(DISTINCT visibilities.id)
+FROM visibilities
 LIMIT ?;`)))
 				Expect(queryArgs).To(HaveLen(1))
 				Expect(queryArgs[0]).Should(Equal("10"))
@@ -508,7 +508,7 @@ WHERE visibilities.id = t.id ;`)))
 
 				Expect(executedQuery).Should(Equal(trim(`
 DELETE
-FROM visibilities 
+FROM visibilities
 WHERE visibilities.id::text = ? ;`)))
 				Expect(queryArgs).To(HaveLen(1))
 				Expect(queryArgs[0]).Should(Equal("1"))
@@ -529,8 +529,8 @@ WHERE visibilities.id::text = ? ;`)))
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(executedQuery).To(Equal(trim(`
-DELETE 
-FROM visibilities 
+DELETE
+FROM visibilities
 RETURNING id, service_plan_id;`)))
 			})
 
@@ -539,8 +539,8 @@ RETURNING id, service_plan_id;`)))
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(executedQuery).To(Equal(trim(`
-DELETE 
-FROM visibilities 
+DELETE
+FROM visibilities
 RETURNING *;`)))
 			})
 

--- a/storage/postgres/where_clause_tree.go
+++ b/storage/postgres/where_clause_tree.go
@@ -99,10 +99,12 @@ func criterionSQL(c query.Criterion, dbTags []tagType, tableAlias string) (strin
 
 func buildRightOp(operator query.Operator, rightOp []string) (string, interface{}) {
 	rightOpBindVar := "?"
-	var rhs interface{} = rightOp[0]
+	var rhs interface{}
 	if operator.Type() == query.MultivariateOperator {
 		rightOpBindVar = "(?)"
 		rhs = rightOp
+	} else {
+		rhs = rightOp[0]
 	}
 	return rightOpBindVar, rhs
 }


### PR DESCRIPTION
## Motivation

If the second operand to `in` operator is an empty array, it used to panic
```
runtime error: index out of range
goroutine 55 [running]:
runtime/debug.Stack(0x1ab5e62, 0xc00073b6f0, 0x100e4e8)
        /usr/local/go/src/runtime/debug/stack.go:24 +0x9d
runtime/debug.PrintStack()
        /usr/local/go/src/runtime/debug/stack.go:16 +0x22
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/api/filters.NewRecoveryMiddleware.func1.1.1(0xc000404b00, 0x1c2f6e0, 0xc0006a4000)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/api/filters/recovery.go:23 +0xe4
panic(0x1991ce0, 0x2476130)
        /usr/local/go/src/runtime/panic.go:522 +0x1b5
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres.buildRightOp(0x1c33a20, 0x1c039a0, 0x24c55a8, 0x0, 0x0, 0xc00074c840, 0x22, 0x19371a0, 0xc00029edd0)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres/where_clause_tree.go:102 +0x103
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres.criterionSQL(0x1ac1c49, 0xf, 0x1c33a20, 0x1c039a0, 0x24c55a8, 0x0, 0x0, 0x1abd50b, 0xa, 0xc000160900, ...)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres/where_clause_tree.go:83 +0x77
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres.(*whereClauseTree).compileSQL(0xc00080a000, 0xc00029ee90, 0x1, 0x1, 0xc00029ee70, 0x1)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres/where_clause_tree.go:56 +0x62d
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres.(*whereClauseTree).compileSQL(0xc0002f7b80, 0x0, 0x0, 0x24c55a8, 0x10, 0x203000)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres/where_clause_tree.go:62 +0x13f
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres.(*whereClauseTree).compileSQL(0xc00073bf98, 0xc00029edc0, 0xc00029edb0, 0x0, 0x2, 0x8)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres/where_clause_tree.go:62 +0x13f
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres.(*pgQuery).whereSQL(0xc000302ff0, 0x1ac044b, 0xd)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres/query_builder.go:289 +0x123
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres.(*pgQuery).resolveQueryTemplate(0xc000302ff0, 0x1c32ea0, 0xc0006f57a0, 0x1af4d61, 0x451, 0x1c039a0, 0x24c55a8, 0x0, 0x0)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres/query_builder.go:175 +0x132
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres.(*pgQuery).List(0xc000302ff0, 0x1c32ea0, 0xc0006f57a0, 0x2, 0xc000302ff0, 0x0)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres/query_builder.go:131 +0x58
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres.(*Storage).List(0xc0003fa6c0, 0x1c32ea0, 0xc0006f57a0, 0x1ac2d0d, 0x10, 0xc000378ab0, 0x2, 0x2, 0x0, 0x0, ...)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/postgres/storage.go:210 +0x106
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage.(*encryptingRepository).List(0xc00031b0c0, 0x1c32ea0, 0xc0006f57a0, 0x1ac2d0d, 0x10, 0xc000378ab0, 0x2, 0x2, 0x90, 0x1943060, ...)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/encrypting_repository.go:131 +0xa3
github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage.(*queryScopedInterceptableRepository).List(0xc0007053b0, 0x1c32ea0, 0xc0006f57a0, 0x1ac2d0d, 0x10, 0xc000378ab0, 0x2, 0x2, 0xc0006f57a0, 0x1c32de0, ...)
        /Users/user/go/src/github.corp/SvcManager/sm-sap/vendor/github.com/Peripli/service-manager/storage/interceptable_repository.go:168 +0x8f
```

## Approach

Refactor code

## Pull Request status

* [x] Refactoring
