### PR TITLE
Persist dashboard_url for Service Instances

### DIFF
--- a/pkg/types/service_instance.go
+++ b/pkg/types/service_instance.go
@@ -33,6 +33,7 @@ type ServiceInstance struct {
 	Name            string          `json:"name"`
 	ServicePlanID   string          `json:"service_plan_id"`
 	PlatformID      string          `json:"platform_id"`
+	DashboardURL    string          `json:"dashboard_url,omitempty"`
 	MaintenanceInfo json.RawMessage `json:"maintenance_info,omitempty"`
 	Context         json.RawMessage `json:"-"`
 	PreviousValues  json.RawMessage `json:"-"`
@@ -49,6 +50,7 @@ func (e *ServiceInstance) Equals(obj Object) bool {
 	if e.Name != instance.Name ||
 		e.PlatformID != instance.PlatformID ||
 		e.ServicePlanID != instance.ServicePlanID ||
+		e.DashboardURL != instance.DashboardURL ||
 		!reflect.DeepEqual(e.PreviousValues, instance.PreviousValues) ||
 		!reflect.DeepEqual(e.Context, instance.Context) ||
 		!reflect.DeepEqual(e.MaintenanceInfo, instance.MaintenanceInfo) {

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -279,6 +279,7 @@ func createServiceInstance(now time.Time) Object {
 		Name:            "name",
 		ServicePlanID:   "1",
 		PlatformID:      "1",
+		DashboardURL:    "http://test-service.com/dashboard",
 		MaintenanceInfo: []byte("default"),
 		Context:         []byte("default"),
 		PreviousValues:  []byte("default"),

--- a/storage/postgres/keystore_test.go
+++ b/storage/postgres/keystore_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Secured Storage", func() {
 		mock.ExpectQuery(`SELECT CURRENT_DATABASE()`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("mock"))
 		mock.ExpectQuery(`SELECT COUNT(1)*`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("1"))
 		mock.ExpectExec("SELECT pg_advisory_lock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20200103101000,false"))
+		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20200114101000,false"))
 		mock.ExpectExec("SELECT pg_advisory_unlock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 		options := storage.DefaultSettings()
 		options.EncryptionKey = string(envEncryptionKey)

--- a/storage/postgres/migrations/20200114101000_dashboard_url.down.sql
+++ b/storage/postgres/migrations/20200114101000_dashboard_url.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE service_instances DROP COLUMN dashboard_url;
+
+COMMIT;

--- a/storage/postgres/migrations/20200114101000_dashboard_url.up.sql
+++ b/storage/postgres/migrations/20200114101000_dashboard_url.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE service_instances ADD COLUMN dashboard_url varchar(100);
+
+COMMIT;

--- a/storage/postgres/migrations/20200114101000_dashboard_url.up.sql
+++ b/storage/postgres/migrations/20200114101000_dashboard_url.up.sql
@@ -1,5 +1,5 @@
 BEGIN;
 
-ALTER TABLE service_instances ADD COLUMN dashboard_url varchar(100);
+ALTER TABLE service_instances ADD COLUMN dashboard_url varchar(16000);
 
 COMMIT;

--- a/storage/postgres/service_instance.go
+++ b/storage/postgres/service_instance.go
@@ -30,6 +30,7 @@ type ServiceInstance struct {
 	Name            string             `db:"name"`
 	ServicePlanID   string             `db:"service_plan_id"`
 	PlatformID      string             `db:"platform_id"`
+	DashboardURL    string             `db:"dashboard_url"`
 	MaintenanceInfo sqlxtypes.JSONText `db:"maintenance_info"`
 	Context         sqlxtypes.JSONText `db:"context"`
 	PreviousValues  sqlxtypes.JSONText `db:"previous_values"`
@@ -49,6 +50,7 @@ func (si *ServiceInstance) ToObject() types.Object {
 		Name:            si.Name,
 		ServicePlanID:   si.ServicePlanID,
 		PlatformID:      si.PlatformID,
+		DashboardURL:    si.DashboardURL,
 		MaintenanceInfo: getJSONRawMessage(si.MaintenanceInfo),
 		Context:         getJSONRawMessage(si.Context),
 		PreviousValues:  getJSONRawMessage(si.PreviousValues),
@@ -73,6 +75,7 @@ func (*ServiceInstance) FromObject(object types.Object) (storage.Entity, bool) {
 		Name:            serviceInstance.Name,
 		ServicePlanID:   serviceInstance.ServicePlanID,
 		PlatformID:      serviceInstance.PlatformID,
+		DashboardURL:    serviceInstance.DashboardURL,
 		MaintenanceInfo: getJSONText(serviceInstance.MaintenanceInfo),
 		Context:         getJSONText(serviceInstance.Context),
 		PreviousValues:  getJSONText(serviceInstance.PreviousValues),

--- a/test/testutil/service_instance/service_instances.go
+++ b/test/testutil/service_instance/service_instances.go
@@ -48,6 +48,7 @@ func Prepare(ctx *common.TestContext, platformID, planID string, OSBContext stri
 		Name:          "test-service-instance",
 		ServicePlanID: planID,
 		PlatformID:    platformID,
+		DashboardURL:  "http://test-service.com/dashboard",
 		Context:       []byte(OSBContext),
 		Ready:         true,
 		Usable:        true,


### PR DESCRIPTION
# Persist dashboard_url for Service Instances

## Motivation

The dashboard_url property is a top-level one which should be returned when fetching instances.

## Pull Request status

* [x] Initial implementation
* [x] Unit tests
* [x] Integration tests