### PR TITLE
Delete notifications to not return result

### DIFF
--- a/api/base_controller.go
+++ b/api/base_controller.go
@@ -149,7 +149,7 @@ func (c *BaseController) DeleteObjects(r *web.Request) (*web.Response, error) {
 	log.C(ctx).Debugf("Deleting %ss...", c.objectType)
 
 	criteria := query.CriteriaForContext(ctx)
-	if _, err := c.repository.Delete(ctx, c.objectType, criteria...); err != nil {
+	if err := c.repository.Delete(ctx, c.objectType, criteria...); err != nil {
 		return nil, util.HandleStorageError(err, c.objectType.String())
 	}
 

--- a/api/osb/store_instances_plugin.go
+++ b/api/osb/store_instances_plugin.go
@@ -270,7 +270,7 @@ func (ssi *StoreServiceInstancePlugin) Deprovision(request *web.Request, next we
 			fallthrough
 		case http.StatusGone:
 			byID := query.ByField(query.EqualsOperator, "id", requestPayload.InstanceID)
-			if _, err := storage.Delete(ctx, types.ServiceInstanceType, byID); err != nil {
+			if err := storage.Delete(ctx, types.ServiceInstanceType, byID); err != nil {
 				if err != util.ErrNotFoundInStorage {
 					return util.HandleStorageError(err, string(types.ServiceInstanceType))
 
@@ -395,7 +395,7 @@ func (ssi *StoreServiceInstancePlugin) PollInstance(request *web.Request, next w
 					}
 				case types.FAILED:
 					byID := query.ByField(query.EqualsOperator, "id", requestPayload.InstanceID)
-					if _, err := storage.Delete(ctx, types.ServiceInstanceType, byID); err != nil {
+					if err := storage.Delete(ctx, types.ServiceInstanceType, byID); err != nil {
 						if err != util.ErrNotFoundInStorage {
 							return util.HandleStorageError(err, string(types.ServiceInstanceType))
 						}
@@ -422,7 +422,7 @@ func (ssi *StoreServiceInstancePlugin) PollInstance(request *web.Request, next w
 				switch resp.State {
 				case types.SUCCEEDED:
 					byID := query.ByField(query.EqualsOperator, "id", requestPayload.InstanceID)
-					if _, err := storage.Delete(ctx, types.ServiceInstanceType, byID); err != nil {
+					if err := storage.Delete(ctx, types.ServiceInstanceType, byID); err != nil {
 						if err != util.ErrNotFoundInStorage {
 							return util.HandleStorageError(err, string(types.ServiceInstanceType))
 						}

--- a/pkg/web/api.go
+++ b/pkg/web/api.go
@@ -226,6 +226,15 @@ func (api *API) filterNames(filters []Filter) []string {
 	return filterNames
 }
 
+func (api *API) pluginNames(plugins []Plugin) []string {
+	var pluginNames []string
+	for i := range plugins {
+		plugin := plugins[i]
+		pluginNames = append(pluginNames, plugin.Name())
+	}
+	return pluginNames
+}
+
 func (api *API) decomposePluginOrDie(plugin Plugin) []Filter {
 	pluginSegments := api.decomposePlugin(plugin)
 	if len(pluginSegments) == 0 {

--- a/pkg/web/api.go
+++ b/pkg/web/api.go
@@ -226,15 +226,6 @@ func (api *API) filterNames(filters []Filter) []string {
 	return filterNames
 }
 
-func (api *API) pluginNames(plugins []Plugin) []string {
-	var pluginNames []string
-	for i := range plugins {
-		plugin := plugins[i]
-		pluginNames = append(pluginNames, plugin.Name())
-	}
-	return pluginNames
-}
-
 func (api *API) decomposePluginOrDie(plugin Plugin) []Filter {
 	pluginSegments := api.decomposePlugin(plugin)
 	if len(pluginSegments) == 0 {

--- a/storage/encrypting_repository.go
+++ b/storage/encrypting_repository.go
@@ -163,8 +163,8 @@ func (er *encryptingRepository) Update(ctx context.Context, obj types.Object, la
 	return updatedObj, nil
 }
 
-func (er *encryptingRepository) Delete(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (types.ObjectList, error) {
-	objList, err := er.repository.Delete(ctx, objectType, criteria...)
+func (er *encryptingRepository) DeleteReturning(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (types.ObjectList, error) {
+	objList, err := er.repository.DeleteReturning(ctx, objectType, criteria...)
 	if err != nil {
 		return nil, err
 	}
@@ -176,6 +176,14 @@ func (er *encryptingRepository) Delete(ctx context.Context, objectType types.Obj
 	}
 
 	return objList, nil
+}
+
+func (er *encryptingRepository) Delete(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) error {
+	if err := er.repository.Delete(ctx, objectType, criteria...); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (er *encryptingRepository) transformCredentials(ctx context.Context, obj types.Object, transformationFunc func(context.Context, []byte, []byte) ([]byte, error)) error {

--- a/storage/encrypting_repository_test.go
+++ b/storage/encrypting_repository_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Encrypting Repository", func() {
 
 		fakeRepository.GetReturns(objWithEncryptedPassword.(*types.ServiceBroker), nil)
 
-		fakeRepository.DeleteReturns(&types.ServiceBrokers{
+		fakeRepository.DeleteReturningReturns(&types.ServiceBrokers{
 			ServiceBrokers: []*types.ServiceBroker{
 				objWithEncryptedPassword.(*types.ServiceBroker),
 			},
@@ -311,21 +311,21 @@ var _ = Describe("Encrypting Repository", func() {
 		})
 	})
 
-	Describe("Delete", func() {
+	Describe("DeleteReturning", func() {
 		Context("when decrypting fails", func() {
 			It("returns an error", func() {
 				fakeEncrypter.DecryptReturns(nil, fmt.Errorf("error"))
 
-				_, err = repository.Delete(ctx, types.ServiceBrokerType)
+				_, err = repository.DeleteReturning(ctx, types.ServiceBrokerType)
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		Context("when delegate call fails", func() {
 			It("returns an error", func() {
-				fakeRepository.DeleteReturns(nil, fmt.Errorf("error"))
+				fakeRepository.DeleteReturns(fmt.Errorf("error"))
 
-				_, err = repository.Delete(ctx, types.ServiceBrokerType)
+				err = repository.Delete(ctx, types.ServiceBrokerType)
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -335,7 +335,7 @@ var _ = Describe("Encrypting Repository", func() {
 			var err error
 
 			BeforeEach(func() {
-				returnedObjList, err = repository.Delete(ctx, types.ServiceBrokerType)
+				returnedObjList, err = repository.DeleteReturning(ctx, types.ServiceBrokerType)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -398,7 +398,7 @@ var _ = Describe("Encrypting Repository", func() {
 
 					// verify delete
 					delegateDeleteCallsCountBeforeOp := fakeRepository.DeleteCallCount()
-					returnedObjList, err = repository.Delete(ctx, types.ServiceBrokerType)
+					returnedObjList, err = repository.DeleteReturning(ctx, types.ServiceBrokerType)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(fakeRepository.DeleteCallCount() - delegateDeleteCallsCountBeforeOp).To(Equal(1))
 					for i := 0; i < returnedObjList.Len(); i++ {

--- a/storage/interceptors/broker_delete_catalog_interceptor.go
+++ b/storage/interceptors/broker_delete_catalog_interceptor.go
@@ -35,12 +35,12 @@ func (b *brokerDeleteCatalogInterceptor) AroundTxDelete(h storage.InterceptDelet
 
 // OnTxDelete loads the broker catalog. Currently the catalog is required so that the additional data to the delete broker notifications can be attached.
 func (b *brokerDeleteCatalogInterceptor) OnTxDelete(h storage.InterceptDeleteOnTxFunc) storage.InterceptDeleteOnTxFunc {
-	return func(ctx context.Context, txStorage storage.Repository, objects types.ObjectList, deletionCriteria ...query.Criterion) (types.ObjectList, error) {
+	return func(ctx context.Context, txStorage storage.Repository, objects types.ObjectList, deletionCriteria ...query.Criterion) error {
 		brokers := objects.(*types.ServiceBrokers)
 		for _, broker := range brokers.ServiceBrokers {
 			serviceOfferings, err := b.CatalogLoader(ctx, broker.GetID(), txStorage)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
 			broker.Services = serviceOfferings.ServiceOfferings

--- a/storage/interceptors/broker_public_plans_interceptor.go
+++ b/storage/interceptors/broker_public_plans_interceptor.go
@@ -122,13 +122,13 @@ func resync(ctx context.Context, broker *types.ServiceBroker, txStorage storage.
 						hasPublicVisibility = true
 						continue
 					} else {
-						if _, err := txStorage.Delete(ctx, types.VisibilityType, byVisibilityID); err != nil {
+						if err := txStorage.Delete(ctx, types.VisibilityType, byVisibilityID); err != nil {
 							return err
 						}
 					}
 				} else {
 					if visibility.PlatformID == "" {
-						if _, err := txStorage.Delete(ctx, types.VisibilityType, byVisibilityID); err != nil {
+						if err := txStorage.Delete(ctx, types.VisibilityType, byVisibilityID); err != nil {
 							return err
 						}
 					} else {

--- a/storage/interceptors/broker_update_catalog_interceptor.go
+++ b/storage/interceptors/broker_update_catalog_interceptor.go
@@ -141,7 +141,7 @@ func (c *brokerUpdateCatalogInterceptor) OnTxUpdate(f storage.InterceptUpdateOnT
 
 		for _, existingServiceOffering := range existingServicesOfferingsMap {
 			byID := query.ByField(query.EqualsOperator, "id", existingServiceOffering.ID)
-			if _, err := txStorage.Delete(ctx, types.ServiceOfferingType, byID); err != nil {
+			if err := txStorage.Delete(ctx, types.ServiceOfferingType, byID); err != nil {
 				return nil, err
 			}
 		}
@@ -201,7 +201,7 @@ func (c *brokerUpdateCatalogInterceptor) OnTxUpdate(f storage.InterceptUpdateOnT
 		for _, existingServicePlansForOffering := range existingServicePlansPerOfferingMap {
 			for _, existingServicePlan := range existingServicePlansForOffering {
 				byID := query.ByField(query.EqualsOperator, "id", existingServicePlan.ID)
-				if _, err := txStorage.Delete(ctx, types.ServicePlanType, byID); err != nil {
+				if err := txStorage.Delete(ctx, types.ServicePlanType, byID); err != nil {
 					if err == util.ErrNotFoundInStorage {
 						// If the service for the plan was deleted, plan would already be gone
 						continue

--- a/storage/interceptors_delete.go
+++ b/storage/interceptors_delete.go
@@ -11,10 +11,10 @@ import (
 )
 
 // InterceptDeleteAroundTxFunc hook for entity deletion outside of transaction
-type InterceptDeleteAroundTxFunc func(ctx context.Context, deletionCriteria ...query.Criterion) (types.ObjectList, error)
+type InterceptDeleteAroundTxFunc func(ctx context.Context, deletionCriteria ...query.Criterion) error
 
 // InterceptDeleteOnTxFunc hook for entity deletion in transaction
-type InterceptDeleteOnTxFunc func(ctx context.Context, txStorage Repository, objects types.ObjectList, deletionCriteria ...query.Criterion) (types.ObjectList, error)
+type InterceptDeleteOnTxFunc func(ctx context.Context, txStorage Repository, objects types.ObjectList, deletionCriteria ...query.Criterion) error
 
 // DeleteAroundTxInterceptor provides hooks on entity deletion during AroundTx
 //go:generate counterfeiter . DeleteAroundTxInterceptor

--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -51,23 +51,25 @@ var (
 
 // Settings type to be loaded from the environment
 type Settings struct {
-	URI                string                `mapstructure:"uri" description:"URI of the storage"`
-	MigrationsURL      string                `mapstructure:"migrations_url" description:"location of a directory containing sql migrations scripts"`
-	EncryptionKey      string                `mapstructure:"encryption_key" description:"key to use for encrypting database entries"`
-	SkipSSLValidation  bool                  `mapstructure:"skip_ssl_validation" description:"whether to skip ssl verification when connecting to the storage"`
-	MaxIdleConnections int                   `mapstructure:"max_idle_connections" description:"sets the maximum number of connections in the idle connection pool"`
-	Notification       *NotificationSettings `mapstructure:"notification"`
+	URI                  string                `mapstructure:"uri" description:"URI of the storage"`
+	TransactionalCaching bool                  `mapstructure:"transactional_caching" description:"transactional caching of similar read statements"`
+	MigrationsURL        string                `mapstructure:"migrations_url" description:"location of a directory containing sql migrations scripts"`
+	EncryptionKey        string                `mapstructure:"encryption_key" description:"key to use for encrypting database entries"`
+	SkipSSLValidation    bool                  `mapstructure:"skip_ssl_validation" description:"whether to skip ssl verification when connecting to the storage"`
+	MaxIdleConnections   int                   `mapstructure:"max_idle_connections" description:"sets the maximum number of connections in the idle connection pool"`
+	Notification         *NotificationSettings `mapstructure:"notification"`
 }
 
 // DefaultSettings returns default values for storage settings
 func DefaultSettings() *Settings {
 	return &Settings{
-		URI:                "",
-		MigrationsURL:      fmt.Sprintf("file://%s/postgres/migrations", basepath),
-		EncryptionKey:      "",
-		SkipSSLValidation:  false,
-		MaxIdleConnections: 5,
-		Notification:       DefaultNotificationSettings(),
+		URI:                  "",
+		MigrationsURL:        fmt.Sprintf("file://%s/postgres/migrations", basepath),
+		EncryptionKey:        "",
+		TransactionalCaching: false,
+		SkipSSLValidation:    false,
+		MaxIdleConnections:   5,
+		Notification:         DefaultNotificationSettings(),
 	}
 }
 
@@ -163,8 +165,11 @@ type Repository interface {
 	// Count retrieves number of objects of particular type in SM DB
 	Count(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (int, error)
 
-	// Delete deletes an object from SM DB
-	Delete(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (types.ObjectList, error)
+	// DeleteReturning deletes objects from SM DB
+	DeleteReturning(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) (types.ObjectList, error)
+
+	//Delete deletes objects from SM DB
+	Delete(ctx context.Context, objectType types.ObjectType, criteria ...query.Criterion) error
 
 	// Update updates an object from SM DB
 	Update(ctx context.Context, obj types.Object, labelChanges query.LabelChanges, criteria ...query.Criterion) (types.Object, error)

--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -51,25 +51,23 @@ var (
 
 // Settings type to be loaded from the environment
 type Settings struct {
-	URI                  string                `mapstructure:"uri" description:"URI of the storage"`
-	TransactionalCaching bool                  `mapstructure:"transactional_caching" description:"transactional caching of similar read statements"`
-	MigrationsURL        string                `mapstructure:"migrations_url" description:"location of a directory containing sql migrations scripts"`
-	EncryptionKey        string                `mapstructure:"encryption_key" description:"key to use for encrypting database entries"`
-	SkipSSLValidation    bool                  `mapstructure:"skip_ssl_validation" description:"whether to skip ssl verification when connecting to the storage"`
-	MaxIdleConnections   int                   `mapstructure:"max_idle_connections" description:"sets the maximum number of connections in the idle connection pool"`
-	Notification         *NotificationSettings `mapstructure:"notification"`
+	URI                string                `mapstructure:"uri" description:"URI of the storage"`
+	MigrationsURL      string                `mapstructure:"migrations_url" description:"location of a directory containing sql migrations scripts"`
+	EncryptionKey      string                `mapstructure:"encryption_key" description:"key to use for encrypting database entries"`
+	SkipSSLValidation  bool                  `mapstructure:"skip_ssl_validation" description:"whether to skip ssl verification when connecting to the storage"`
+	MaxIdleConnections int                   `mapstructure:"max_idle_connections" description:"sets the maximum number of connections in the idle connection pool"`
+	Notification       *NotificationSettings `mapstructure:"notification"`
 }
 
 // DefaultSettings returns default values for storage settings
 func DefaultSettings() *Settings {
 	return &Settings{
-		URI:                  "",
-		MigrationsURL:        fmt.Sprintf("file://%s/postgres/migrations", basepath),
-		EncryptionKey:        "",
-		TransactionalCaching: false,
-		SkipSSLValidation:    false,
-		MaxIdleConnections:   5,
-		Notification:         DefaultNotificationSettings(),
+		URI:                "",
+		MigrationsURL:      fmt.Sprintf("file://%s/postgres/migrations", basepath),
+		EncryptionKey:      "",
+		SkipSSLValidation:  false,
+		MaxIdleConnections: 5,
+		Notification:       DefaultNotificationSettings(),
 	}
 }
 

--- a/storage/notification_cleaner.go
+++ b/storage/notification_cleaner.go
@@ -68,13 +68,14 @@ func (nc *NotificationCleaner) clean(ctx context.Context) {
 	log.C(ctx).Infof("Deleting notifications created before %s", cleanTimestamp)
 
 	q := query.ByField(query.LessThanOperator, "created_at", cleanTimestamp)
-	deletedNotifications, err := nc.Storage.Delete(ctx, types.NotificationType, q)
-
-	if err == util.ErrNotFoundInStorage {
-		log.C(ctx).Debug("no old notifications to delete")
-	} else if err != nil {
-		log.C(ctx).WithError(err).Error("could not delete old notifications")
+	if err := nc.Storage.Delete(ctx, types.NotificationType, q); err != nil {
+		if err == util.ErrNotFoundInStorage {
+			log.C(ctx).Debug("no old notifications to delete")
+		} else {
+			log.C(ctx).WithError(err).Error("could not delete old notifications")
+		}
 	} else {
-		log.C(ctx).Infof("successfully deleted %d old notifications", deletedNotifications.Len())
+		log.C(ctx).Infof("successfully deleted notifications created before %v", cleanTimestamp)
+
 	}
 }

--- a/storage/notification_cleaner_test.go
+++ b/storage/notification_cleaner_test.go
@@ -77,15 +77,15 @@ var _ = Describe("Notification cleaner", func() {
 
 	Describe("clean", func() {
 		Context("When scheduled", func() {
-			It("Should call storage.Delete", func() {
+			It("Should call storage.DeleteReturning", func() {
 				nc.Settings.Notification.CleanInterval = 0
 				var objType types.ObjectType
 				var criteria []query.Criterion
-				fakeStorage.DeleteStub = func(ctx context.Context, objectType types.ObjectType, criterion ...query.Criterion) (types.ObjectList, error) {
+				fakeStorage.DeleteStub = func(ctx context.Context, objectType types.ObjectType, criterion ...query.Criterion) error {
 					objType = objectType
 					criteria = criterion
 					cancel() // stop notification cleaner
-					return &types.Notifications{}, nil
+					return nil
 				}
 				err := nc.Start(ctx, wg)
 				Expect(err).ToNot(HaveOccurred())
@@ -102,13 +102,13 @@ var _ = Describe("Notification cleaner", func() {
 		checkCleanerNotStopped := func(storageError error) {
 			nc.Settings.Notification.CleanInterval = 0
 			called := false
-			fakeStorage.DeleteStub = func(ctx context.Context, objectType types.ObjectType, criterion ...query.Criterion) (types.ObjectList, error) {
+			fakeStorage.DeleteStub = func(ctx context.Context, objectType types.ObjectType, criterion ...query.Criterion) error {
 				if !called {
 					called = true
-					return nil, storageError
+					return storageError
 				} else {
 					cancel()
-					return &types.Notifications{}, nil
+					return nil
 				}
 			}
 			err := nc.Start(ctx, wg)

--- a/storage/postgres/query_builder_test.go
+++ b/storage/postgres/query_builder_test.go
@@ -463,14 +463,14 @@ LIMIT ?;`)))
 	Describe("Delete", func() {
 		Context("when entity does not have an associated label entity", func() {
 			It("returns error", func() {
-				_, err := qb.NewQuery(&postgres.Safe{}).Delete(ctx)
+				_, _, err := qb.NewQuery(&postgres.Safe{}).Delete(ctx)
 				Expect(err.Error()).To(ContainSubstring("query builder requires the entity to have associated label entity"))
 			})
 		})
 
 		Context("when no criteria is used", func() {
 			It("builds query to delete all entries", func() {
-				_, err := qb.NewQuery(entity).Delete(ctx)
+				_, _, err := qb.NewQuery(entity).Delete(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(executedQuery).To(Equal(trim(`
 DELETE
@@ -482,7 +482,7 @@ FROM visibilities ;`)))
 			It("builds query with label criteria", func() {
 				criteria1 := query.ByLabel(query.EqualsOperator, "left1", "right1")
 				criteria2 := query.ByLabel(query.InOperator, "left2", "right2", "right3")
-				_, err := qb.NewQuery(entity).WithCriteria(criteria1, criteria2).Delete(ctx)
+				_, _, err := qb.NewQuery(entity).WithCriteria(criteria1, criteria2).Delete(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(executedQuery).Should(Equal(trim(`
 DELETE
@@ -503,7 +503,7 @@ WHERE visibilities.id = t.id ;`)))
 		Context("when field criteria is used", func() {
 			It("builds query with field criteria", func() {
 				criteria := query.ByField(query.EqualsOperator, "id", "1")
-				_, err := qb.NewQuery(entity).WithCriteria(criteria).Delete(ctx)
+				_, _, err := qb.NewQuery(entity).WithCriteria(criteria).Delete(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(executedQuery).Should(Equal(trim(`
@@ -517,7 +517,7 @@ WHERE visibilities.id::text = ? ;`)))
 			Context("when field is missing", func() {
 				It("returns error", func() {
 					criteria := query.ByField(query.EqualsOperator, "non-existing-field", "value")
-					_, err := qb.NewQuery(entity).WithCriteria(criteria).Delete(ctx)
+					_, _, err := qb.NewQuery(entity).WithCriteria(criteria).Delete(ctx)
 					Expect(err).To(HaveOccurred())
 				})
 			})
@@ -525,7 +525,7 @@ WHERE visibilities.id::text = ? ;`)))
 
 		Context("when returning clause is used", func() {
 			It("builds query with specified fields fields", func() {
-				_, err := qb.NewQuery(entity).Return("id", "service_plan_id").Delete(ctx)
+				_, _, err := qb.NewQuery(entity).Return("id", "service_plan_id").Delete(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(executedQuery).To(Equal(trim(`
@@ -535,7 +535,7 @@ RETURNING id, service_plan_id;`)))
 			})
 
 			It("builds query with *", func() {
-				_, err := qb.NewQuery(entity).Return("*").Delete(ctx)
+				_, _, err := qb.NewQuery(entity).Return("*").Delete(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(executedQuery).To(Equal(trim(`
@@ -546,7 +546,7 @@ RETURNING *;`)))
 
 			Context("when unknown field is specified", func() {
 				It("returns error", func() {
-					_, err := qb.NewQuery(entity).Return("unknown-field").Delete(ctx)
+					_, _, err := qb.NewQuery(entity).Return("unknown-field").Delete(ctx)
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("unsupported entity field for return type: unknown-field"))
 				})
@@ -565,7 +565,7 @@ RETURNING *;`)))
 
 				criteria7 := query.OrderResultBy("id", query.AscOrder)
 
-				_, err := qb.NewQuery(entity).WithCriteria(criteria1, criteria2, criteria3, criteria4, criteria5, criteria6, criteria7).Return("*").Delete(ctx)
+				_, _, err := qb.NewQuery(entity).WithCriteria(criteria1, criteria2, criteria3, criteria4, criteria5, criteria6, criteria7).Return("*").Delete(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(executedQuery).Should(Equal(trim(`
 DELETE

--- a/storage/postgres/query_builder_test.go
+++ b/storage/postgres/query_builder_test.go
@@ -463,14 +463,14 @@ LIMIT ?;`)))
 	Describe("Delete", func() {
 		Context("when entity does not have an associated label entity", func() {
 			It("returns error", func() {
-				_, _, err := qb.NewQuery(&postgres.Safe{}).Delete(ctx)
+				_, err := qb.NewQuery(&postgres.Safe{}).Delete(ctx)
 				Expect(err.Error()).To(ContainSubstring("query builder requires the entity to have associated label entity"))
 			})
 		})
 
 		Context("when no criteria is used", func() {
 			It("builds query to delete all entries", func() {
-				_, _, err := qb.NewQuery(entity).Delete(ctx)
+				_, err := qb.NewQuery(entity).Delete(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(executedQuery).To(Equal(trim(`
 DELETE
@@ -482,7 +482,7 @@ FROM visibilities ;`)))
 			It("builds query with label criteria", func() {
 				criteria1 := query.ByLabel(query.EqualsOperator, "left1", "right1")
 				criteria2 := query.ByLabel(query.InOperator, "left2", "right2", "right3")
-				_, _, err := qb.NewQuery(entity).WithCriteria(criteria1, criteria2).Delete(ctx)
+				_, err := qb.NewQuery(entity).WithCriteria(criteria1, criteria2).Delete(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(executedQuery).Should(Equal(trim(`
 DELETE
@@ -503,7 +503,7 @@ WHERE visibilities.id = t.id ;`)))
 		Context("when field criteria is used", func() {
 			It("builds query with field criteria", func() {
 				criteria := query.ByField(query.EqualsOperator, "id", "1")
-				_, _, err := qb.NewQuery(entity).WithCriteria(criteria).Delete(ctx)
+				_, err := qb.NewQuery(entity).WithCriteria(criteria).Delete(ctx)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(executedQuery).Should(Equal(trim(`
@@ -517,7 +517,14 @@ WHERE visibilities.id::text = ? ;`)))
 			Context("when field is missing", func() {
 				It("returns error", func() {
 					criteria := query.ByField(query.EqualsOperator, "non-existing-field", "value")
-					_, _, err := qb.NewQuery(entity).WithCriteria(criteria).Delete(ctx)
+					_, err := qb.NewQuery(entity).WithCriteria(criteria).Delete(ctx)
+					Expect(err).To(HaveOccurred())
+				})
+			})
+
+			Context("when returning field is not specified", func() {
+				It("returns error", func() {
+					_, err := qb.NewQuery(entity).DeleteReturning(ctx)
 					Expect(err).To(HaveOccurred())
 				})
 			})
@@ -525,7 +532,7 @@ WHERE visibilities.id::text = ? ;`)))
 
 		Context("when returning clause is used", func() {
 			It("builds query with specified fields fields", func() {
-				_, _, err := qb.NewQuery(entity).Return("id", "service_plan_id").Delete(ctx)
+				_, err := qb.NewQuery(entity).DeleteReturning(ctx, "id", "service_plan_id")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(executedQuery).To(Equal(trim(`
@@ -535,7 +542,7 @@ RETURNING id, service_plan_id;`)))
 			})
 
 			It("builds query with *", func() {
-				_, _, err := qb.NewQuery(entity).Return("*").Delete(ctx)
+				_, err := qb.NewQuery(entity).DeleteReturning(ctx, "*")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(executedQuery).To(Equal(trim(`
@@ -546,7 +553,7 @@ RETURNING *;`)))
 
 			Context("when unknown field is specified", func() {
 				It("returns error", func() {
-					_, _, err := qb.NewQuery(entity).Return("unknown-field").Delete(ctx)
+					_, err := qb.NewQuery(entity).DeleteReturning(ctx, "unknown-field")
 					Expect(err).Should(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("unsupported entity field for return type: unknown-field"))
 				})
@@ -565,7 +572,7 @@ RETURNING *;`)))
 
 				criteria7 := query.OrderResultBy("id", query.AscOrder)
 
-				_, _, err := qb.NewQuery(entity).WithCriteria(criteria1, criteria2, criteria3, criteria4, criteria5, criteria6, criteria7).Return("*").Delete(ctx)
+				_, err := qb.NewQuery(entity).WithCriteria(criteria1, criteria2, criteria3, criteria4, criteria5, criteria6, criteria7).DeleteReturning(ctx, "*")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(executedQuery).Should(Equal(trim(`
 DELETE

--- a/storage/postgres/storage.go
+++ b/storage/postgres/storage.go
@@ -247,7 +247,7 @@ func (ps *Storage) DeleteReturning(ctx context.Context, objType types.ObjectType
 		return nil, err
 	}
 
-	rows, _, err := ps.queryBuilder.NewQuery(entity).WithCriteria(criteria...).Return("*").Delete(ctx)
+	rows, err := ps.queryBuilder.NewQuery(entity).WithCriteria(criteria...).DeleteReturning(ctx, "*")
 	defer closeRows(ctx, rows)
 	if err != nil {
 		pqError, ok := err.(*pq.Error)
@@ -279,7 +279,7 @@ func (ps *Storage) Delete(ctx context.Context, objType types.ObjectType, criteri
 		return err
 	}
 
-	_, result, err := ps.queryBuilder.NewQuery(entity).WithCriteria(criteria...).Delete(ctx)
+	result, err := ps.queryBuilder.NewQuery(entity).WithCriteria(criteria...).Delete(ctx)
 	if err != nil {
 		pqError, ok := err.(*pq.Error)
 		if ok && pqError.Code.Name() == foreignKeyViolation {

--- a/storage/postgres/storage.go
+++ b/storage/postgres/storage.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/lib/pq"
 	"sync"
 	"time"
+
+	"github.com/lib/pq"
 
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/query"
@@ -240,13 +241,13 @@ func (ps *Storage) Count(ctx context.Context, objType types.ObjectType, criteria
 	return ps.queryBuilder.NewQuery(entity).WithCriteria(criteria...).WithLock().Count(ctx)
 }
 
-func (ps *Storage) Delete(ctx context.Context, objType types.ObjectType, criteria ...query.Criterion) (types.ObjectList, error) {
+func (ps *Storage) DeleteReturning(ctx context.Context, objType types.ObjectType, criteria ...query.Criterion) (types.ObjectList, error) {
 	entity, err := ps.scheme.provide(objType)
 	if err != nil {
 		return nil, err
 	}
 
-	rows, err := ps.queryBuilder.NewQuery(entity).WithCriteria(criteria...).Return("*").Delete(ctx)
+	rows, _, err := ps.queryBuilder.NewQuery(entity).WithCriteria(criteria...).Return("*").Delete(ctx)
 	defer closeRows(ctx, rows)
 	if err != nil {
 		pqError, ok := err.(*pq.Error)
@@ -270,6 +271,30 @@ func (ps *Storage) Delete(ctx context.Context, objType types.ObjectType, criteri
 		return nil, util.ErrNotFoundInStorage
 	}
 	return objectList, nil
+}
+
+func (ps *Storage) Delete(ctx context.Context, objType types.ObjectType, criteria ...query.Criterion) error {
+	entity, err := ps.scheme.provide(objType)
+	if err != nil {
+		return err
+	}
+
+	_, result, err := ps.queryBuilder.NewQuery(entity).WithCriteria(criteria...).Delete(ctx)
+	if err != nil {
+		pqError, ok := err.(*pq.Error)
+		if ok && pqError.Code.Name() == foreignKeyViolation {
+			entityName := objType.String()
+			referenceEntityName := ps.scheme.entityToObjectTypeConverter[pqError.Table]
+
+			return &util.ErrForeignKeyViolation{
+				Entity:          entityName,
+				ReferenceEntity: referenceEntityName,
+			}
+		}
+		return err
+	}
+
+	return checkRowsAffected(ctx, result)
 }
 
 func (ps *Storage) Update(ctx context.Context, obj types.Object, labelChanges query.LabelChanges, _ ...query.Criterion) (types.Object, error) {

--- a/storage/storagefakes/fake_storage.go
+++ b/storage/storagefakes/fake_storage.go
@@ -50,7 +50,7 @@ type FakeStorage struct {
 		result1 types.Object
 		result2 error
 	}
-	DeleteStub        func(context.Context, types.ObjectType, ...query.Criterion) (types.ObjectList, error)
+	DeleteStub        func(context.Context, types.ObjectType, ...query.Criterion) error
 	deleteMutex       sync.RWMutex
 	deleteArgsForCall []struct {
 		arg1 context.Context
@@ -58,10 +58,23 @@ type FakeStorage struct {
 		arg3 []query.Criterion
 	}
 	deleteReturns struct {
+		result1 error
+	}
+	deleteReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DeleteReturningStub        func(context.Context, types.ObjectType, ...query.Criterion) (types.ObjectList, error)
+	deleteReturningMutex       sync.RWMutex
+	deleteReturningArgsForCall []struct {
+		arg1 context.Context
+		arg2 types.ObjectType
+		arg3 []query.Criterion
+	}
+	deleteReturningReturns struct {
 		result1 types.ObjectList
 		result2 error
 	}
-	deleteReturnsOnCall map[int]struct {
+	deleteReturningReturnsOnCall map[int]struct {
 		result1 types.ObjectList
 		result2 error
 	}
@@ -335,7 +348,7 @@ func (fake *FakeStorage) CreateReturnsOnCall(i int, result1 types.Object, result
 	}{result1, result2}
 }
 
-func (fake *FakeStorage) Delete(arg1 context.Context, arg2 types.ObjectType, arg3 ...query.Criterion) (types.ObjectList, error) {
+func (fake *FakeStorage) Delete(arg1 context.Context, arg2 types.ObjectType, arg3 ...query.Criterion) error {
 	fake.deleteMutex.Lock()
 	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
 	fake.deleteArgsForCall = append(fake.deleteArgsForCall, struct {
@@ -349,10 +362,10 @@ func (fake *FakeStorage) Delete(arg1 context.Context, arg2 types.ObjectType, arg
 		return fake.DeleteStub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1
 	}
 	fakeReturns := fake.deleteReturns
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1
 }
 
 func (fake *FakeStorage) DeleteCallCount() int {
@@ -361,7 +374,7 @@ func (fake *FakeStorage) DeleteCallCount() int {
 	return len(fake.deleteArgsForCall)
 }
 
-func (fake *FakeStorage) DeleteCalls(stub func(context.Context, types.ObjectType, ...query.Criterion) (types.ObjectList, error)) {
+func (fake *FakeStorage) DeleteCalls(stub func(context.Context, types.ObjectType, ...query.Criterion) error) {
 	fake.deleteMutex.Lock()
 	defer fake.deleteMutex.Unlock()
 	fake.DeleteStub = stub
@@ -374,27 +387,89 @@ func (fake *FakeStorage) DeleteArgsForCall(i int) (context.Context, types.Object
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeStorage) DeleteReturns(result1 types.ObjectList, result2 error) {
+func (fake *FakeStorage) DeleteReturns(result1 error) {
 	fake.deleteMutex.Lock()
 	defer fake.deleteMutex.Unlock()
 	fake.DeleteStub = nil
 	fake.deleteReturns = struct {
-		result1 types.ObjectList
-		result2 error
-	}{result1, result2}
+		result1 error
+	}{result1}
 }
 
-func (fake *FakeStorage) DeleteReturnsOnCall(i int, result1 types.ObjectList, result2 error) {
+func (fake *FakeStorage) DeleteReturnsOnCall(i int, result1 error) {
 	fake.deleteMutex.Lock()
 	defer fake.deleteMutex.Unlock()
 	fake.DeleteStub = nil
 	if fake.deleteReturnsOnCall == nil {
 		fake.deleteReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStorage) DeleteReturning(arg1 context.Context, arg2 types.ObjectType, arg3 ...query.Criterion) (types.ObjectList, error) {
+	fake.deleteReturningMutex.Lock()
+	ret, specificReturn := fake.deleteReturningReturnsOnCall[len(fake.deleteReturningArgsForCall)]
+	fake.deleteReturningArgsForCall = append(fake.deleteReturningArgsForCall, struct {
+		arg1 context.Context
+		arg2 types.ObjectType
+		arg3 []query.Criterion
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("DeleteReturning", []interface{}{arg1, arg2, arg3})
+	fake.deleteReturningMutex.Unlock()
+	if fake.DeleteReturningStub != nil {
+		return fake.DeleteReturningStub(arg1, arg2, arg3...)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.deleteReturningReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStorage) DeleteReturningCallCount() int {
+	fake.deleteReturningMutex.RLock()
+	defer fake.deleteReturningMutex.RUnlock()
+	return len(fake.deleteReturningArgsForCall)
+}
+
+func (fake *FakeStorage) DeleteReturningCalls(stub func(context.Context, types.ObjectType, ...query.Criterion) (types.ObjectList, error)) {
+	fake.deleteReturningMutex.Lock()
+	defer fake.deleteReturningMutex.Unlock()
+	fake.DeleteReturningStub = stub
+}
+
+func (fake *FakeStorage) DeleteReturningArgsForCall(i int) (context.Context, types.ObjectType, []query.Criterion) {
+	fake.deleteReturningMutex.RLock()
+	defer fake.deleteReturningMutex.RUnlock()
+	argsForCall := fake.deleteReturningArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeStorage) DeleteReturningReturns(result1 types.ObjectList, result2 error) {
+	fake.deleteReturningMutex.Lock()
+	defer fake.deleteReturningMutex.Unlock()
+	fake.DeleteReturningStub = nil
+	fake.deleteReturningReturns = struct {
+		result1 types.ObjectList
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStorage) DeleteReturningReturnsOnCall(i int, result1 types.ObjectList, result2 error) {
+	fake.deleteReturningMutex.Lock()
+	defer fake.deleteReturningMutex.Unlock()
+	fake.DeleteReturningStub = nil
+	if fake.deleteReturningReturnsOnCall == nil {
+		fake.deleteReturningReturnsOnCall = make(map[int]struct {
 			result1 types.ObjectList
 			result2 error
 		})
 	}
-	fake.deleteReturnsOnCall[i] = struct {
+	fake.deleteReturningReturnsOnCall[i] = struct {
 		result1 types.ObjectList
 		result2 error
 	}{result1, result2}
@@ -819,6 +894,8 @@ func (fake *FakeStorage) Invocations() map[string][][]interface{} {
 	defer fake.createMutex.RUnlock()
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
+	fake.deleteReturningMutex.RLock()
+	defer fake.deleteReturningMutex.RUnlock()
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
 	fake.inTransactionMutex.RLock()

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -18,11 +18,12 @@ package broker_test
 import (
 	"context"
 	"fmt"
-	"github.com/Peripli/service-manager/test/testutil/service_instance"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Peripli/service-manager/test/testutil/service_instance"
 
 	"github.com/Peripli/service-manager/pkg/httpclient"
 	"github.com/Peripli/service-manager/pkg/web"
@@ -1176,7 +1177,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 							AfterEach(func() {
 								byIDs := query.ByField(query.InOperator, "id", serviceInstanceIDs...)
-								_, err := ctx.SMRepository.Delete(context.Background(), types.ServiceInstanceType, byIDs)
+								err := ctx.SMRepository.Delete(context.Background(), types.ServiceInstanceType, byIDs)
 								Expect(err).To(Not(HaveOccurred()))
 							})
 
@@ -1381,7 +1382,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 							AfterEach(func() {
 								byID := query.ByField(query.EqualsOperator, "id", serviceInstance.ID)
-								_, err := ctx.SMRepository.Delete(context.Background(), types.ServiceInstanceType, byID)
+								err := ctx.SMRepository.Delete(context.Background(), types.ServiceInstanceType, byID)
 								Expect(err).To(Not(HaveOccurred()))
 							})
 

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -204,18 +204,15 @@ func MapContains(actual Object, expected Object) {
 }
 
 func RemoveAllOperations(repository storage.Repository) error {
-	_, err := repository.Delete(context.TODO(), types.OperationType)
-	return err
+	return repository.Delete(context.TODO(), types.OperationType)
 }
 
 func RemoveAllNotifications(repository storage.Repository) error {
-	_, err := repository.Delete(context.TODO(), types.NotificationType)
-	return err
+	return repository.Delete(context.TODO(), types.NotificationType)
 }
 
 func RemoveAllInstances(repository storage.Repository) error {
-	_, err := repository.Delete(context.TODO(), types.ServiceInstanceType)
-	return err
+	return repository.Delete(context.TODO(), types.ServiceInstanceType)
 }
 
 func RemoveAllBrokers(SM *SMExpect) {

--- a/test/osb_test/poll_instance_last_operation_test.go
+++ b/test/osb_test/poll_instance_last_operation_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 
 					By(fmt.Sprintf("Deleting instance with id %s", SID))
 					byID := query.ByField(query.EqualsOperator, "id", SID)
-					_, err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
+					err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
 					Expect(err).ToNot(HaveOccurred())
 
 					ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
@@ -334,7 +334,7 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 
 					By(fmt.Sprintf("Deleting instance with id %s", SID))
 					byID := query.ByField(query.EqualsOperator, "id", SID)
-					_, err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
+					err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
 					Expect(err).ToNot(HaveOccurred())
 
 					ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
@@ -456,7 +456,7 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 
 					By(fmt.Sprintf("Deleting instance with id %s", SID))
 					byID := query.ByField(query.EqualsOperator, "id", SID)
-					_, err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
+					err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
 					Expect(err).ToNot(HaveOccurred())
 
 					ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
@@ -536,7 +536,7 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 
 					By(fmt.Sprintf("Deleting instance with id %s", SID))
 					byID := query.ByField(query.EqualsOperator, "id", SID)
-					_, err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
+					err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
 					Expect(err).ToNot(HaveOccurred())
 
 					ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).

--- a/test/query_test/query_test.go
+++ b/test/query_test/query_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Service Manager Query", func() {
 
 	AfterEach(func() {
 		if repository != nil {
-			_, err := repository.Delete(context.Background(), types.NotificationType)
+			err := repository.Delete(context.Background(), types.NotificationType)
 			Expect(err).ShouldNot(HaveOccurred())
 		}
 	})

--- a/test/ws_notification_test/ws_notification_test.go
+++ b/test/ws_notification_test/ws_notification_test.go
@@ -87,7 +87,7 @@ var _ = Describe("WS", func() {
 
 	AfterEach(func() {
 		if repository != nil {
-			_, err := repository.Delete(context.Background(), types.NotificationType)
+			err := repository.Delete(context.Background(), types.NotificationType)
 			if err != nil {
 				Expect(err).To(Equal(util.ErrNotFoundInStorage))
 			}


### PR DESCRIPTION
Notifications payload is often large and loading deleted notifications inmemory is not necessary. In general in most places we delete stuff, loading it inmemory is not needed. The PR addresses these points