### PR TITLE
Introduce ClaimedAt operations property [async engine story]

### DIFF
--- a/operations/maintainer.go
+++ b/operations/maintainer.go
@@ -78,7 +78,7 @@ func (om *OperationMaintainer) deleteOldOperations() {
 func (om *OperationMaintainer) markOrphanOperationsFailed() {
 	criteria := []query.Criterion{
 		query.ByField(query.EqualsOperator, "state", string(types.IN_PROGRESS)),
-		query.ByField(query.LessThanOperator, "created_at", util.ToRFCNanoFormat(time.Now().Add(-om.jobTimeout))),
+		query.ByField(query.LessThanOperator, "claimed_at", util.ToRFCNanoFormat(time.Now().Add(-om.jobTimeout))),
 	}
 
 	objectList, err := om.repository.List(om.smCtx, types.OperationType, criteria...)

--- a/operations/maintainer.go
+++ b/operations/maintainer.go
@@ -97,5 +97,5 @@ func (om *OperationMaintainer) markOrphanOperationsFailed() {
 		}
 	}
 
-	log.D().Debug("Successfully cleaned up orphan operations")
+	log.D().Debug("Successfully marked orphan operations as failed")
 }

--- a/pkg/types/operation.go
+++ b/pkg/types/operation.go
@@ -19,6 +19,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/Peripli/service-manager/pkg/util"
 )
@@ -55,6 +56,7 @@ const (
 // Operation struct
 type Operation struct {
 	Base
+	ClaimedAt     time.Time         `json:"claimed_at"`
 	Description   string            `json:"description"`
 	Type          OperationCategory `json:"type"`
 	State         OperationState    `json:"state"`

--- a/storage/postgres/keystore_test.go
+++ b/storage/postgres/keystore_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Secured Storage", func() {
 		mock.ExpectQuery(`SELECT CURRENT_DATABASE()`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("mock"))
 		mock.ExpectQuery(`SELECT COUNT(1)*`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("1"))
 		mock.ExpectExec("SELECT pg_advisory_lock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20191206134500,false"))
+		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20200101212700,false"))
 		mock.ExpectExec("SELECT pg_advisory_unlock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 		options := storage.DefaultSettings()
 		options.EncryptionKey = string(envEncryptionKey)

--- a/storage/postgres/migrations/20200101212700_operations_claimed_at.down.sql
+++ b/storage/postgres/migrations/20200101212700_operations_claimed_at.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE operations DROP COLUMN claimed_at;
+
+COMMIT;

--- a/storage/postgres/migrations/20200101212700_operations_claimed_at.up.sql
+++ b/storage/postgres/migrations/20200101212700_operations_claimed_at.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE operations ADD COLUMN claimed_at timestamptz;
+
+COMMIT;

--- a/storage/postgres/operation.go
+++ b/storage/postgres/operation.go
@@ -18,6 +18,7 @@ package postgres
 
 import (
 	"database/sql"
+	"github.com/lib/pq"
 	"time"
 
 	"github.com/Peripli/service-manager/pkg/types"
@@ -29,7 +30,7 @@ import (
 //go:generate smgen storage operation github.com/Peripli/service-manager/pkg/types:Operation
 type Operation struct {
 	BaseEntity
-	ClaimedAt     time.Time          `db:"claimed_at"`
+	ClaimedAt     pq.NullTime        `db:"claimed_at"`
 	Description   sql.NullString     `db:"description"`
 	Type          string             `db:"type"`
 	State         string             `db:"state"`
@@ -48,7 +49,7 @@ func (o *Operation) ToObject() types.Object {
 			UpdatedAt:      o.UpdatedAt,
 			PagingSequence: o.PagingSequence,
 		},
-		ClaimedAt:     o.ClaimedAt,
+		ClaimedAt:     o.ClaimedAt.Time,
 		Description:   o.Description.String,
 		Type:          types.OperationCategory(o.Type),
 		State:         types.OperationState(o.State),
@@ -66,6 +67,11 @@ func (*Operation) FromObject(object types.Object) (storage.Entity, bool) {
 		return nil, false
 	}
 
+	claimedAt := pq.NullTime{
+		Time:  operation.ClaimedAt,
+		Valid: operation.ClaimedAt != time.Time{},
+	}
+
 	o := &Operation{
 		BaseEntity: BaseEntity{
 			ID:             operation.ID,
@@ -73,7 +79,7 @@ func (*Operation) FromObject(object types.Object) (storage.Entity, bool) {
 			UpdatedAt:      operation.UpdatedAt,
 			PagingSequence: operation.PagingSequence,
 		},
-		ClaimedAt:     operation.ClaimedAt,
+		ClaimedAt:     claimedAt,
 		Description:   toNullString(operation.Description),
 		Type:          string(operation.Type),
 		State:         string(operation.State),

--- a/storage/postgres/operation.go
+++ b/storage/postgres/operation.go
@@ -18,6 +18,7 @@ package postgres
 
 import (
 	"database/sql"
+	"time"
 
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/storage"
@@ -28,6 +29,7 @@ import (
 //go:generate smgen storage operation github.com/Peripli/service-manager/pkg/types:Operation
 type Operation struct {
 	BaseEntity
+	ClaimedAt     time.Time          `db:"claimed_at"`
 	Description   sql.NullString     `db:"description"`
 	Type          string             `db:"type"`
 	State         string             `db:"state"`
@@ -46,6 +48,7 @@ func (o *Operation) ToObject() types.Object {
 			UpdatedAt:      o.UpdatedAt,
 			PagingSequence: o.PagingSequence,
 		},
+		ClaimedAt:     o.ClaimedAt,
 		Description:   o.Description.String,
 		Type:          types.OperationCategory(o.Type),
 		State:         types.OperationState(o.State),
@@ -70,6 +73,7 @@ func (*Operation) FromObject(object types.Object) (storage.Entity, bool) {
 			UpdatedAt:      operation.UpdatedAt,
 			PagingSequence: operation.PagingSequence,
 		},
+		ClaimedAt:     operation.ClaimedAt,
 		Description:   toNullString(operation.Description),
 		Type:          string(operation.Type),
 		State:         string(operation.State),


### PR DESCRIPTION
# Introduce ClaimedAt property [async engine story]

## Note

This PR was created in the hopes to ease the discussion process of whether we need such a change. Until the team has agreed upon such an approach, this change only serves as a reference implementation.

## Motivation

The operation maintainer currently updates operations older than job_timeout to failed. It does so by making a diff between the current time and the created_at timestamp of the operation, but this is somewhat flawed - it's possible for an operation to be in the "job queue" and may have not been claimed at. Such operations are not stuck or orphans, they are just waiting for their turn to come when they're executed.

This PR proposes an introduction of a `claimed_at` property to operation entities, which will be set first thing when an operation (job) execution starts running.

This way the maintainer can differentiate which operations have indeed been stuck/orphaned due to SM node crash (for example) and which are waiting to be claimed.
