### PR TITLE
Introduce Resource Validator [API-level validation]

### DIFF
--- a/api/base_controller.go
+++ b/api/base_controller.go
@@ -46,24 +46,13 @@ const pagingLimitOffset = 1
 
 // BaseController provides common CRUD handlers for all object types in the service manager
 type BaseController struct {
-	resourceBaseURL string
-	objectType      types.ObjectType
-	repository      storage.Repository
-	objectBlueprint func() types.Object
-	DefaultPageSize int
-	MaxPageSize     int
-}
-
-// NewController returns a new base controller
-func NewController(repository storage.Repository, resourceBaseURL string, objectType types.ObjectType, objectBlueprint func() types.Object, defaultPageSize, maxPageSize int) *BaseController {
-	return &BaseController{
-		repository:      repository,
-		resourceBaseURL: resourceBaseURL,
-		objectBlueprint: objectBlueprint,
-		objectType:      objectType,
-		DefaultPageSize: defaultPageSize,
-		MaxPageSize:     maxPageSize,
-	}
+	ResourceBaseURL   string
+	ObjectType        types.ObjectType
+	Repository        storage.Repository
+	ObjectBlueprint   func() types.Object
+	DefaultPageSize   int
+	MaxPageSize       int
+	ResourceValidator ResourceValidator
 }
 
 // Routes returns the common set of routes for all objects
@@ -72,42 +61,42 @@ func (c *BaseController) Routes() []web.Route {
 		{
 			Endpoint: web.Endpoint{
 				Method: http.MethodPost,
-				Path:   c.resourceBaseURL,
+				Path:   c.ResourceBaseURL,
 			},
 			Handler: c.CreateObject,
 		},
 		{
 			Endpoint: web.Endpoint{
 				Method: http.MethodGet,
-				Path:   fmt.Sprintf("%s/{%s}", c.resourceBaseURL, PathParamID),
+				Path:   fmt.Sprintf("%s/{%s}", c.ResourceBaseURL, PathParamID),
 			},
 			Handler: c.GetSingleObject,
 		},
 		{
 			Endpoint: web.Endpoint{
 				Method: http.MethodGet,
-				Path:   c.resourceBaseURL,
+				Path:   c.ResourceBaseURL,
 			},
 			Handler: c.ListObjects,
 		},
 		{
 			Endpoint: web.Endpoint{
 				Method: http.MethodDelete,
-				Path:   c.resourceBaseURL,
+				Path:   c.ResourceBaseURL,
 			},
 			Handler: c.DeleteObjects,
 		},
 		{
 			Endpoint: web.Endpoint{
 				Method: http.MethodDelete,
-				Path:   fmt.Sprintf("%s/{%s}", c.resourceBaseURL, PathParamID),
+				Path:   fmt.Sprintf("%s/{%s}", c.ResourceBaseURL, PathParamID),
 			},
 			Handler: c.DeleteSingleObject,
 		},
 		{
 			Endpoint: web.Endpoint{
 				Method: http.MethodPatch,
-				Path:   fmt.Sprintf("%s/{%s}", c.resourceBaseURL, PathParamID),
+				Path:   fmt.Sprintf("%s/{%s}", c.ResourceBaseURL, PathParamID),
 			},
 			Handler: c.PatchObject,
 		},
@@ -117,9 +106,9 @@ func (c *BaseController) Routes() []web.Route {
 // CreateObject handles the creation of a new object
 func (c *BaseController) CreateObject(r *web.Request) (*web.Response, error) {
 	ctx := r.Context()
-	log.C(ctx).Debugf("Creating new %s", c.objectType)
+	log.C(ctx).Debugf("Creating new %s", c.ObjectType)
 
-	result := c.objectBlueprint()
+	result := c.ObjectBlueprint()
 	if err := util.BytesToObject(r.Body, result); err != nil {
 		return nil, err
 	}
@@ -127,7 +116,7 @@ func (c *BaseController) CreateObject(r *web.Request) (*web.Response, error) {
 	if result.GetID() == "" {
 		UUID, err := uuid.NewV4()
 		if err != nil {
-			return nil, fmt.Errorf("could not generate GUID for %s: %s", c.objectType, err)
+			return nil, fmt.Errorf("could not generate GUID for %s: %s", c.ObjectType, err)
 		}
 		result.SetID(UUID.String())
 	}
@@ -135,9 +124,14 @@ func (c *BaseController) CreateObject(r *web.Request) (*web.Response, error) {
 	result.SetCreatedAt(currentTime)
 	result.SetUpdatedAt(currentTime)
 
-	createdObj, err := c.repository.Create(ctx, result)
+	log.C(ctx).Debugf("Attempting to validate creation of %s object with ID (%s)", result.GetType(), result.GetID())
+	if err := c.ResourceValidator.ValidateCreate(ctx, c.Repository, result); err != nil {
+		return nil, err
+	}
+
+	createdObj, err := c.Repository.Create(ctx, result)
 	if err != nil {
-		return nil, util.HandleStorageError(err, c.objectType.String())
+		return nil, util.HandleStorageError(err, c.ObjectType.String())
 	}
 
 	return util.NewJSONResponse(http.StatusCreated, createdObj)
@@ -146,11 +140,26 @@ func (c *BaseController) CreateObject(r *web.Request) (*web.Response, error) {
 // DeleteObjects handles the deletion of the objects specified in the request
 func (c *BaseController) DeleteObjects(r *web.Request) (*web.Response, error) {
 	ctx := r.Context()
-	log.C(ctx).Debugf("Deleting %ss...", c.objectType)
+	log.C(ctx).Debugf("Deleting %ss...", c.ObjectType)
 
 	criteria := query.CriteriaForContext(ctx)
-	if _, err := c.repository.Delete(ctx, c.objectType, criteria...); err != nil {
-		return nil, util.HandleStorageError(err, c.objectType.String())
+
+	objectList, err := c.Repository.List(ctx, c.ObjectType, criteria...)
+	if err != nil {
+		return nil, err
+	}
+
+	log.C(ctx).Debugf("Attempting to validate deletion of %s object(s)", c.ObjectType)
+	for i := 0; i < objectList.Len(); i++ {
+		log.C(ctx).Debugf("Attempting to validate deletion of %s object with ID (%s)", c.ObjectType, objectList.ItemAt(i).GetID())
+		err = c.ResourceValidator.ValidateDelete(ctx, c.Repository, objectList.ItemAt(i))
+		if err != nil {
+			return nil, util.HandleStorageError(err, c.ObjectType.String())
+		}
+	}
+
+	if _, err := c.Repository.Delete(ctx, c.ObjectType, criteria...); err != nil {
+		return nil, util.HandleStorageError(err, c.ObjectType.String())
 	}
 
 	return util.NewJSONResponse(http.StatusOK, map[string]string{})
@@ -160,7 +169,7 @@ func (c *BaseController) DeleteObjects(r *web.Request) (*web.Response, error) {
 func (c *BaseController) DeleteSingleObject(r *web.Request) (*web.Response, error) {
 	objectID := r.PathParams[PathParamID]
 	ctx := r.Context()
-	log.C(ctx).Debugf("Deleting %s with id %s", c.objectType, objectID)
+	log.C(ctx).Debugf("Deleting %s with id %s", c.ObjectType, objectID)
 
 	byID := query.ByField(query.EqualsOperator, "id", objectID)
 	ctx, err := query.AddCriteria(ctx, byID)
@@ -176,7 +185,7 @@ func (c *BaseController) DeleteSingleObject(r *web.Request) (*web.Response, erro
 func (c *BaseController) GetSingleObject(r *web.Request) (*web.Response, error) {
 	objectID := r.PathParams[PathParamID]
 	ctx := r.Context()
-	log.C(ctx).Debugf("Getting %s with id %s", c.objectType, objectID)
+	log.C(ctx).Debugf("Getting %s with id %s", c.ObjectType, objectID)
 
 	byID := query.ByField(query.EqualsOperator, "id", objectID)
 	var err error
@@ -185,9 +194,9 @@ func (c *BaseController) GetSingleObject(r *web.Request) (*web.Response, error) 
 		return nil, err
 	}
 	criteria := query.CriteriaForContext(ctx)
-	object, err := c.repository.Get(ctx, c.objectType, criteria...)
+	object, err := c.Repository.Get(ctx, c.ObjectType, criteria...)
 	if err != nil {
-		return nil, util.HandleStorageError(err, c.objectType.String())
+		return nil, util.HandleStorageError(err, c.ObjectType.String())
 	}
 
 	stripCredentials(ctx, object)
@@ -200,9 +209,9 @@ func (c *BaseController) ListObjects(r *web.Request) (*web.Response, error) {
 	ctx := r.Context()
 
 	criteria := query.CriteriaForContext(ctx)
-	count, err := c.repository.Count(ctx, c.objectType, criteria...)
+	count, err := c.Repository.Count(ctx, c.ObjectType, criteria...)
 	if err != nil {
-		return nil, util.HandleStorageError(err, c.objectType.String())
+		return nil, util.HandleStorageError(err, c.ObjectType.String())
 	}
 
 	maxItems := r.URL.Query().Get("max_items")
@@ -212,7 +221,7 @@ func (c *BaseController) ListObjects(r *web.Request) (*web.Response, error) {
 	}
 
 	if limit == 0 {
-		log.C(ctx).Debugf("Returning only count of %s since max_items is 0", c.objectType)
+		log.C(ctx).Debugf("Returning only count of %s since max_items is 0", c.ObjectType)
 		page := struct {
 			ItemsCount int `json:"num_items"`
 		}{
@@ -231,10 +240,10 @@ func (c *BaseController) ListObjects(r *web.Request) (*web.Response, error) {
 		query.OrderResultBy("paging_sequence", query.AscOrder),
 		query.ByField(query.GreaterThanOperator, "paging_sequence", pagingSequence))
 
-	log.C(ctx).Debugf("Getting a page of %ss", c.objectType)
-	objectList, err := c.repository.List(ctx, c.objectType, criteria...)
+	log.C(ctx).Debugf("Getting a page of %ss", c.ObjectType)
+	objectList, err := c.Repository.List(ctx, c.ObjectType, criteria...)
 	if err != nil {
-		return nil, util.HandleStorageError(err, c.objectType.String())
+		return nil, util.HandleStorageError(err, c.ObjectType.String())
 	}
 
 	page := pageFromObjectList(ctx, objectList, count, limit)
@@ -258,7 +267,7 @@ func (c *BaseController) ListObjects(r *web.Request) (*web.Response, error) {
 func (c *BaseController) PatchObject(r *web.Request) (*web.Response, error) {
 	objectID := r.PathParams[PathParamID]
 	ctx := r.Context()
-	log.C(ctx).Debugf("Updating %s with id %s", c.objectType, objectID)
+	log.C(ctx).Debugf("Updating %s with id %s", c.ObjectType, objectID)
 
 	labelChanges, err := query.LabelChangesFromJSON(r.Body)
 	if err != nil {
@@ -271,9 +280,9 @@ func (c *BaseController) PatchObject(r *web.Request) (*web.Response, error) {
 		return nil, err
 	}
 	criteria := query.CriteriaForContext(ctx)
-	objFromDB, err := c.repository.Get(ctx, c.objectType, criteria...)
+	objFromDB, err := c.Repository.Get(ctx, c.ObjectType, criteria...)
 	if err != nil {
-		return nil, util.HandleStorageError(err, c.objectType.String())
+		return nil, util.HandleStorageError(err, c.ObjectType.String())
 	}
 
 	if r.Body, err = sjson.DeleteBytes(r.Body, "labels"); err != nil {
@@ -293,9 +302,14 @@ func (c *BaseController) PatchObject(r *web.Request) (*web.Response, error) {
 	labels, _, _ := query.ApplyLabelChangesToLabels(labelChanges, objFromDB.GetLabels())
 	objFromDB.SetLabels(labels)
 
-	object, err := c.repository.Update(ctx, objFromDB, labelChanges, criteria...)
+	log.C(ctx).Debugf("Attempting to validate update of %s object with ID (%s)", objFromDB.GetType(), objFromDB.GetID())
+	if err := c.ResourceValidator.ValidateUpdate(ctx, c.Repository, objFromDB); err != nil {
+		return nil, util.HandleStorageError(err, c.ObjectType.String())
+	}
+
+	object, err := c.Repository.Update(ctx, objFromDB, labelChanges, criteria...)
 	if err != nil {
-		return nil, util.HandleStorageError(err, c.objectType.String())
+		return nil, util.HandleStorageError(err, c.ObjectType.String())
 	}
 
 	stripCredentials(ctx, object)

--- a/api/broker_validator.go
+++ b/api/broker_validator.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"context"
+	"github.com/Peripli/service-manager/pkg/log"
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/Peripli/service-manager/pkg/util"
+	"github.com/Peripli/service-manager/pkg/util/slice"
+	"github.com/Peripli/service-manager/storage"
+	"net/http"
+)
+
+// BrokerValidator is a type of ResourceValidator
+type BrokerValidator struct {
+	DefaultResourceValidator
+	FetchCatalog func(ctx context.Context, broker *types.ServiceBroker) ([]byte, error)
+}
+
+// ValidateUpdate ensures that there are no service instances associated with a service plan
+// in the cases when a broker's catalog gets updated by removing that service plan
+func (bv *BrokerValidator) ValidateUpdate(ctx context.Context, repository storage.Repository, object types.Object) error {
+	_, ok := object.(*types.ServiceBroker)
+	if !ok {
+		log.C(ctx).Debugf("Provided object is of type %s. Cannot validate broker deletion.", object.GetType())
+		return ErrIncompatibleObjectType
+	}
+
+	if err := object.Validate(); err != nil {
+		return &util.HTTPError{
+			ErrorType:   "BadRequest",
+			Description: err.Error(),
+			StatusCode:  http.StatusBadRequest,
+		}
+	}
+
+	broker := object.(*types.ServiceBroker)
+
+	currentCatalog := struct {
+		Services []*types.ServiceOffering `json:"services"`
+	}{}
+	if err := util.BytesToObject(broker.Catalog, &currentCatalog); err != nil {
+		return err
+	}
+
+	catalogBytes, err := bv.FetchCatalog(ctx, broker)
+	if err != nil {
+		return err
+	}
+	latestCatalog := struct {
+		Services []*types.ServiceOffering `json:"services"`
+	}{}
+	if err := util.BytesToObject(catalogBytes, &latestCatalog); err != nil {
+		return err
+	}
+
+	currentCatalogPlanIDs := retrieveCatalogPlanIDs(currentCatalog.Services)
+	latestCatalogPlanIDs := retrieveCatalogPlanIDs(latestCatalog.Services)
+
+	removedCatalogPlanIDs := make([]string, 0)
+	for _, catalogPlanID := range currentCatalogPlanIDs {
+		if !slice.StringsAnyEquals(latestCatalogPlanIDs, catalogPlanID) {
+			removedCatalogPlanIDs = append(removedCatalogPlanIDs, catalogPlanID)
+		}
+	}
+
+	if len(removedCatalogPlanIDs) > 0 {
+		log.C(ctx).Debugf("Fetching service instances for plans removed from catalog of broker with ID (%s)", object.GetID())
+	}
+	instanceIDs, err := retrieveServiceInstanceIDsByCatalogPlanIDs(ctx, repository, removedCatalogPlanIDs)
+	if err != nil {
+		return err
+	}
+
+	if len(instanceIDs) > 0 {
+		log.C(ctx).Infof("Found service instances associated with plans removed from catalog of broker with ID (%s): %s", object.GetID(), instanceIDs)
+		return &util.ErrForeignKeyViolation{
+			Entity:             types.ServicePlanType.String(),
+			ReferenceEntity:    types.ServiceInstanceType.String(),
+			ReferenceEntityIDs: instanceIDs,
+		}
+	}
+
+	log.C(ctx).Debugf("No service instances associated with plans removed from catalog of broker with ID (%s) were found. Broker update can continue...", object.GetID())
+	return nil
+}
+
+// ValidateDelete ensures that there are no service instances associated with a service plan of the broker that's about to be deleted
+func (bv *BrokerValidator) ValidateDelete(ctx context.Context, repository storage.Repository, object types.Object) error {
+	_, ok := object.(*types.ServiceBroker)
+	if !ok {
+		log.C(ctx).Debugf("Provided object is of type %s. Cannot validate broker deletion.", object.GetType())
+		return ErrIncompatibleObjectType
+	}
+
+	log.C(ctx).Debugf("Fetching service instances for broker with ID (%s)", object.GetID())
+	instanceIDs, err := retrieveServiceInstanceIDsByBrokerID(ctx, repository, object.GetID())
+	if err != nil {
+		return err
+	}
+
+	if len(instanceIDs) > 0 {
+		log.C(ctx).Infof("Found service instances associated with broker with ID (%s): %s", object.GetID(), instanceIDs)
+		return &util.ErrForeignKeyViolation{
+			Entity:             types.ServicePlanType.String(),
+			ReferenceEntity:    types.ServiceInstanceType.String(),
+			ReferenceEntityIDs: instanceIDs,
+		}
+	}
+
+	log.C(ctx).Debugf("No service instances associated with broker with ID (%s) were found. Broker deletion can continue...", object.GetID())
+	return nil
+}
+
+func retrieveCatalogPlanIDs(services []*types.ServiceOffering) []string {
+	catalogPlanIDs := make([]string, 0)
+	for _, svc := range services {
+		for _, plan := range svc.Plans {
+			catalogPlanIDs = append(catalogPlanIDs, plan.ID)
+		}
+	}
+	return catalogPlanIDs
+}
+
+func retrieveServiceInstanceIDsByCatalogPlanIDs(ctx context.Context, repository storage.Repository, catalogPlanIDs []string) ([]string, error) {
+	if len(catalogPlanIDs) == 0 {
+		return []string{}, nil
+	}
+
+	byCatalogPlanIDs := query.ByField(query.InOperator, "catalog_id", catalogPlanIDs...)
+	instanceIDs, err := retrieveServiceInstanceIDsByPlanCriteria(ctx, repository, byCatalogPlanIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return instanceIDs, nil
+}
+
+func retrieveServiceInstanceIDsByBrokerID(ctx context.Context, repository storage.Repository, brokerID string) ([]string, error) {
+	byBrokerID := query.ByField(query.EqualsOperator, "broker_id", brokerID)
+	offeringList, err := repository.List(ctx, types.ServiceOfferingType, byBrokerID)
+	if err != nil {
+		return nil, util.HandleStorageError(err, types.ServiceOfferingType.String())
+	}
+
+	if offeringList.Len() == 0 {
+		return []string{}, nil
+	}
+
+	offeringIDs := make([]string, 0)
+	for i := 0; i < offeringList.Len(); i++ {
+		offeringIDs = append(offeringIDs, offeringList.ItemAt(i).GetID())
+	}
+
+	byOfferingIDs := query.ByField(query.InOperator, "service_offering_id", offeringIDs...)
+	instanceIDs, err := retrieveServiceInstanceIDsByPlanCriteria(ctx, repository, byOfferingIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	return instanceIDs, nil
+}
+
+func retrieveServiceInstanceIDsByPlanCriteria(ctx context.Context, repository storage.Repository, planCriteria ...query.Criterion) ([]string, error) {
+	planList, err := repository.List(ctx, types.ServicePlanType, planCriteria...)
+	if err != nil {
+		return nil, util.HandleStorageError(err, types.ServicePlanType.String())
+	}
+
+	if planList.Len() == 0 {
+		return []string{}, nil
+	}
+
+	planIDs := make([]string, 0)
+	for i := 0; i < planList.Len(); i++ {
+		planIDs = append(planIDs, planList.ItemAt(i).GetID())
+	}
+
+	byPlanIDs := query.ByField(query.InOperator, "service_plan_id", planIDs...)
+	instanceIDs, err := retrieveServiceInstanceIDsByCriteria(ctx, repository, byPlanIDs)
+	if err != nil {
+		return nil, util.HandleStorageError(err, types.ServiceInstanceType.String())
+	}
+
+	return instanceIDs, nil
+}

--- a/api/configuration/controller.go
+++ b/api/configuration/controller.go
@@ -35,6 +35,13 @@ func (c *Controller) setLoggingConfiguration(r *web.Request) (*web.Response, err
 	if err := util.BytesToObject(r.Body, &loggingConfig); err != nil {
 		return nil, err
 	}
+	if err := loggingConfig.Validate(); err != nil {
+		return nil, &util.HTTPError{
+			ErrorType:   "BadRequest",
+			Description: err.Error(),
+			StatusCode:  http.StatusBadRequest,
+		}
+	}
 
 	log.C(ctx).Infof("Attempting to set logging configuration with level: %s and format: %s", loggingConfig.Level, loggingConfig.Format)
 

--- a/api/filters/protected_labels.go
+++ b/api/filters/protected_labels.go
@@ -70,6 +70,15 @@ func (flo *ProtectedLabelsFilter) Run(req *web.Request, next web.Handler) (*web.
 		if err := util.BytesToObject(labelsBytes, &labels); err != nil {
 			return nil, err
 		}
+
+		if err := labels.Validate(); err != nil {
+			return nil, &util.HTTPError{
+				ErrorType:   "BadRequest",
+				Description: err.Error(),
+				StatusCode:  http.StatusBadRequest,
+			}
+		}
+
 		for lKey := range labels {
 			_, found := flo.protectedLabels[lKey]
 			if !found {

--- a/api/osb/store_instances_plugin.go
+++ b/api/osb/store_instances_plugin.go
@@ -192,6 +192,10 @@ func (ssi *StoreServiceInstancePlugin) Provision(request *web.Request, next web.
 		return nil, err
 	}
 
+	if err := util.Validate(requestPayload); err != nil {
+		return nil, err
+	}
+
 	response, err := next.Handle(request)
 	if err != nil {
 		return nil, err
@@ -270,7 +274,7 @@ func (ssi *StoreServiceInstancePlugin) Deprovision(request *web.Request, next we
 			byID := query.ByField(query.EqualsOperator, "id", requestPayload.InstanceID)
 			if _, err := storage.Delete(ctx, types.ServiceInstanceType, byID); err != nil {
 				if err != util.ErrNotFoundInStorage {
-					return util.HandleStorageError(err, string(types.ServiceInstanceType))
+					return util.HandleStorageError(err, types.ServiceInstanceType.String())
 
 				}
 			}
@@ -295,6 +299,10 @@ func (ssi *StoreServiceInstancePlugin) UpdateService(request *web.Request, next 
 
 	requestPayload := &updateRequest{}
 	if err := decodeRequestBody(request, requestPayload); err != nil {
+		return nil, err
+	}
+
+	if err := util.Validate(requestPayload); err != nil {
 		return nil, err
 	}
 
@@ -373,7 +381,7 @@ func (ssi *StoreServiceInstancePlugin) PollInstance(request *web.Request, next w
 		}
 		op, err := storage.Get(ctx, types.OperationType, criteria...)
 		if err != nil && err != util.ErrNotFoundInStorage {
-			return util.HandleStorageError(err, string(types.OperationType))
+			return util.HandleStorageError(err, types.OperationType.String())
 		}
 		if op == nil {
 			return nil
@@ -395,7 +403,7 @@ func (ssi *StoreServiceInstancePlugin) PollInstance(request *web.Request, next w
 					byID := query.ByField(query.EqualsOperator, "id", requestPayload.InstanceID)
 					if _, err := storage.Delete(ctx, types.ServiceInstanceType, byID); err != nil {
 						if err != util.ErrNotFoundInStorage {
-							return util.HandleStorageError(err, string(types.ServiceInstanceType))
+							return util.HandleStorageError(err, types.ServiceInstanceType.String())
 						}
 					}
 					if err := ssi.updateOperation(ctx, operationFromDB, storage, requestPayload, &resp.Response, types.FAILED, correlationID); err != nil {
@@ -422,7 +430,7 @@ func (ssi *StoreServiceInstancePlugin) PollInstance(request *web.Request, next w
 					byID := query.ByField(query.EqualsOperator, "id", requestPayload.InstanceID)
 					if _, err := storage.Delete(ctx, types.ServiceInstanceType, byID); err != nil {
 						if err != util.ErrNotFoundInStorage {
-							return util.HandleStorageError(err, string(types.ServiceInstanceType))
+							return util.HandleStorageError(err, types.ServiceInstanceType.String())
 						}
 					}
 					if err := ssi.updateOperation(ctx, operationFromDB, storage, requestPayload, &resp.Response, types.SUCCEEDED, correlationID); err != nil {
@@ -536,7 +544,7 @@ func (ssi *StoreServiceInstancePlugin) updateInstance(ctx context.Context, req *
 	var err error
 	if instance, err = storage.Get(ctx, types.ServiceInstanceType, byID); err != nil {
 		if err != util.ErrNotFoundInStorage {
-			return util.HandleStorageError(err, string(types.ServiceInstanceType))
+			return util.HandleStorageError(err, types.ServiceInstanceType.String())
 		}
 	}
 	if instance == nil {
@@ -582,7 +590,7 @@ func (ssi *StoreServiceInstancePlugin) rollbackInstance(ctx context.Context, req
 	var instance types.Object
 	var err error
 	if instance, err = storage.Get(ctx, types.ServiceInstanceType, byID); err != nil {
-		return util.HandleStorageError(err, string(types.ServiceInstanceType))
+		return util.HandleStorageError(err, types.ServiceInstanceType.String())
 	}
 	if instance == nil {
 		return nil
@@ -618,7 +626,7 @@ func (ssi *StoreServiceInstancePlugin) updateInstanceReady(ctx context.Context, 
 	var instance types.Object
 	var err error
 	if instance, err = storage.Get(ctx, types.ServiceInstanceType, byID); err != nil {
-		return util.HandleStorageError(err, string(types.ServiceInstanceType))
+		return util.HandleStorageError(err, types.ServiceInstanceType.String())
 	}
 	if instance == nil {
 		return nil
@@ -638,14 +646,14 @@ func findServicePlanIDByCatalogIDs(ctx context.Context, storage storage.Reposito
 	byBrokerID := query.ByField(query.EqualsOperator, "broker_id", brokerID)
 	serviceOffering, err := storage.Get(ctx, types.ServiceOfferingType, byBrokerID, byCatalogServiceID)
 	if err != nil {
-		return "", util.HandleStorageError(err, string(types.ServiceOfferingType))
+		return "", util.HandleStorageError(err, types.ServiceOfferingType.String())
 	}
 
 	byServiceOfferingID := query.ByField(query.EqualsOperator, "service_offering_id", serviceOffering.GetID())
 	byCatalogPlanID := query.ByField(query.EqualsOperator, "catalog_id", catalogPlanID)
 	servicePlan, err := storage.Get(ctx, types.ServicePlanType, byServiceOfferingID, byCatalogPlanID)
 	if err != nil {
-		return "", util.HandleStorageError(err, string(types.ServicePlanType))
+		return "", util.HandleStorageError(err, types.ServicePlanType.String())
 	}
 
 	return servicePlan.GetID(), nil

--- a/api/platform_validator.go
+++ b/api/platform_validator.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"context"
+	"github.com/Peripli/service-manager/pkg/log"
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/Peripli/service-manager/pkg/util"
+	"github.com/Peripli/service-manager/storage"
+)
+
+// PlatformValidator is a type of ResourceValidator
+type PlatformValidator struct {
+	DefaultResourceValidator
+}
+
+// ValidateDelete ensures that there are no existing service instances prior to deleting of a platform
+func (pv *PlatformValidator) ValidateDelete(ctx context.Context, repository storage.Repository, object types.Object) error {
+	_, ok := object.(*types.Platform)
+	if !ok {
+		log.C(ctx).Debugf("Provided object is of type %s. Cannot validate platform deletion.", object.GetType())
+		return ErrIncompatibleObjectType
+	}
+
+	log.C(ctx).Debugf("Fetching service instances for platform with ID (%s)", object.GetID())
+	byPlatformIDs := query.ByField(query.EqualsOperator, "platform_id", object.GetID())
+	instanceIDs, err := retrieveServiceInstanceIDsByCriteria(ctx, repository, byPlatformIDs)
+	if err != nil {
+		return err
+	}
+
+	if len(instanceIDs) > 0 {
+		log.C(ctx).Infof("Found service instances associated with platform with ID (%s): %s", object.GetID(), instanceIDs)
+		return &util.ErrForeignKeyViolation{
+			Entity:             object.GetType().String(),
+			ReferenceEntity:    types.ServiceInstanceType.String(),
+			ReferenceEntityIDs: instanceIDs,
+		}
+	}
+
+	log.C(ctx).Debugf("No service instances associated with platform with ID (%s) were found. Platform deletion can continue...", object.GetID())
+	return nil
+}

--- a/api/resource_validator.go
+++ b/api/resource_validator.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/Peripli/service-manager/pkg/util"
+	"github.com/Peripli/service-manager/storage"
+	"net/http"
+)
+
+// ResourceValidator allows plugging custom validation logic prior to executing CUD API requests
+type ResourceValidator interface {
+	ValidateCreate(ctx context.Context, repository storage.Repository, object types.Object) error
+	ValidateUpdate(ctx context.Context, repository storage.Repository, object types.Object) error
+	ValidateDelete(ctx context.Context, repository storage.Repository, object types.Object) error
+}
+
+var ErrIncompatibleObjectType = errors.New("incompatible object type provided")
+
+type DefaultResourceValidator struct{}
+
+func (drv *DefaultResourceValidator) ValidateCreate(_ context.Context, _ storage.Repository, object types.Object) error {
+	if err := object.Validate(); err != nil {
+		return &util.HTTPError{
+			ErrorType:   "BadRequest",
+			Description: err.Error(),
+			StatusCode:  http.StatusBadRequest,
+		}
+	}
+	return nil
+}
+
+func (drv *DefaultResourceValidator) ValidateUpdate(_ context.Context, _ storage.Repository, object types.Object) error {
+	if err := object.Validate(); err != nil {
+		return &util.HTTPError{
+			ErrorType:   "BadRequest",
+			Description: err.Error(),
+			StatusCode:  http.StatusBadRequest,
+		}
+	}
+	return nil
+}
+
+func (drv *DefaultResourceValidator) ValidateDelete(_ context.Context, _ storage.Repository, object types.Object) error {
+	return nil
+}
+
+func retrieveServiceInstanceIDsByCriteria(ctx context.Context, repository storage.Repository, criteria ...query.Criterion) ([]string, error) {
+	objectList, err := repository.List(ctx, types.ServiceInstanceType, criteria...)
+	if err != nil {
+		return nil, util.HandleStorageError(err, types.ServiceInstanceType.String())
+	}
+
+	instanceIDs := make([]string, 0)
+	for i := 0; i < objectList.Len(); i++ {
+		instanceIDs = append(instanceIDs, objectList.ItemAt(i).GetID())
+	}
+
+	return instanceIDs, nil
+}

--- a/api/service_instance_controller.go
+++ b/api/service_instance_controller.go
@@ -33,9 +33,17 @@ type ServiceInstanceController struct {
 
 func NewServiceInstanceController(repository storage.Repository, defaultPageSize, maxPageSize int) *ServiceInstanceController {
 	return &ServiceInstanceController{
-		BaseController: NewController(repository, web.ServiceInstancesURL, types.ServiceInstanceType, func() types.Object {
-			return &types.ServiceInstance{}
-		}, defaultPageSize, maxPageSize),
+		BaseController: &BaseController{
+			ResourceBaseURL: web.ServiceInstancesURL,
+			ObjectType:      types.ServiceInstanceType,
+			ObjectBlueprint: func() types.Object {
+				return &types.ServiceInstance{}
+			},
+			Repository:        repository,
+			DefaultPageSize:   defaultPageSize,
+			MaxPageSize:       maxPageSize,
+			ResourceValidator: &DefaultResourceValidator{},
+		},
 	}
 }
 func (c *ServiceInstanceController) Routes() []web.Route {

--- a/api/service_offering_controller.go
+++ b/api/service_offering_controller.go
@@ -33,9 +33,17 @@ type ServiceOfferingController struct {
 
 func NewServiceOfferingController(repository storage.Repository, defaultPageSize, maxPageSize int) *ServiceOfferingController {
 	return &ServiceOfferingController{
-		BaseController: NewController(repository, web.ServiceOfferingsURL, types.ServiceOfferingType, func() types.Object {
-			return &types.ServiceOffering{}
-		}, defaultPageSize, maxPageSize),
+		BaseController: &BaseController{
+			ResourceBaseURL: web.ServiceOfferingsURL,
+			ObjectType:      types.ServiceOfferingType,
+			ObjectBlueprint: func() types.Object {
+				return &types.ServiceOffering{}
+			},
+			Repository:        repository,
+			DefaultPageSize:   defaultPageSize,
+			MaxPageSize:       maxPageSize,
+			ResourceValidator: &DefaultResourceValidator{},
+		},
 	}
 }
 func (c *ServiceOfferingController) Routes() []web.Route {

--- a/api/service_plan_controller.go
+++ b/api/service_plan_controller.go
@@ -32,9 +32,17 @@ type ServicePlanController struct {
 
 func NewServicePlanController(repository storage.Repository, defaultPageSize, maxPageSize int) *ServicePlanController {
 	return &ServicePlanController{
-		BaseController: NewController(repository, web.ServicePlansURL, types.ServicePlanType, func() types.Object {
-			return &types.ServicePlan{}
-		}, defaultPageSize, maxPageSize),
+		BaseController: &BaseController{
+			ResourceBaseURL: web.ServicePlansURL,
+			ObjectType:      types.ServicePlanType,
+			ObjectBlueprint: func() types.Object {
+				return &types.ServicePlan{}
+			},
+			Repository:        repository,
+			DefaultPageSize:   defaultPageSize,
+			MaxPageSize:       maxPageSize,
+			ResourceValidator: &DefaultResourceValidator{},
+		},
 	}
 }
 

--- a/pkg/query/update.go
+++ b/pkg/query/update.go
@@ -19,6 +19,7 @@ package query
 import (
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/Peripli/service-manager/pkg/types"
 
@@ -84,6 +85,14 @@ func LabelChangesFromJSON(jsonBytes []byte) ([]*LabelChange, error) {
 
 	if err := util.BytesToObject([]byte(labelChangesBytes), &labelChanges); err != nil {
 		return nil, err
+	}
+
+	if err := labelChanges.Validate(); err != nil {
+		return nil, &util.HTTPError{
+			ErrorType:   "BadRequest",
+			Description: err.Error(),
+			StatusCode:  http.StatusBadRequest,
+		}
 	}
 
 	for _, v := range labelChanges {

--- a/pkg/util/api.go
+++ b/pkg/util/api.go
@@ -88,19 +88,7 @@ func RequestBodyToBytes(request *http.Request) ([]byte, error) {
 
 // BytesToObject converts the provided bytes to object and validates it
 func BytesToObject(bytes []byte, object interface{}) error {
-	if err := unmarshal(bytes, object); err != nil {
-		return err
-	}
-	if err := validate(object); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// unmarshal unmarshals the specified []byte into the provided value and returns an HttpError in unmarshaling fails
-func unmarshal(body []byte, value interface{}) error {
-	err := json.Unmarshal(body, value)
+	err := json.Unmarshal(bytes, object)
 	if err != nil {
 		log.D().Error("Failed to decode request body: ", err)
 		return &HTTPError{
@@ -112,8 +100,8 @@ func unmarshal(body []byte, value interface{}) error {
 	return nil
 }
 
-// validate validates the specified value in case it implements InputValidator
-func validate(value interface{}) error {
+// Validate validates the specified value in case it implements InputValidator
+func Validate(value interface{}) error {
 	if input, ok := value.(InputValidator); ok {
 		if err := input.Validate(); err != nil {
 			return &HTTPError{

--- a/storage/postgres/storage.go
+++ b/storage/postgres/storage.go
@@ -255,8 +255,9 @@ func (ps *Storage) Delete(ctx context.Context, objType types.ObjectType, criteri
 			referenceEntityName := ps.scheme.entityToObjectTypeConverter[pqError.Table]
 
 			return nil, &util.ErrForeignKeyViolation{
-				Entity:          entityName,
-				ReferenceEntity: referenceEntityName,
+				Entity:             entityName,
+				ReferenceEntity:    referenceEntityName,
+				ReferenceEntityIDs: []string{},
 			}
 		}
 

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -640,7 +640,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							Status(http.StatusOK).
 							JSON().Object()
 
-						assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+						assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 
 						reply = ctx.SMWithOAuth.GET(web.ServiceBrokersURL + "/" + brokerID).
 							Expect().
@@ -661,7 +661,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							ContainsKey("created_at").
 							ValueNotEqual("created_at", createdAt)
 
-						assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+						assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 
 						ctx.SMWithOAuth.GET(web.ServiceBrokersURL+"/"+brokerID).
 							Expect().
@@ -717,7 +717,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								ContainsMap(expectedUpdatedBrokerResponse).
 								Keys().NotContains("services", "credentials")
 
-							assertInvocationCount(updatedBrokerServer.CatalogEndpointRequests, 1)
+							assertInvocationCount(updatedBrokerServer.CatalogEndpointRequests, 2)
 
 							ctx.SMWithOAuth.GET(web.ServiceBrokersURL+"/"+brokerID).
 								Expect().
@@ -745,7 +745,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Keys().NotContains("services", "credentials")
 
 							assertInvocationCount(brokerServer.CatalogEndpointRequests, 0)
-							assertInvocationCount(updatedBrokerServer.CatalogEndpointRequests, 1)
+							assertInvocationCount(updatedBrokerServer.CatalogEndpointRequests, 2)
 
 							ctx.SMWithOAuth.GET(web.ServiceBrokersURL+"/"+brokerID).
 								Expect().
@@ -800,7 +800,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Keys().NotContains("services", "credentials")
 
 						}
-						assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
+						assertInvocationCount(brokerServer.CatalogEndpointRequests, 4)
 					})
 				})
 
@@ -819,7 +819,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusNotFound)
 
-							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+							assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 						})
 					})
 
@@ -843,7 +843,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							ctx.SMWithOAuth.List(web.ServiceBrokersURL).First().Object().
 								ContainsMap(expectedBrokerResponse)
 
-							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+							assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 						})
 					})
 				})
@@ -936,7 +936,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							plansJsonResp.Path("$[*].catalog_id").Array().Contains(existingPlanID)
 							plansJsonResp.Path("$[*].service_offering_id").Array().Contains(soID)
 
-							assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
+							assertInvocationCount(brokerServer.CatalogEndpointRequests, 4)
 						})
 
 						It("is returned from the repository as part of the brokers catalog field", func() {
@@ -994,7 +994,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							plansJsonResp.Path("$[*].catalog_id").Array().Contains(anotherPlanID)
 							plansJsonResp.Path("$[*].service_offering_id").Array().Contains(soID)
 
-							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+							assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 						})
 
 						It("is returned from the repository as part of the brokers catalog field", func() {
@@ -1019,7 +1019,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						It("returns correct response", func() {
 							responseVerifier(ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerID).WithJSON(common.Object{}).Expect())
 
-							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+							assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 						})
 
 						Specify("the catalog is correctly returned by the repository", func() {
@@ -1045,7 +1045,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						It("returns correct response", func() {
 							responseVerifier(ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerID).WithJSON(common.Object{}).Expect())
 
-							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+							assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 						})
 
 						Specify("the catalog is correctly returned by the repository", func() {
@@ -1080,7 +1080,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							jsonResp.Path("$[*].catalog_id").Array().Contains(anotherServiceID)
 							jsonResp.Path("$[*].broker_id").Array().Contains(brokerID)
 
-							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+							assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 						})
 
 						It("is returned from the repository as part of the brokers catalog field", func() {
@@ -1140,7 +1140,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								ctx.SMWithOAuth.List(web.ServiceOfferingsURL).NotContains(serviceOfferingID)
 								ctx.SMWithOAuth.List(web.ServicePlansURL).NotContains(planIDsForService)
 
-								assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+								assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 							})
 
 							It("is not returned from the repository as part of the brokers catalog field", func() {
@@ -1157,7 +1157,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect(err).To(Not(HaveOccurred()))
 							})
 
-							It("should return 400 with user-friendly message", func() {
+							It("should fail and return 400 with user-friendly message containing existing instance IDs", func() {
 								plans := ctx.SMWithOAuth.List(web.ServicePlansURL).Iter()
 
 								var planIDsForService []string
@@ -1179,20 +1179,23 @@ var _ = test.DescribeTestsFor(test.TestCase{
 									serviceInstanceIDs = append(serviceInstanceIDs, serviceInstance.ID)
 								}
 
-								ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerID).
+								resp := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerID).
 									WithJSON(common.Object{}).
 									Expect().
 									Status(http.StatusConflict).
-									JSON().Object().
-									Value("error").String().Contains("ExistingReferenceEntity")
+									JSON().Object()
 
-								ctx.SMWithOAuth.GET(web.ServiceOfferingsURL + "/" + serviceOfferingID).
-									Expect().
-									Status(http.StatusOK).Body().NotEmpty()
+								resp.Value("error").String().Contains("ExistingReferenceEntity")
+								resp.Value("description").String().Contains(strings.Join(serviceInstanceIDs, ","))
+
+								serviceOfferings := ctx.SMWithOAuth.ListWithQuery(web.ServiceOfferingsURL, fmt.Sprintf("fieldQuery=id eq '%s'", serviceOfferingID))
+								serviceOfferings.NotEmpty()
 
 								servicePlans := ctx.SMWithOAuth.ListWithQuery(web.ServicePlansURL, "fieldQuery="+fmt.Sprintf("id in ('%s')", strings.Join(planIDsForService, "','")))
 								servicePlans.NotEmpty()
 								servicePlans.Length().Equal(len(planIDsForService))
+
+								assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
 							})
 						})
 					})
@@ -1214,7 +1217,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 									Expect().
 									Status(http.StatusConflict).JSON().Object().Keys().Contains("error", "description")
 
-								assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+								assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 							})
 
 							Specify("the catalog before the modification is returned by the repository", func() {
@@ -1304,7 +1307,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							jsonResp.Path("$[*].catalog_id").Array().Contains(anotherPlanID)
 							jsonResp.Path("$[*].service_offering_id").Array().Contains(serviceOfferingID)
 
-							assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+							assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 						})
 
 						It("is returned from the repository as part of the brokers catalog field", func() {
@@ -1324,7 +1327,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							brokerServer.Catalog = common.SBCatalog(s)
 						})
 
-						Context("with no existing service instances", func() {
+						Context("without existing service instances", func() {
 							It("is no longer returned by the Plans API", func() {
 								ctx.SMWithOAuth.List(web.ServicePlansURL).
 									Path("$[*].catalog_id").Array().Contains(removedPlanCatalogID)
@@ -1337,7 +1340,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								ctx.SMWithOAuth.List(web.ServicePlansURL).
 									Path("$[*].catalog_id").Array().NotContains(removedPlanCatalogID)
 
-								assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+								assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 							})
 
 							It("is not returned from the repository as part of the brokers catalog field", func() {
@@ -1362,19 +1365,23 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect(err).To(Not(HaveOccurred()))
 							})
 
-							It("should return 400 with user-friendly message", func() {
+							It("should fail and return 400 with user-friendly message containing existing instance ID", func() {
 								ctx.SMWithOAuth.List(web.ServicePlansURL).
 									Path("$[*].catalog_id").Array().Contains(removedPlanCatalogID)
 
-								ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerID).
+								resp := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerID).
 									WithJSON(common.Object{}).
 									Expect().
 									Status(http.StatusConflict).
-									JSON().Object().
-									Value("error").String().Contains("ExistingReferenceEntity")
+									JSON().Object()
+
+								resp.Value("error").String().Contains("ExistingReferenceEntity")
+								resp.Value("description").String().Contains(serviceInstance.ID)
 
 								ctx.SMWithOAuth.List(web.ServicePlansURL).
 									Path("$[*].catalog_id").Array().Contains(removedPlanCatalogID)
+
+								assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
 							})
 						})
 					})
@@ -1397,7 +1404,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 									Expect().
 									Status(http.StatusConflict).JSON().Object().Keys().Contains("error", "description")
 
-								assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+								assertInvocationCount(brokerServer.CatalogEndpointRequests, 2)
 							})
 
 							Specify("the catalog before the modification is returned by the repository", func() {
@@ -1667,12 +1674,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 			Describe("DELETE", func() {
 				var (
-					brokerID string
+					brokerID        string
+					serviceInstance *types.ServiceInstance
 				)
 
 				BeforeEach(func() {
-					var serviceInstance *types.ServiceInstance
-
 					brokerID, serviceInstance = service_instance.Prepare(ctx, ctx.TestPlatform.ID, "", "{}")
 					ctx.SMRepository.Create(context.Background(), serviceInstance)
 				})
@@ -1682,12 +1688,22 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				})
 
 				Context("with existing service instances to some broker plan", func() {
-					It("should return 400 with user-friendly message", func() {
-						ctx.SMWithOAuth.DELETE(web.ServiceBrokersURL + "/" + brokerID).
+					It("should fail and return 400 with user-friendly message containing existing instance ID", func() {
+						ctx.SMWithOAuth.GET(web.ServiceBrokersURL + "/" + brokerID).
+							Expect().
+							Status(http.StatusOK)
+
+						resp := ctx.SMWithOAuth.DELETE(web.ServiceBrokersURL + "/" + brokerID).
 							Expect().
 							Status(http.StatusConflict).
-							JSON().Object().
-							Value("error").String().Contains("ExistingReferenceEntity")
+							JSON().Object()
+
+						resp.Value("error").String().Contains("ExistingReferenceEntity")
+						resp.Value("description").String().Contains(serviceInstance.ID)
+
+						ctx.SMWithOAuth.GET(web.ServiceBrokersURL + "/" + brokerID).
+							Expect().
+							Status(http.StatusOK)
 					})
 				})
 			})

--- a/test/osb_test/osb_suite_test.go
+++ b/test/osb_test/osb_suite_test.go
@@ -123,7 +123,7 @@ var _ = AfterSuite(func() {
 
 func assertMissingBrokerError(req *httpexpect.Response) {
 	req.Status(http.StatusNotFound).JSON().Object().
-		Value("description").String().Contains("could not find such broker")
+		Value("description").String().Contains("could not find such " + types.ServiceBrokerType.String())
 }
 
 func assertUnresponsiveBrokerError(req *httpexpect.Response) {


### PR DESCRIPTION
# Introduce Resource Validator [API-level validation]

## Motivation [related to #358]

Current validation of entities approach is very limited and hidden. It allows us to pretty much check only entity properties for validity.

The intent of this change is to expand on the term "validate" and allow making API-level validation, or in other words to validate whether specific POST/PATCH/DELETE requests are valid.

This way we can make custom validation checks prior to actually executing the POST/PATCH/DELETE operation.

Examples of such use cases are:
- Platform entities should not be deleted if Service Instance entities exist
- Broker entities should not be deleted if Service Instance entities associated with one of the broker's catalog exist
- Broker's catalog should not allow removal of one of its Service Plan entities if Service Instance entities associated with this service plan exist 

## Approach

A new interface `ResourceValidator` is introduced. Every base controller will have one.

```go
type ResourceValidator interface {
	ValidateCreate(ctx context.Context, repository storage.Repository, object types.Object) error
	ValidateUpdate(ctx context.Context, repository storage.Repository, object types.Object) error
	ValidateDelete(ctx context.Context, repository storage.Repository, object types.Object) error
}
```

The idea is that just before passing the current object for _Creation/Update/Deletion_ to a controller's repository to execute the request, the corresponding `ValidateCreate`, `ValidateUpdate` and `ValidateDelete` will be called.

There is a `DefaultResourceValidator` for controllers which don't require custom validation logic.

If someone wants to create a custom API validator for some resource, he only has to implement `ResourceValidator` and provide that implementation to the specific API controller. 

## Use case example

Broker's catalog should not allow removal of one of its Service Plan entities if Service Instance entities associated with this service plan exist. This means we need to introduce a `BrokerValidator` and define it's `ValidateUpdate` method to check what's needed.

Here's an example error message if the validation fails:

```json
{
  "error": "ExistingReferenceEntity",
  "description": "Error executing ServiceBroker request: Could not delete ServicePlan due to one or more existing ServiceInstance reference entities with ID(s): [57bd8c39-d736-4089-aa5c-8a28e0f5d749,e3f8db5b-4425-4a4c-8bc5-95825f785d26,095d0237-ad89-4ef5-8f15-c09216bb52c9]"
}
```

## Pros/Cons of such an API-level validation approach

Pros:
* Can have custom validation logic for each API type
* Gives access to violation IDs (in cases such as foreign key violation constraints, eg. deleting a Platform with Service Instances) 
* Save valuable time troubleshooting

Cons:
* Possible race conditions - validation DB calls are not in the same transaction as the requested CUD operation. **[we should think of a way to move this API-level validation a little further down (eg. somewhere right after the start of the interceptor chain) - this way we can ensure that no race conditions will occur]**. If we cannot mitigate this - we can at least combine this approach with #358 and in this way when a race condition does occur, the client will receive 400 Bad request with both entity and violation entity - they just won't have the violation IDs in the response message.
* Extra DB calls (unavoidable, requiring to do custom validation pretty much guarantees that this will happen)
* Will have to call Validate method manually in certain places

## Note

This change allows us to remove the hidden `Validate()` invocation from the `BytesToObject()` implementation. If this new validation approach is adopted, the other repos need to be updated.

## Pull Request status

* [x] Initial implementation
* [x] Integration tests