### PR TITLE
Increase Operation external_id length

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -14,10 +14,6 @@ _How does this change address the problem?_
 
 ## Pull Request status
 
-Use checklists as a means to represent the status of your Pull Request.
-
-For example:
-
 * [x] Initial implementation
 * [ ] Refactoring
 * [ ] Unit tests

--- a/storage/postgres/keystore_test.go
+++ b/storage/postgres/keystore_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Secured Storage", func() {
 		mock.ExpectQuery(`SELECT CURRENT_DATABASE()`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("mock"))
 		mock.ExpectQuery(`SELECT COUNT(1)*`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("1"))
 		mock.ExpectExec("SELECT pg_advisory_lock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20191206134500,false"))
+		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20191214124420,false"))
 		mock.ExpectExec("SELECT pg_advisory_unlock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 		options := storage.DefaultSettings()
 		options.EncryptionKey = string(envEncryptionKey)

--- a/storage/postgres/migrations/20191214124420_increase_operations_external_id_length.down.sql
+++ b/storage/postgres/migrations/20191214124420_increase_operations_external_id_length.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE operations ALTER COLUMN external_id TYPE VARCHAR(100);
+
+COMMIT;

--- a/storage/postgres/migrations/20191214124420_increase_operations_external_id_length.up.sql
+++ b/storage/postgres/migrations/20191214124420_increase_operations_external_id_length.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE operations ALTER COLUMN external_id TYPE VARCHAR(10000);
+
+COMMIT;


### PR DESCRIPTION
# Increase Operation external_id length

## Motivation

Some brokers returns operation strings longer than 100 symbols (the current cap). Also OSB spec states that 10 000 characters should be the max: https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#body-4

## Approach

Migrations added.

## Note

We still don't have an operations maintainer. Currently operations are never deleted. Increasing the size of an operation record will shorten the time until we eventually fill up the DB.
So it's important to introduce an operations maintainer ASAP.

## Pull Request status

* [x] Initial implementation