### PR TITLE
Forbid registering brokers with long names

### DIFF
--- a/pkg/types/service_broker.go
+++ b/pkg/types/service_broker.go
@@ -20,7 +20,11 @@ package types
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strconv"
 )
+
+const maxNameLength = 255
 
 //go:generate smgen api ServiceBroker
 // ServiceBroker broker struct
@@ -48,6 +52,9 @@ func (e *ServiceBroker) GetCredentials() *Credentials {
 func (e *ServiceBroker) Validate() error {
 	if e.Name == "" {
 		return errors.New("missing broker name")
+	}
+	if len(e.Name) > maxNameLength {
+		return errors.New(fmt.Sprintf("broker name cannot exceed %s symbols", strconv.Itoa(maxNameLength)))
 	}
 	if e.BrokerURL == "" {
 		return errors.New("missing broker url")

--- a/pkg/types/service_broker.go
+++ b/pkg/types/service_broker.go
@@ -54,7 +54,7 @@ func (e *ServiceBroker) Validate() error {
 		return errors.New("missing broker name")
 	}
 	if len(e.Name) > maxNameLength {
-		return errors.New(fmt.Sprintf("broker name cannot exceed %s symbols", strconv.Itoa(maxNameLength)))
+		return fmt.Errorf("broker name cannot exceed %s symbols", strconv.Itoa(maxNameLength))
 	}
 	if e.BrokerURL == "" {
 		return errors.New("missing broker url")

--- a/pkg/util/api.go
+++ b/pkg/util/api.go
@@ -118,7 +118,7 @@ func validate(value interface{}) error {
 		if err := input.Validate(); err != nil {
 			return &HTTPError{
 				ErrorType:   "BadRequest",
-				Description: input.Validate().Error(),
+				Description: err.Error(),
 				StatusCode:  http.StatusBadRequest,
 			}
 		}

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -238,6 +238,29 @@ var _ = test.DescribeTestsFor(test.TestCase{
 					})
 				})
 
+				Context("when request body has invalid field", func() {
+					Context("when name field is too long", func() {
+						BeforeEach(func() {
+							length := 500
+							brokerName := make([]rune, length)
+							for i := range brokerName {
+								brokerName[i] = 'a'
+							}
+							postBrokerRequestWithLabels["name"] = string(brokerName)
+						})
+
+						It("returns 400", func() {
+							ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerRequestWithLabels).
+								Expect().
+								Status(http.StatusBadRequest).
+								JSON().Object().
+								Keys().Contains("error", "description")
+
+							assertInvocationCount(brokerServer.CatalogEndpointRequests, 0)
+						})
+					})
+				})
+
 				Context("when obtaining the broker catalog fails because the broker is not reachable", func() {
 					BeforeEach(func() {
 						postBrokerRequestWithNoLabels["broker_url"] = "http://localhost:12345"


### PR DESCRIPTION
# Forbid registering brokers with long names

## Motivation

Sometimes broker registrations contain names longer than the DB max char limit (255) for that field, which results in 500 Internal Server error.

## Approach

The `Validate()` method of the Service Broker entity ensures the broker name is lesser than 255 symbols. If it is bigger, 400 Bad Request with appropriate error message is returned.

## Pull Request status

* [x] Initial implementation
* [x] Integration tests
