### PR TITLE
Handle 410 Gone on Last Operation requests

### DIFF
--- a/api/osb/store_instances_plugin.go
+++ b/api/osb/store_instances_plugin.go
@@ -351,7 +351,7 @@ func (ssi *StoreServiceInstancePlugin) PollInstance(request *web.Request, next w
 		return nil, err
 	}
 
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode != http.StatusOK || response.StatusCode != http.StatusGone {
 		return response, nil
 	}
 
@@ -382,6 +382,13 @@ func (ssi *StoreServiceInstancePlugin) PollInstance(request *web.Request, next w
 		}
 
 		operationFromDB := op.(*types.Operation)
+		if response.StatusCode == http.StatusGone {
+			if operationFromDB.Type != types.DELETE {
+				return nil
+			}
+			resp.State = types.SUCCEEDED
+		}
+
 		if operationFromDB.State != resp.State {
 			switch operationFromDB.Type {
 			case types.CREATE:

--- a/api/osb/store_instances_plugin.go
+++ b/api/osb/store_instances_plugin.go
@@ -351,7 +351,7 @@ func (ssi *StoreServiceInstancePlugin) PollInstance(request *web.Request, next w
 		return nil, err
 	}
 
-	if response.StatusCode != http.StatusOK || response.StatusCode != http.StatusGone {
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusGone {
 		return response, nil
 	}
 

--- a/test/osb_test/poll_instance_last_operation_test.go
+++ b/test/osb_test/poll_instance_last_operation_test.go
@@ -227,6 +227,19 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 				By(fmt.Sprintf("Getting last operation for service instance with id %s", SID))
 				ctx.SMWithBasic.GET(smBrokerURL+"/v2/service_instances/"+SID+"/last_operation").WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
 					Expect().Status(http.StatusGone)
+
+				By(fmt.Sprintf("Verifying service instance with id %s is not updated to ready=true", SID))
+				ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
+					Expect().Status(http.StatusOK).JSON().Object().Value("ready").Boolean().Equal(false)
+
+				By(fmt.Sprintf("Verifying create operation for service instance with id %s is not updated to succeeded", SID))
+				verifyOperationExists(operationExpectations{
+					Type:         types.CREATE,
+					State:        types.IN_PROGRESS,
+					ResourceID:   SID,
+					ResourceType: "/v1/service_instances",
+					ExternalID:   "",
+				})
 			})
 		})
 	})
@@ -425,6 +438,15 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 				By(fmt.Sprintf("Getting last operation for service instance with id %s", SID))
 				ctx.SMWithBasic.GET(smBrokerURL+"/v2/service_instances/"+SID+"/last_operation").WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
 					Expect().Status(http.StatusGone)
+
+				By(fmt.Sprintf("Verifying update operation for service instance with id %s is still in progress", SID))
+				verifyOperationExists(operationExpectations{
+					Type:         types.UPDATE,
+					State:        types.IN_PROGRESS,
+					ResourceID:   SID,
+					ResourceType: "/v1/service_instances",
+					ExternalID:   "",
+				})
 			})
 		})
 	})

--- a/test/osb_test/poll_instance_last_operation_test.go
+++ b/test/osb_test/poll_instance_last_operation_test.go
@@ -217,6 +217,18 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 				})
 			})
 		})
+
+		Context("that returns 410 gone", func() {
+			BeforeEach(func() {
+				brokerServer.ServiceInstanceLastOpHandler = parameterizedHandler(http.StatusGone, `{}`)
+			})
+
+			It("returns 410", func() {
+				By(fmt.Sprintf("Getting last operation for service instance with id %s", SID))
+				ctx.SMWithBasic.GET(smBrokerURL+"/v2/service_instances/"+SID+"/last_operation").WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
+					Expect().Status(http.StatusGone)
+			})
+		})
 	})
 
 	Context("when polling UPDATE for which operation exists", func() {
@@ -401,6 +413,18 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 					ResourceType: "/v1/service_instances",
 					ExternalID:   "",
 				})
+			})
+		})
+
+		Context("that returns 410 gone", func() {
+			BeforeEach(func() {
+				brokerServer.ServiceInstanceLastOpHandler = parameterizedHandler(http.StatusGone, `{}`)
+			})
+
+			It("returns 410", func() {
+				By(fmt.Sprintf("Getting last operation for service instance with id %s", SID))
+				ctx.SMWithBasic.GET(smBrokerURL+"/v2/service_instances/"+SID+"/last_operation").WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
+					Expect().Status(http.StatusGone)
 			})
 		})
 	})

--- a/test/osb_test/poll_instance_last_operation_test.go
+++ b/test/osb_test/poll_instance_last_operation_test.go
@@ -601,6 +601,51 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 				})
 			})
 		})
+
+		Context("that returns 410 gone", func() {
+			BeforeEach(func() {
+				brokerServer.ServiceInstanceLastOpHandler = parameterizedHandler(http.StatusGone, `{}`)
+			})
+
+			It("deletes the instance and updates the operation to delete succeeded", func() {
+				By(fmt.Sprintf("Getting last operation for service instance with id %s", SID))
+				ctx.SMWithBasic.GET(smBrokerURL+"/v2/service_instances/"+SID+"/last_operation").WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
+					Expect().Status(http.StatusGone)
+
+				By(fmt.Sprintf("Verifying service instance with id %s is deleted", SID))
+				ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
+					Expect().Status(http.StatusNotFound)
+
+				By(fmt.Sprintf("Verifying delete operation for service instance with id %s is updated to succeeded", SID))
+				verifyOperationExists(operationExpectations{
+					Type:         types.DELETE,
+					State:        types.SUCCEEDED,
+					ResourceID:   SID,
+					ResourceType: "/v1/service_instances",
+					ExternalID:   "",
+				})
+			})
+
+			Context("when instance does not exist", func() {
+				BeforeEach(func() {
+					brokerServer.ServiceInstanceHandler = parameterizedHandler(http.StatusOK, `{}`)
+
+					By(fmt.Sprintf("Deleting instance with id %s", SID))
+					byID := query.ByField(query.EqualsOperator, "id", SID)
+					err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
+					Expect(err).ToNot(HaveOccurred())
+
+					ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
+						Expect().Status(http.StatusNotFound)
+				})
+
+				It("does not fail", func() {
+					By(fmt.Sprintf("Getting last operation for service instance with id %s", SID))
+					ctx.SMWithBasic.GET(smBrokerURL+"/v2/service_instances/"+SID+"/last_operation").WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
+						Expect().Status(http.StatusGone)
+				})
+			})
+		})
 	})
 
 	Context("when call to working service broker", func() {


### PR DESCRIPTION
# Handle 410 Gone on Last Operation requests

## Motivation

As per OSB spec a response to a last operation call can return 410 Gone: https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#response-1

In the case of an async delete operation, this has to be interpreted as the instances has been deleted in the original service broker.

Currently we do not handle this scenario as we're always expecting a 200 OK response: https://github.com/Peripli/service-manager/blob/8598d3c656897e687b8b443ef256839e0792f42a/api/osb/store_instances_plugin.go#L354

The consequences are that we have orphan instances in our DB, which furthermore complicate things as those instances block the deletion(or catalog update) of the corresponding service broker in SM. For such cases, we have to go directly in the DB and delete those instances (until we have a DELETE API).

## Approach

Handle the case where 410 Gone is returned on last operation requests.

## Pull Request status

* [x] Initial implementation
* [x] Integration tests