### PR TITLE
Service Instance GET/LIST APIs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -106,6 +106,7 @@ func New(ctx context.Context, e env.Environment, options *Options) (*web.API, er
 			apiNotifications.NewController(ctx, options.Repository, options.WSSettings, options.Notificator),
 			NewServiceOfferingController(options.Repository, options.APISettings.DefaultPageSize, options.APISettings.MaxPageSize),
 			NewServicePlanController(options.Repository, options.APISettings.DefaultPageSize, options.APISettings.MaxPageSize),
+			NewServiceInstanceController(options.Repository, options.APISettings.DefaultPageSize, options.APISettings.MaxPageSize),
 			&info.Controller{
 				TokenIssuer:    options.APISettings.TokenIssuerURL,
 				TokenBasicAuth: options.APISettings.TokenBasicAuth,

--- a/api/service_instance_controller.go
+++ b/api/service_instance_controller.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/Peripli/service-manager/storage"
+
+	"github.com/Peripli/service-manager/pkg/web"
+)
+
+// ServiceInstanceController implements api.Controller by providing service instances API logic
+type ServiceInstanceController struct {
+	*BaseController
+}
+
+func NewServiceInstanceController(repository storage.Repository, defaultPageSize, maxPageSize int) *ServiceInstanceController {
+	return &ServiceInstanceController{
+		BaseController: NewController(repository, web.ServiceInstancesURL, types.ServiceInstanceType, func() types.Object {
+			return &types.ServiceInstance{}
+		}, defaultPageSize, maxPageSize),
+	}
+}
+func (c *ServiceInstanceController) Routes() []web.Route {
+	return []web.Route{
+		{
+			Endpoint: web.Endpoint{
+				Method: http.MethodGet,
+				Path:   fmt.Sprintf("%s/{%s}", web.ServiceInstancesURL, PathParamID),
+			},
+			Handler: c.GetSingleObject,
+		},
+		{
+			Endpoint: web.Endpoint{
+				Method: http.MethodGet,
+				Path:   web.ServiceInstancesURL,
+			},
+			Handler: c.ListObjects,
+		},
+	}
+}

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -12,6 +12,9 @@ const (
 	// ServicePlansURL is the URL path to manage service plans
 	ServicePlansURL = "/" + apiVersion + "/service_plans"
 
+	// ServiceInstancesURL is the URL path to manage service instances
+	ServiceInstancesURL = "/" + apiVersion + "/service_instances"
+
 	// VisibilitiesURL is the URL path to manage visibilities
 	VisibilitiesURL = "/" + apiVersion + "/visibilities"
 


### PR DESCRIPTION
# Service Instance GET/LIST APIs

## Prerequisites

https://github.com/Peripli/service-manager/pull/353

## Motivation

Allows fetching existing Service Instances. Authentication/Authorization is not included.

## Pull Request status

For example:

* [x] Initial implementation

## Topic branch:
https://github.com/Peripli/service-manager/pull/351