### PR TITLE
Add authentication for service instance endpoint

### DIFF
--- a/api/filters/basic_authentication.go
+++ b/api/filters/basic_authentication.go
@@ -123,6 +123,12 @@ func basicAuthnMatchers() []web.FilterMatcher {
 		{
 			Matchers: []web.Matcher{
 				web.Methods(http.MethodGet),
+				web.Path(web.ServiceInstancesURL + "/**"),
+			},
+		},
+		{
+			Matchers: []web.Matcher{
+				web.Methods(http.MethodGet),
 				web.Path(web.VisibilitiesURL + "/**"),
 			},
 		},

--- a/api/filters/oidc_authentication.go
+++ b/api/filters/oidc_authentication.go
@@ -53,6 +53,7 @@ func oidcAuthnMatchers() []web.FilterMatcher {
 					web.ServiceOfferingsURL+"/**",
 					web.ServicePlansURL+"/**",
 					web.VisibilitiesURL+"/**",
+					web.ServiceInstancesURL+"/**",
 					web.ConfigURL+"/**",
 				),
 			},

--- a/api/filters/tenant_filter.go
+++ b/api/filters/tenant_filter.go
@@ -155,5 +155,11 @@ func (f *TenantFilter) FilterMatchers() []web.FilterMatcher {
 				web.Methods(f.Methods...),
 			},
 		},
+		{
+			Matchers: []web.Matcher{
+				web.Path(web.ServiceInstancesURL + "/**"),
+				web.Methods(f.Methods...),
+			},
+		},
 	}
 }

--- a/api/filters/tenant_filter_test.go
+++ b/api/filters/tenant_filter_test.go
@@ -192,7 +192,8 @@ var _ = Describe("TenantFilters", func() {
 							Name:               "test",
 							AccessLevel:        web.TenantAccess,
 						}))
-						multitenancyFilters[0].Run(fakeRequest, fakeHandler)
+						_, err = multitenancyFilters[0].Run(fakeRequest, fakeHandler)
+						Expect(err).ToNot(HaveOccurred())
 						Expect(fakeHandler.HandleCallCount()).To(Equal(1))
 						actualRequest := fakeHandler.HandleArgsForCall(0)
 						criteria := query.CriteriaForContext(actualRequest.Context())
@@ -280,7 +281,7 @@ var _ = Describe("TenantFilters", func() {
 				fakeRequest.Body = []byte(t.actualRequestBody)
 				_, err = multitenancyFilters[1].Run(fakeRequest, fakeHandler)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(string(fakeRequest.Body))).To(unmarshalledmatchers.MatchOrderedJSON(t.expectedRequestBody))
+				Expect(string(fakeRequest.Body)).To(unmarshalledmatchers.MatchOrderedJSON(t.expectedRequestBody))
 			}, entries...)
 		})
 	})

--- a/pkg/security/filters/required_authn.go
+++ b/pkg/security/filters/required_authn.go
@@ -63,6 +63,7 @@ func (raf *requiredAuthnFilter) FilterMatchers() []web.FilterMatcher {
 					web.ServicePlansURL+"/**",
 					web.VisibilitiesURL+"/**",
 					web.NotificationsURL+"/**",
+					web.ServiceInstancesURL+"/**",
 					web.ConfigURL+"/**",
 				),
 			},

--- a/test/auth_test/auth_test.go
+++ b/test/auth_test/auth_test.go
@@ -17,9 +17,10 @@
 package auth_test
 
 import (
-	"github.com/Peripli/service-manager/pkg/web"
 	"net/http"
 	"testing"
+
+	"github.com/Peripli/service-manager/pkg/web"
 
 	"github.com/Peripli/service-manager/test/common"
 	. "github.com/onsi/ginkgo"
@@ -209,6 +210,17 @@ var _ = Describe("Service Manager Authentication", func() {
 			{"Invalid authorization schema", "PUT", web.LoggingConfigURL, "Basic abc"},
 			{"Missing token in authorization header", "PUT", web.LoggingConfigURL, "Bearer "},
 			{"Invalid token in authorization header", "PUT", web.LoggingConfigURL, "Bearer abc"},
+
+			// SERVICE INSTANCES
+			{"Missing authorization header", "GET", web.ServiceInstancesURL + "/999", ""},
+			{"Invalid authorization schema", "GET", web.ServiceInstancesURL + "/999", "Basic abc"},
+			{"Missing token in authorization header", "GET", web.ServiceInstancesURL + "/999", "Bearer "},
+			{"Invalid token in authorization header", "GET", web.ServiceInstancesURL + "/999", "Bearer abc"},
+
+			{"Missing authorization header", "GET", web.ServiceInstancesURL, ""},
+			{"Invalid authorization schema", "GET", web.ServiceInstancesURL, "Basic abc"},
+			{"Missing token in authorization header", "GET", web.ServiceInstancesURL, "Bearer "},
+			{"Invalid token in authorization header", "GET", web.ServiceInstancesURL, "Bearer abc"},
 		}
 
 		for _, request := range authRequests {

--- a/test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_test/service_instance_test.go
@@ -19,12 +19,13 @@ package service_test
 import (
 	"context"
 	"fmt"
-	"github.com/Peripli/service-manager/pkg/query"
-	"github.com/Peripli/service-manager/pkg/types"
-	"github.com/gofrs/uuid"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/gofrs/uuid"
 
 	"github.com/Peripli/service-manager/pkg/web"
 	"github.com/Peripli/service-manager/test/common"
@@ -89,7 +90,8 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				When("service instance contains tenant identifier in OSB context", func() {
 					BeforeEach(func() {
 						serviceInstance = prepareServiceInstance(ctx, ctx.SMWithOAuth, fmt.Sprintf(`{"%s":"%s"}`, TenantIdentifier, TenantValue))
-						ctx.SMRepository.Create(context.Background(), serviceInstance)
+						_, err := ctx.SMRepository.Create(context.Background(), serviceInstance)
+						Expect(err).ToNot(HaveOccurred())
 					})
 
 					It("labels instance with tenant identifier", func() {
@@ -102,7 +104,8 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				When("service instance doesn't contain tenant identifier in OSB context", func() {
 					BeforeEach(func() {
 						serviceInstance = prepareServiceInstance(ctx, ctx.SMWithOAuth, "{}")
-						ctx.SMRepository.Create(context.Background(), serviceInstance)
+						_, err := ctx.SMRepository.Create(context.Background(), serviceInstance)
+						Expect(err).ToNot(HaveOccurred())
 					})
 
 					It("doesn't label instance with tenant identifier", func() {
@@ -125,7 +128,10 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 func blueprint(ctx *common.TestContext, auth *common.SMExpect) common.Object {
 	serviceInstance := prepareServiceInstance(ctx, auth, fmt.Sprintf(`{"%s":"%s"}`, TenantIdentifier, TenantValue))
-	ctx.SMRepository.Create(context.Background(), serviceInstance)
+	_, err := ctx.SMRepository.Create(context.Background(), serviceInstance)
+	if err != nil {
+		Fail(fmt.Sprintf("could not create service instance: %s", err))
+	}
 
 	return auth.ListWithQuery(web.ServiceInstancesURL, fmt.Sprintf("fieldQuery=id eq '%s'", serviceInstance.ID)).First().Object().Raw()
 }


### PR DESCRIPTION
# Add authentication for service instance endpoint

## Motivation

The service instance api should be used only by authenticated users.

## Approach

Extend the existing authentication mechanism by adding the service instance url.

## Pull Request status

Use checklists as a means to represent the status of your Pull Request.

For example:

* [x] Implementation
* [x] Tests
