### PR TITLE
Batch fetching details for visibility notifications

### DIFF
--- a/pkg/types/interfaces.go
+++ b/pkg/types/interfaces.go
@@ -68,3 +68,24 @@ type ObjectPage struct {
 	ItemsCount int      `json:"num_items"`
 	Items      []Object `json:"items"`
 }
+
+// ObjectArray is an ObjectList backed by a slice of Object's
+type ObjectArray struct {
+	Objects []Object
+}
+
+func NewObjectArray(objects ...Object) *ObjectArray {
+	return &ObjectArray{objects}
+}
+
+func (a *ObjectArray) Add(object Object) {
+	a.Objects = append(a.Objects, object)
+}
+
+func (a *ObjectArray) ItemAt(index int) Object {
+	return a.Objects[index]
+}
+
+func (a *ObjectArray) Len() int {
+	return len(a.Objects)
+}

--- a/storage/interceptors/broker_notifications_interceptor.go
+++ b/storage/interceptors/broker_notifications_interceptor.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Peripli/service-manager/pkg/util"
-
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/storage"
 )
@@ -15,12 +13,15 @@ func NewBrokerNotificationsInterceptor() *NotificationsInterceptor {
 		PlatformIdProviderFunc: func(ctx context.Context, obj types.Object) string {
 			return ""
 		},
-		AdditionalDetailsFunc: func(ctx context.Context, obj types.Object, repository storage.Repository) (util.InputValidator, error) {
-			broker := obj.(*types.ServiceBroker)
-
-			return &BrokerAdditional{
-				Services: broker.Services,
-			}, nil
+		AdditionalDetailsFunc: func(ctx context.Context, objects types.ObjectList, repository storage.Repository) (objectDetails, error) {
+			details := make(objectDetails, objects.Len())
+			for i := 0; i < objects.Len(); i++ {
+				broker := objects.ItemAt(i).(*types.ServiceBroker)
+				details[broker.ID] = &BrokerAdditional{
+					Services: broker.Services,
+				}
+			}
+			return details, nil
 		},
 	}
 }

--- a/storage/interceptors/notifications_interceptor.go
+++ b/storage/interceptors/notifications_interceptor.go
@@ -28,9 +28,11 @@ type ObjectPayload struct {
 	Additional util.InputValidator `json:"additional,omitempty"`
 }
 
+type objectDetails map[string]util.InputValidator
+
 type NotificationsInterceptor struct {
 	PlatformIdProviderFunc func(ctx context.Context, object types.Object) string
-	AdditionalDetailsFunc  func(ctx context.Context, object types.Object, repository storage.Repository) (util.InputValidator, error)
+	AdditionalDetailsFunc  func(ctx context.Context, objects types.ObjectList, repository storage.Repository) (objectDetails, error)
 }
 
 func (ni *NotificationsInterceptor) OnTxCreate(h storage.InterceptCreateOnTxFunc) storage.InterceptCreateOnTxFunc {
@@ -40,7 +42,7 @@ func (ni *NotificationsInterceptor) OnTxCreate(h storage.InterceptCreateOnTxFunc
 			return nil, err
 		}
 
-		additionalDetails, err := ni.AdditionalDetailsFunc(ctx, obj, repository)
+		additionalDetails, err := ni.AdditionalDetailsFunc(ctx, types.NewObjectArray(obj), repository)
 		if err != nil {
 			return nil, err
 		}
@@ -50,7 +52,7 @@ func (ni *NotificationsInterceptor) OnTxCreate(h storage.InterceptCreateOnTxFunc
 		return newObj, CreateNotification(ctx, repository, types.CREATED, newObj.GetType(), platformID, &Payload{
 			New: &ObjectPayload{
 				Resource:   newObj,
-				Additional: additionalDetails,
+				Additional: additionalDetails[obj.GetID()],
 			},
 		})
 	}
@@ -63,10 +65,11 @@ func (ni *NotificationsInterceptor) OnTxUpdate(h storage.InterceptUpdateOnTxFunc
 			return nil, err
 		}
 
-		additionalDetails, err := ni.AdditionalDetailsFunc(ctx, updatedObject, repository)
+		detailsMap, err := ni.AdditionalDetailsFunc(ctx, types.NewObjectArray(updatedObject), repository)
 		if err != nil {
 			return nil, err
 		}
+		additionalDetails := detailsMap[updatedObject.GetID()]
 
 		oldPlatformID := ni.PlatformIdProviderFunc(ctx, oldObject)
 		newPlatformID := ni.PlatformIdProviderFunc(ctx, newObject)
@@ -113,16 +116,9 @@ func (ni *NotificationsInterceptor) OnTxUpdate(h storage.InterceptUpdateOnTxFunc
 
 func (ni *NotificationsInterceptor) OnTxDelete(h storage.InterceptDeleteOnTxFunc) storage.InterceptDeleteOnTxFunc {
 	return func(ctx context.Context, repository storage.Repository, objects types.ObjectList, deletionCriteria ...query.Criterion) (types.ObjectList, error) {
-		additionalDetailsMap := make(map[string]util.InputValidator)
-
-		for i := 0; i < objects.Len(); i++ {
-			object := objects.ItemAt(i)
-			additionalDetails, err := ni.AdditionalDetailsFunc(ctx, object, repository)
-			if err != nil {
-				return nil, err
-			}
-
-			additionalDetailsMap[object.GetID()] = additionalDetails
+		additionalDetailsMap, err := ni.AdditionalDetailsFunc(ctx, objects, repository)
+		if err != nil {
+			return nil, err
 		}
 
 		deletedObjects, err := h(ctx, repository, objects, deletionCriteria...)


### PR DESCRIPTION
# Pull Request Template

## Motivation

Deleting a visibility creates the corresponding notification. The notification requires also additional data, so for each visibility SM loads its plan, service offering and broker - 3 db calls for each visibility.
In case multiple visibilities are deleted in one operation this produces a lot of db calls and the operation may take 10+ seconds.

## Approach

Now the additional data is loaded for all deleted visibilities with just 3 db calls independent of the visibility count.

## Pull Request status

* [x] Refactoring
