### PR TITLE
Introduce Service Instance labelling interceptor

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -50,7 +50,7 @@ type Settings struct {
 	TokenIssuerURL  string   `mapstructure:"token_issuer_url" description:"url of the token issuer which to use for validating tokens"`
 	ClientID        string   `mapstructure:"client_id" description:"id of the client from which the token must be issued"`
 	TokenBasicAuth  bool     `mapstructure:"token_basic_auth" description:"specifies if client credentials to the authorization server should be sent in the header as basic auth (true) or in the body (false)"`
-	ProctedLabels   []string `mapstructure:"protected_labels" description:"defines labels which cannot be modified/added by REST API requests"`
+	ProtectedLabels []string `mapstructure:"protected_labels" description:"defines labels which cannot be modified/added by REST API requests"`
 	OSBVersion      string   `mapstructure:"-"`
 	MaxPageSize     int      `mapstructure:"max_page_size" description:"maximum number of items that could be returned in a single page"`
 	DefaultPageSize int      `mapstructure:"default_page_size" description:"default number of items returned in a single page if not specified in request"`
@@ -65,7 +65,7 @@ func DefaultSettings() *Settings {
 		OSBVersion:      osbVersion,
 		MaxPageSize:     200,
 		DefaultPageSize: 50,
-		ProctedLabels:   []string{},
+		ProtectedLabels: []string{},
 	}
 }
 
@@ -132,7 +132,7 @@ func New(ctx context.Context, e env.Environment, options *Options) (*web.API, er
 			bearerAuthnFilter,
 			secfilters.NewRequiredAuthnFilter(),
 			&filters.SelectionCriteria{},
-			filters.NewProtectedLabelsFilter(options.APISettings.ProctedLabels),
+			filters.NewProtectedLabelsFilter(options.APISettings.ProtectedLabels),
 			&filters.PlatformAwareVisibilityFilter{},
 			&filters.PatchOnlyLabelsFilter{},
 			filters.NewPlansFilterByVisibility(options.Repository),

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -406,5 +406,8 @@ func (smb *ServiceManagerBuilder) EnableMultitenancy(labelKey string, extractTen
 
 	multitenancyFilters := filters.NewMultitenancyFilters(labelKey, extractTenantFunc)
 	smb.RegisterFiltersAfter(filters.ProtectedLabelsFilterName, multitenancyFilters...)
+	smb.WithCreateInterceptorProvider(types.ServiceInstanceType, &interceptors.ServiceInstanceCreateInsterceptorProvider{
+		TenantIdentifier: labelKey,
+	}).Register()
 	return smb
 }

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -406,7 +406,7 @@ func (smb *ServiceManagerBuilder) EnableMultitenancy(labelKey string, extractTen
 
 	multitenancyFilters := filters.NewMultitenancyFilters(labelKey, extractTenantFunc)
 	smb.RegisterFiltersAfter(filters.ProtectedLabelsFilterName, multitenancyFilters...)
-	smb.WithCreateInterceptorProvider(types.ServiceInstanceType, &interceptors.ServiceInstanceCreateInsterceptorProvider{
+	smb.WithCreateAroundTxInterceptorProvider(types.ServiceInstanceType, &interceptors.ServiceInstanceCreateInsterceptorProvider{
 		TenantIdentifier: labelKey,
 	}).Register()
 	return smb

--- a/storage/interceptors/service_instance_create_interceptor.go
+++ b/storage/interceptors/service_instance_create_interceptor.go
@@ -60,6 +60,9 @@ func (c *serviceInstanceCreateInterceptor) AroundTxCreate(h storage.InterceptCre
 		}
 
 		labels := serviceInstance.GetLabels()
+		if labels == nil {
+			labels = types.Labels{}
+		}
 		labels[c.TenantIdentifier] = []string{tenantID.String()}
 
 		serviceInstance.SetLabels(labels)

--- a/storage/interceptors/service_instance_create_interceptor.go
+++ b/storage/interceptors/service_instance_create_interceptor.go
@@ -38,7 +38,6 @@ func (c *ServiceInstanceCreateInsterceptorProvider) Provide() storage.CreateInte
 	return &serviceInstanceCreateInterceptor{
 		TenantIdentifier: c.TenantIdentifier,
 	}
-
 }
 
 type serviceInstanceCreateInterceptor struct {

--- a/storage/interceptors/service_instance_create_interceptor.go
+++ b/storage/interceptors/service_instance_create_interceptor.go
@@ -19,7 +19,6 @@ package interceptors
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/storage"
 	"github.com/tidwall/gjson"
@@ -50,12 +49,12 @@ func (c *serviceInstanceCreateInterceptor) AroundTxCreate(h storage.InterceptCre
 	return func(ctx context.Context, obj types.Object) (types.Object, error) {
 		serviceInstance := obj.(*types.ServiceInstance)
 
-		b, err := json.Marshal(&serviceInstance.Context)
+		bytes, err := json.Marshal(&serviceInstance.Context)
 		if err != nil {
 			return nil, err
 		}
 
-		tenantID := gjson.Get(string(b), fmt.Sprintf("context.%s", c.TenantIdentifier))
+		tenantID := gjson.Get(string(bytes), c.TenantIdentifier)
 		if !tenantID.Exists() {
 			return h(ctx, serviceInstance)
 		}

--- a/test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_test/service_instance_test.go
@@ -82,6 +82,10 @@ var _ = test.DescribeTestsFor(test.TestCase{
 			Describe("GET", func() {
 				var serviceInstance *types.ServiceInstance
 
+				AfterEach(func() {
+					ctx.CleanupAdditionalResources()
+				})
+
 				When("service instance contains tenant identifier in OSB context", func() {
 					BeforeEach(func() {
 						serviceInstance = prepareServiceInstance(ctx, ctx.SMWithOAuth, fmt.Sprintf(`{"%s":"%s"}`, TenantIdentifier, TenantValue))


### PR DESCRIPTION
# Introduce Service Instance labelling interceptor

## Motivation

Service Manager needs to label all instances with the tenant in which it is created.

## Approach

To do this, there needs to be an AroundTx interceptor that adds a <tenant_identifier> label to the service instance. The value of the <tenant_identifier> label can be obtained from the context field in the service instance.

## Pull Request status

* [x] Initial implementation
* [x] Integration tests
