### PR TITLE
Remove visibility notification labels

### DIFF
--- a/pkg/types/interfaces.go
+++ b/pkg/types/interfaces.go
@@ -56,13 +56,9 @@ type Object interface {
 }
 
 func Equals(obj, other Object) bool {
-	if obj.GetType() != other.GetType() {
-		return false
-	}
-	if obj.GetID() != other.GetID() {
-		return false
-	}
-	if !obj.GetCreatedAt().Equal(other.GetCreatedAt()) {
+	if obj.GetID() != other.GetID() ||
+		obj.GetType() != other.GetType() ||
+		!obj.GetCreatedAt().Equal(other.GetCreatedAt()) {
 		return false
 	}
 	return true

--- a/pkg/types/interfaces.go
+++ b/pkg/types/interfaces.go
@@ -42,6 +42,7 @@ type Secured interface {
 type Object interface {
 	util.InputValidator
 
+	Equals(object Object) bool
 	SetID(id string)
 	GetID() string
 	GetType() ObjectType
@@ -52,6 +53,19 @@ type Object interface {
 	SetUpdatedAt(time time.Time)
 	GetUpdatedAt() time.Time
 	GetPagingSequence() int64
+}
+
+func Equals(obj, other Object) bool {
+	if obj.GetType() != other.GetType() {
+		return false
+	}
+	if obj.GetID() != other.GetID() {
+		return false
+	}
+	if !obj.GetCreatedAt().Equal(other.GetCreatedAt()) {
+		return false
+	}
+	return true
 }
 
 // ObjectList is the interface that lists of objects must implement

--- a/pkg/types/notification.go
+++ b/pkg/types/notification.go
@@ -19,6 +19,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/Peripli/service-manager/pkg/util"
 )
@@ -50,6 +51,24 @@ type Notification struct {
 	Revision      int64                 `json:"revision"`
 	Payload       json.RawMessage       `json:"payload"`
 	CorrelationID string                `json:"correlation_id"`
+}
+
+func (e *Notification) Equals(obj Object) bool {
+	if !Equals(e, obj) {
+		return false
+	}
+
+	notification := obj.(*Notification)
+	if e.PlatformID != notification.PlatformID ||
+		e.Type != notification.Type ||
+		e.Resource != notification.Resource ||
+		e.Revision != notification.Revision ||
+		e.CorrelationID != notification.CorrelationID ||
+		!reflect.DeepEqual(e.Payload, notification.Payload) {
+		return false
+	}
+
+	return true
 }
 
 // Validate implements InputValidator and verifies all mandatory fields are populated

--- a/pkg/types/operation.go
+++ b/pkg/types/operation.go
@@ -19,6 +19,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/Peripli/service-manager/pkg/util"
 )
@@ -63,6 +64,26 @@ type Operation struct {
 	Errors        json.RawMessage   `json:"errors"`
 	CorrelationID string            `json:"correlation_id"`
 	ExternalID    string            `json:"-"`
+}
+
+func (e *Operation) Equals(obj Object) bool {
+	if !Equals(e, obj) {
+		return false
+	}
+
+	operation := obj.(*Operation)
+	if e.Description != operation.Description ||
+		e.ResourceID != operation.ResourceID ||
+		e.ResourceType != operation.ResourceType ||
+		e.CorrelationID != operation.CorrelationID ||
+		e.ExternalID != operation.ExternalID ||
+		e.State != operation.State ||
+		e.Type != operation.Type ||
+		!reflect.DeepEqual(e.Errors, operation.Errors) {
+		return false
+	}
+
+	return true
 }
 
 // Validate implements InputValidator and verifies all mandatory fields are populated

--- a/pkg/types/platform.go
+++ b/pkg/types/platform.go
@@ -19,6 +19,7 @@ package types
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/Peripli/service-manager/pkg/util"
@@ -37,6 +38,24 @@ type Platform struct {
 	Credentials *Credentials `json:"credentials,omitempty"`
 	Active      bool         `json:"-"`
 	LastActive  time.Time    `json:"-"`
+}
+
+func (e *Platform) Equals(obj Object) bool {
+	if !Equals(e, obj) {
+		return false
+	}
+
+	platform := obj.(*Platform)
+	if e.Description != platform.Description ||
+		e.Type != platform.Type ||
+		e.Name != platform.Name ||
+		e.Active != platform.Active ||
+		!e.LastActive.Equal(platform.LastActive) ||
+		!reflect.DeepEqual(e.Credentials, platform.Credentials) {
+		return false
+	}
+
+	return true
 }
 
 func (e *Platform) SetCredentials(credentials *Credentials) {

--- a/pkg/types/service_broker.go
+++ b/pkg/types/service_broker.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 )
 
@@ -34,10 +35,10 @@ type ServiceBroker struct {
 	Name        string       `json:"name"`
 	Description string       `json:"description"`
 	BrokerURL   string       `json:"broker_url"`
-	Credentials *Credentials `json:"credentials,omitempty" structs:"-"`
+	Credentials *Credentials `json:"credentials,omitempty"`
 
-	Catalog  json.RawMessage    `json:"-" structs:"-"`
-	Services []*ServiceOffering `json:"-" structs:"-"`
+	Catalog  json.RawMessage    `json:"-"`
+	Services []*ServiceOffering `json:"-"`
 }
 
 func (e *ServiceBroker) SetCredentials(credentials *Credentials) {
@@ -68,4 +69,21 @@ func (e *ServiceBroker) Validate() error {
 		return errors.New("missing credentials")
 	}
 	return e.Credentials.Validate()
+}
+
+func (e *ServiceBroker) Equals(obj Object) bool {
+	if !Equals(e, obj) {
+		return false
+	}
+
+	broker := obj.(*ServiceBroker)
+	if e.Name != broker.Name ||
+		e.BrokerURL != broker.BrokerURL ||
+		e.Description != broker.Description ||
+		!reflect.DeepEqual(e.Catalog, broker.Catalog) ||
+		!reflect.DeepEqual(e.Credentials, broker.Credentials) {
+		return false
+	}
+
+	return true
 }

--- a/pkg/types/service_instance.go
+++ b/pkg/types/service_instance.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/Peripli/service-manager/pkg/util"
 )
@@ -37,6 +38,24 @@ type ServiceInstance struct {
 	PreviousValues  json.RawMessage `json:"-"`
 	Ready           bool            `json:"ready"`
 	Usable          bool            `json:"usable"`
+}
+
+func (e *ServiceInstance) Equals(obj Object) bool {
+	if !Equals(e, obj) {
+		return false
+	}
+
+	instance := obj.(*ServiceInstance)
+	if e.Name != instance.Name ||
+		e.PlatformID != instance.PlatformID ||
+		e.ServicePlanID != instance.ServicePlanID ||
+		!reflect.DeepEqual(e.PreviousValues, instance.PreviousValues) ||
+		!reflect.DeepEqual(e.Context, instance.Context) ||
+		!reflect.DeepEqual(e.MaintenanceInfo, instance.MaintenanceInfo) {
+		return false
+	}
+
+	return true
 }
 
 // Validate implements InputValidator and verifies all mandatory fields are populated

--- a/pkg/types/service_offering.go
+++ b/pkg/types/service_offering.go
@@ -19,6 +19,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/Peripli/service-manager/pkg/util"
 )
@@ -44,6 +45,30 @@ type ServiceOffering struct {
 	CatalogName string `json:"catalog_name"`
 
 	Plans []*ServicePlan `json:"plans"`
+}
+
+func (e *ServiceOffering) Equals(obj Object) bool {
+	if !Equals(e, obj) {
+		return false
+	}
+
+	offering := obj.(*ServiceOffering)
+	if e.Name != offering.Name ||
+		e.PlanUpdatable != offering.PlanUpdatable ||
+		e.Bindable != offering.Bindable ||
+		e.BindingsRetrievable != offering.BindingsRetrievable ||
+		e.BrokerID != offering.BrokerID ||
+		e.CatalogID != offering.CatalogID ||
+		e.CatalogName != offering.CatalogName ||
+		e.Description != offering.Description ||
+		e.InstancesRetrievable != offering.InstancesRetrievable ||
+		!reflect.DeepEqual(e.Tags, offering.Tags) ||
+		!reflect.DeepEqual(e.Requires, offering.Requires) ||
+		!reflect.DeepEqual(e.Metadata, offering.Metadata) {
+		return false
+	}
+
+	return true
 }
 
 // Validate implements InputValidator and verifies all mandatory fields are populated

--- a/pkg/types/service_plan.go
+++ b/pkg/types/service_plan.go
@@ -19,6 +19,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/Peripli/service-manager/pkg/util"
 )
@@ -40,6 +41,28 @@ type ServicePlan struct {
 	Schemas  json.RawMessage `json:"schemas,omitempty"`
 
 	ServiceOfferingID string `json:"service_offering_id"`
+}
+
+func (e *ServicePlan) Equals(obj Object) bool {
+	if !Equals(e, obj) {
+		return false
+	}
+
+	plan := obj.(*ServicePlan)
+	if e.Name != plan.Name ||
+		e.PlanUpdatable != plan.PlanUpdatable ||
+		e.Bindable != plan.Bindable ||
+		e.ServiceOfferingID != plan.ServiceOfferingID ||
+		e.Free != plan.Free ||
+		e.CatalogID != plan.CatalogID ||
+		e.CatalogName != plan.CatalogName ||
+		e.Description != plan.Description ||
+		!reflect.DeepEqual(e.Schemas, plan.Schemas) ||
+		!reflect.DeepEqual(e.Metadata, plan.Metadata) {
+		return false
+	}
+
+	return true
 }
 
 // Validate implements InputValidator and verifies all mandatory fields are populated

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,432 @@
+package types
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fatih/structs"
+	. "github.com/onsi/ginkgo"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestTypes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Types test suite")
+}
+
+var _ = Describe("Types test", func() {
+	now := time.Now()
+	entries := []*testCase{
+		{
+			expectedEqual: []string{
+				"Base.Labels", "Base.UpdatedAt", "Base.PagingSequence",
+			},
+			baseObjectCreateFunc: createBroker,
+		},
+		{
+			expectedEqual: []string{
+				"Base.Labels", "Base.UpdatedAt", "Base.PagingSequence",
+			},
+			baseObjectCreateFunc: createPlatform,
+		},
+		{
+			expectedEqual: []string{
+				"Base.Labels", "Base.UpdatedAt", "Base.PagingSequence",
+			},
+			baseObjectCreateFunc: createVisibility,
+		},
+		{
+			expectedEqual: []string{
+				"Base.Labels", "Base.UpdatedAt", "Base.PagingSequence",
+			},
+			baseObjectCreateFunc: createServiceOffering,
+		},
+		{
+			expectedEqual: []string{
+				"Base.Labels", "Base.UpdatedAt", "Base.PagingSequence",
+			},
+			baseObjectCreateFunc: createServicePlan,
+		},
+		{
+			expectedEqual: []string{
+				"Base.Labels", "Base.UpdatedAt", "Base.PagingSequence", "Ready", "Usable",
+			},
+			baseObjectCreateFunc: createServiceInstance,
+		},
+		{
+			expectedEqual: []string{
+				"Base.Labels", "Base.UpdatedAt", "Base.PagingSequence",
+			},
+			baseObjectCreateFunc: createNotification,
+		},
+		{
+			expectedEqual: []string{
+				"Base.Labels", "Base.UpdatedAt", "Base.PagingSequence",
+			},
+			baseObjectCreateFunc: createOperation,
+		},
+	}
+
+	for i := range entries {
+		func(entry *testCase) {
+			blueprint := entry.baseObjectCreateFunc(now)
+			typ := blueprint.GetType().String()
+			Context(typ, func() {
+				var object1, object2 Object
+				BeforeEach(func() {
+					object1 = entry.baseObjectCreateFunc(now)
+					object2 = entry.baseObjectCreateFunc(now)
+
+				})
+
+				changeableProps := setProps(blueprint, "")
+				for k := range changeableProps {
+					func(cp propChange) {
+						When(fmt.Sprintf("%s is changed", cp.path), func() {
+							BeforeEach(func() {
+								err := setProp(object1, cp.path, cp.value)
+								Expect(err).ShouldNot(HaveOccurred())
+							})
+							var expectedEqual bool
+							for _, e := range entry.expectedEqual {
+								if e == cp.path {
+									expectedEqual = true
+									break
+								}
+							}
+							itmsg := "should be equal"
+							if !expectedEqual {
+								itmsg = "should NOT be equal"
+							}
+
+							It(itmsg, func() {
+								Expect(object1.Equals(object2)).To(Equal(expectedEqual))
+							})
+						})
+					}(changeableProps[k])
+				}
+			})
+		}(entries[i])
+	}
+})
+
+type testCase struct {
+	baseObjectCreateFunc func(time.Time) Object
+	expectedEqual        []string
+}
+
+type propChange struct {
+	path  string
+	value interface{}
+}
+
+func setProp(object Object, key string, value interface{}) error {
+	paths := strings.Split(key, ".")
+	s := structs.New(object)
+	finalProp := s.Field(paths[0])
+	paths = paths[1:]
+	var found bool
+	for _, p := range paths {
+		finalProp, found = finalProp.FieldOk(p)
+		if !found {
+			return errors.New("errored")
+		}
+	}
+	return finalProp.Set(value)
+}
+
+func setProps(object interface{}, propPath string) []propChange {
+	result := make([]propChange, 0)
+	s := structs.New(object)
+	fields := s.Fields()
+	for _, f := range fields {
+		currentPath := f.Name()
+		if len(propPath) != 0 {
+			currentPath = fmt.Sprintf("%s.%s", propPath, f.Name())
+		}
+		if f.IsZero() {
+			continue
+		}
+		if f.Kind() != reflect.Struct && f.Kind() != reflect.Ptr {
+			assigned := true
+			switch f.Value().(type) {
+			case string:
+				result = append(result, propChange{
+					path:  currentPath,
+					value: "changed",
+				})
+			case ObjectType:
+				result = append(result, propChange{
+					path:  currentPath,
+					value: ObjectType("changed"),
+				})
+			case NotificationOperation:
+				result = append(result, propChange{
+					path:  currentPath,
+					value: NotificationOperation("changed"),
+				})
+			case OperationCategory:
+				result = append(result, propChange{
+					path:  currentPath,
+					value: OperationCategory("changed"),
+				})
+			case OperationState:
+				result = append(result, propChange{
+					path:  currentPath,
+					value: OperationState("changed"),
+				})
+			case Labels:
+				result = append(result, propChange{
+					path: currentPath,
+					value: Labels{
+						"new": []string{"value"},
+					},
+				})
+			case json.RawMessage:
+				result = append(result, propChange{
+					path:  currentPath,
+					value: []byte("changed"),
+				})
+			default:
+				assigned = false
+			}
+			if assigned {
+				continue
+			}
+			assigned = true
+
+			switch f.Kind() {
+			case reflect.Bool:
+				result = append(result, propChange{
+					path:  currentPath,
+					value: false,
+				})
+			case reflect.Int:
+				result = append(result, propChange{
+					path:  currentPath,
+					value: int(2),
+				})
+			case reflect.Int32:
+				result = append(result, propChange{
+					path:  currentPath,
+					value: int32(2),
+				})
+			case reflect.Int64:
+				result = append(result, propChange{
+					path:  currentPath,
+					value: int64(2),
+				})
+			default:
+				assigned = false
+			}
+			if !assigned {
+				panic("Not able to assign property")
+			}
+		} else {
+			switch f.Value().(type) {
+			case time.Time:
+				result = append(result, propChange{
+					path:  currentPath,
+					value: time.Now(),
+				})
+			default:
+				result = append(result, setProps(f.Value(), currentPath)...)
+			}
+		}
+	}
+	return result
+}
+
+func createOperation(now time.Time) Object {
+	labels := Labels{
+		"label_key": []string{"value"},
+	}
+	return &Operation{
+		Base: Base{
+			ID:        "id",
+			Labels:    labels,
+			CreatedAt: now,
+			UpdatedAt: now.Add(time.Second * 10),
+		},
+		Description:   "description",
+		Type:          OperationCategory("category"),
+		State:         OperationState("state"),
+		ResourceID:    "1",
+		ResourceType:  "type",
+		Errors:        []byte("errors"),
+		CorrelationID: "1",
+		ExternalID:    "1",
+	}
+}
+
+func createServiceInstance(now time.Time) Object {
+	labels := Labels{
+		"label_key": []string{"value"},
+	}
+	return &ServiceInstance{
+		Base: Base{
+			ID:        "id",
+			Labels:    labels,
+			CreatedAt: now,
+			UpdatedAt: now.Add(time.Second * 10),
+		},
+		Name:            "name",
+		ServicePlanID:   "1",
+		PlatformID:      "1",
+		MaintenanceInfo: []byte("default"),
+		Context:         []byte("default"),
+		PreviousValues:  []byte("default"),
+		Ready:           true,
+		Usable:          true,
+	}
+}
+
+func createNotification(now time.Time) Object {
+	labels := Labels{
+		"label_key": []string{"value"},
+	}
+	return &Notification{
+		Base: Base{
+			ID:        "id",
+			Labels:    labels,
+			CreatedAt: now,
+			UpdatedAt: now.Add(time.Second * 10),
+		},
+		Resource:      ObjectType("resource"),
+		Type:          NotificationOperation("type"),
+		PlatformID:    "1",
+		Revision:      1,
+		Payload:       []byte("payload"),
+		CorrelationID: "1",
+	}
+}
+
+func createServicePlan(now time.Time) Object {
+	labels := Labels{
+		"label_key": []string{"value"},
+	}
+	return &ServicePlan{
+		Base: Base{
+			ID:             "id",
+			CreatedAt:      now,
+			UpdatedAt:      now.Add(time.Second * 10),
+			Labels:         labels,
+			PagingSequence: 0,
+		},
+		Name:              "name",
+		Description:       "description",
+		CatalogID:         "1",
+		CatalogName:       "catname",
+		Free:              true,
+		Bindable:          true,
+		PlanUpdatable:     true,
+		Metadata:          []byte("metadata"),
+		Schemas:           []byte("schema"),
+		ServiceOfferingID: "1",
+	}
+}
+
+func createServiceOffering(now time.Time) Object {
+	labels := Labels{
+		"label_key": []string{"value"},
+	}
+	return &ServiceOffering{
+		Base: Base{
+			ID:             "id",
+			CreatedAt:      now,
+			UpdatedAt:      now.Add(time.Second * 10),
+			Labels:         labels,
+			PagingSequence: 0,
+		},
+		Name:                 "name",
+		Description:          "description",
+		Bindable:             true,
+		InstancesRetrievable: true,
+		BindingsRetrievable:  true,
+		PlanUpdatable:        true,
+		Tags:                 []byte("tags"),
+		Requires:             []byte("requires"),
+		Metadata:             []byte("metadata"),
+		BrokerID:             "1",
+		CatalogID:            "1",
+		CatalogName:          "catname",
+		Plans:                nil,
+	}
+}
+
+func createVisibility(now time.Time) Object {
+	labels := Labels{
+		"label_key": []string{"value"},
+	}
+	return &Visibility{
+		Base: Base{
+			ID:             "id",
+			CreatedAt:      now,
+			UpdatedAt:      now.Add(time.Second * 10),
+			Labels:         labels,
+			PagingSequence: 0,
+		},
+		PlatformID:    "1",
+		ServicePlanID: "1",
+	}
+}
+
+func createPlatform(now time.Time) Object {
+	labels := Labels{
+		"label_key": []string{"value"},
+	}
+	return &Platform{
+		Base: Base{
+			ID:             "id",
+			CreatedAt:      now,
+			UpdatedAt:      now.Add(time.Second * 10),
+			Labels:         labels,
+			PagingSequence: 0,
+		},
+		Secured:     nil,
+		Type:        "cloudfoundry",
+		Name:        "test_broker",
+		Description: "decription",
+		Credentials: &Credentials{
+			Basic: &Basic{
+				Username: "user",
+				Password: "password",
+			},
+		},
+		Active:     true,
+		LastActive: now,
+	}
+}
+
+func createBroker(now time.Time) Object {
+	labels := Labels{
+		"label_key": []string{"value"},
+	}
+	return &ServiceBroker{
+		Base: Base{
+			ID:             "id",
+			CreatedAt:      now,
+			UpdatedAt:      now.Add(time.Second * 10),
+			Labels:         labels,
+			PagingSequence: 0,
+		},
+		Secured:     nil,
+		Name:        "test_broker",
+		Description: "broker decription",
+		BrokerURL:   "broker_url",
+		Credentials: &Credentials{
+			Basic: &Basic{
+				Username: "user",
+				Password: "password",
+			},
+		},
+		Catalog:  nil,
+		Services: nil,
+	}
+}

--- a/pkg/types/visibility.go
+++ b/pkg/types/visibility.go
@@ -31,6 +31,20 @@ type Visibility struct {
 	ServicePlanID string `json:"service_plan_id"`
 }
 
+func (e *Visibility) Equals(obj Object) bool {
+	if !Equals(e, obj) {
+		return false
+	}
+
+	visibility := obj.(*Visibility)
+	if e.PlatformID != visibility.PlatformID ||
+		e.ServicePlanID != visibility.ServicePlanID {
+		return false
+	}
+
+	return true
+}
+
 // Validate implements InputValidator and verifies all mandatory fields are populated
 func (e *Visibility) Validate() error {
 	if e.ServicePlanID == "" {

--- a/storage/postgres/scheme_test.go
+++ b/storage/postgres/scheme_test.go
@@ -156,6 +156,10 @@ var _ = Describe("Postgres Storage", func() {
 type obj struct {
 }
 
+func (obj) Equals(other types.Object) bool {
+	return false
+}
+
 func (obj) Validate() error {
 	return nil
 }

--- a/test/notification_test/notification_test.go
+++ b/test/notification_test/notification_test.go
@@ -446,6 +446,8 @@ var _ = Describe("Notifications Suite", func() {
 				Expect(actualOldPayload).To(MatchUnorderedJSON(expectedOldPayload))
 
 				newResource := gjson.GetBytes(notification.Payload, "new.resource").Value().(common.Object)
+				delete(objAfterOp, "labels")
+				delete(newResource, "labels")
 				Expect(newResource).To(Equal(objAfterOp))
 
 				actualNewPayload := gjson.GetBytes(notification.Payload, "new.additional").Raw


### PR DESCRIPTION
In certain cases - there is no need to send visibility's labels such as:

1) Update visibility
1.1) when platform id and plan id is not changes - then only label changes are enough
1.2) when plan id is changed, then old visibility's labels are not needed, as we know we should delete all visibilities in the platform. Only the new visibility's labels are needed
1.3) when platform id is changed, then no update notification should be send, because only delete and create notifications are needed. Currently this cannot be avoided because tests will fail for broker notifications.

Overall result is: Approximately 2x times smaller notification size, because old visibility will never have labels. Sometimes the size will be even smaller, when no visibility labels will be sent at all, as only label changes are needed. For example: when an organisation is added to the labels.

Possible improvements:
- When only plan id is changed, no need to send labels, because the labels will be the same, only the plan id in the platform should be updated. But this has to be researched further as it may have some troubles on the way.

![image](https://user-images.githubusercontent.com/4245946/71582292-3d88c280-2b12-11ea-879f-628120bfbab7.png)
