### PR TITLE
Log original SQL error

### DIFF
--- a/storage/postgres/abstract.go
+++ b/storage/postgres/abstract.go
@@ -185,7 +185,7 @@ func checkUniqueViolation(ctx context.Context, err error) error {
 	}
 	sqlErr, ok := err.(*pq.Error)
 	if ok && sqlErr.Code.Name() == "unique_violation" {
-		log.C(ctx).Debug(sqlErr)
+		log.C(ctx).Errorf("%v: %v", sqlErr.Message, sqlErr.Detail)
 		return util.ErrAlreadyExistsInStorage
 	}
 	return err
@@ -197,7 +197,7 @@ func checkIntegrityViolation(ctx context.Context, err error) error {
 	}
 	sqlErr, ok := err.(*pq.Error)
 	if ok && (sqlErr.Code.Class() == "42" || sqlErr.Code.Class() == "44" || sqlErr.Code.Class() == "23") {
-		log.C(ctx).Debug(sqlErr)
+		log.C(ctx).Errorf("%v: %v", sqlErr.Message, sqlErr.Detail)
 		return &util.ErrBadRequestStorage{Cause: err}
 	}
 	return err


### PR DESCRIPTION
## Motivation

Sometimes the error info in the log is not enough, e.g.
```
HTTPError: found conflicting Platform
```

## Approach

Now we log also the original postgres error, e.g.
```
duplicate key value violates unique constraint "platforms_name_key": Key (name)=(cf1) already exists.
```
