### PR TITLE
Log error when no plan visibility is found

### DIFF
--- a/api/osb/check_instance_owner_plugin.go
+++ b/api/osb/check_instance_owner_plugin.go
@@ -1,7 +1,8 @@
 package osb
 
 import (
-	"fmt"
+	"net/http"
+
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/query"
 	"github.com/Peripli/service-manager/pkg/types"
@@ -9,7 +10,6 @@ import (
 	"github.com/Peripli/service-manager/pkg/web"
 	"github.com/Peripli/service-manager/storage"
 	"github.com/tidwall/gjson"
-	"net/http"
 )
 
 const CheckInstanceOwnerPluginName = "CheckInstanceOwnerPlugin"
@@ -76,7 +76,7 @@ func (p *checkInstanceOwnerPlugin) assertOwner(req *web.Request, next web.Handle
 		log.C(ctx).Errorf("Instance owner %s is not the same as the caller %s", instanceOwnerTenantID, callerTenantID)
 		return nil, &util.HTTPError{
 			ErrorType:   "NotFound",
-			Description: fmt.Sprintf("could not find such %s", string(types.ServiceInstanceType)),
+			Description: "could not find such service instance",
 			StatusCode:  http.StatusNotFound,
 		}
 	}

--- a/api/osb/check_platform_id_plugin.go
+++ b/api/osb/check_platform_id_plugin.go
@@ -1,14 +1,14 @@
 package osb
 
 import (
-	"fmt"
+	"net/http"
+
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/query"
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/pkg/util"
 	"github.com/Peripli/service-manager/pkg/web"
 	"github.com/Peripli/service-manager/storage"
-	"net/http"
 )
 
 const CheckPlatformIDPluginName = "CheckPlatformIDPlugin"
@@ -86,7 +86,7 @@ func (p *checkPlatformIDPlugin) assertPlatformID(req *web.Request, next web.Hand
 		log.C(ctx).Errorf("Instance with id %s and platform id %s does not belong to platform with id %s", instance.ID, instance.PlatformID, platform.ID)
 		return nil, &util.HTTPError{
 			ErrorType:   "NotFound",
-			Description: fmt.Sprintf("could not find such %s", string(types.ServiceInstanceType)),
+			Description: "could not find such service instance",
 			StatusCode:  http.StatusNotFound,
 		}
 	}

--- a/api/osb/check_visibility_plugin.go
+++ b/api/osb/check_visibility_plugin.go
@@ -2,7 +2,6 @@ package osb
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/Peripli/service-manager/pkg/log"
@@ -96,7 +95,7 @@ func (p *checkVisibilityPlugin) checkVisibility(req *web.Request, next web.Handl
 			}
 		}
 		for _, v := range visibilities.Visibilities {
-			if v.PlatformID == "" {
+			if v.PlatformID == "" { // public visibility
 				return next.Handle(req)
 			}
 			if v.PlatformID == platform.ID {
@@ -114,23 +113,25 @@ func (p *checkVisibilityPlugin) checkVisibility(req *web.Request, next web.Handl
 				}
 			}
 		}
+		log.C(ctx).Errorf("Service plan %v is not visible on platform %v", planID, platform.ID)
 		return nil, &util.HTTPError{
 			ErrorType:   "NotFound",
-			Description: fmt.Sprintf("could not find such %s", string(types.ServicePlanType)),
+			Description: "could not find such service plan",
 			StatusCode:  http.StatusNotFound,
 		}
 	default:
 		for _, v := range visibilities.Visibilities {
-			if v.PlatformID == "" {
+			if v.PlatformID == "" { // public visibility
 				return next.Handle(req)
 			}
 			if v.PlatformID == platform.ID {
 				return next.Handle(req)
 			}
 		}
+		log.C(ctx).Errorf("Service plan %v is not visible on platform %v", planID, platform.ID)
 		return nil, &util.HTTPError{
 			ErrorType:   "NotFound",
-			Description: fmt.Sprintf("could not find such %s", string(types.ServicePlanType)),
+			Description: "could not find such service plan",
 			StatusCode:  http.StatusNotFound,
 		}
 	}


### PR DESCRIPTION
## Motivation

In case the service plan is not visible, service provisioning fails and we could see only this error in the log
```
HTTPError: could not find such types.ServicePlan
```
The actual reason was not clear.

## Approach

Log explicitly that the plan is not visible.

## Pull Request status

* [x] Initial implementation
