### PR TITLE
Add maintainer job pool

### DIFF
--- a/operations/maintainer.go
+++ b/operations/maintainer.go
@@ -18,12 +18,14 @@ package operations
 
 import (
 	"context"
+	"sync"
+	"time"
+
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/query"
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/pkg/util"
 	"github.com/Peripli/service-manager/storage"
-	"time"
 )
 
 // Maintainer ensures that operations old enough are deleted
@@ -34,16 +36,20 @@ type Maintainer struct {
 	jobTimeout          time.Duration
 	markOrphansInterval time.Duration
 	cleanupInterval     time.Duration
+	workers             chan struct{}
+	wg                  *sync.WaitGroup
 }
 
 // NewMaintainer constructs a Maintainer
-func NewMaintainer(smCtx context.Context, repository storage.Repository, options *Settings) *Maintainer {
+func NewMaintainer(smCtx context.Context, repository storage.Repository, options *Settings, wg *sync.WaitGroup) *Maintainer {
 	return &Maintainer{
 		smCtx:               smCtx,
 		repository:          repository,
 		jobTimeout:          options.JobTimeout,
 		markOrphansInterval: options.MarkOrphansInterval,
 		cleanupInterval:     options.CleanupInterval,
+		workers:             make(chan struct{}, options.DefaultPoolSize),
+		wg:                  wg,
 	}
 }
 
@@ -58,6 +64,8 @@ func (om *Maintainer) Run() {
 func (om *Maintainer) processOldOperations() {
 	ticker := time.NewTicker(om.cleanupInterval)
 	defer ticker.Stop()
+	om.wg.Add(1)
+	defer om.wg.Done()
 	for {
 		select {
 		case <-ticker.C:
@@ -89,7 +97,7 @@ func (om *Maintainer) processOrphanOperations() {
 func (om *Maintainer) cleanUpOldOperations() {
 	byDate := query.ByField(query.LessThanOperator, "created_at", util.ToRFCNanoFormat(time.Now().Add(-om.cleanupInterval)))
 	if err := om.repository.Delete(om.smCtx, types.OperationType, byDate); err != nil {
-		log.D().Debugf("Failed to cleanup operations: %s", err)
+		log.C(om.smCtx).Errorf("Failed to cleanup operations: %s", err)
 		return
 	}
 	log.D().Debug("Successfully cleaned up operations")
@@ -103,19 +111,40 @@ func (om *Maintainer) markOrphanOperationsFailed() {
 
 	objectList, err := om.repository.List(om.smCtx, types.OperationType, criteria...)
 	if err != nil {
-		log.D().Debugf("Failed to fetch orphan operations: %s", err)
+		log.C(om.smCtx).Errorf("Failed to fetch orphan operations: %s", err)
 		return
 	}
 
+	operationsLeftCount := 0
 	operations := objectList.(*types.Operations)
 	for i := 0; i < operations.Len(); i++ {
 		operation := operations.ItemAt(i).(*types.Operation)
-		operation.State = types.FAILED
-
-		if _, err := om.repository.Update(om.smCtx, operation, query.LabelChanges{}); err != nil {
-			log.D().Debugf("Failed to update orphan operation with ID (%s) state to FAILED: %s", operation.ID, err)
+		if !om.tryOperation(operation) {
+			operationsLeftCount++
 		}
 	}
+	log.C(om.smCtx).Infof("%d operations will be maintained during next maintainer scheduled time", operationsLeftCount)
+}
 
-	log.D().Debug("Successfully marked orphan operations as failed")
+func (om *Maintainer) tryOperation(operation *types.Operation) bool {
+	select {
+	case om.workers <- struct{}{}:
+		om.wg.Add(1)
+		go func() {
+			defer func() {
+				<-om.workers
+				om.wg.Done()
+			}()
+			operation.State = types.FAILED
+			if _, err := om.repository.Update(om.smCtx, operation, query.LabelChanges{}); err != nil {
+				log.C(om.smCtx).Errorf("Failed to update orphan operation with ID (%s) state to FAILED: %s", operation.ID, err)
+			}
+			log.C(om.smCtx).Debugf("Successfully marked orphan operation with id %s as failed", operation.ID)
+		}()
+	default:
+		log.C(om.smCtx).Warnf("Maintainer too busy. Will schedule operation with id %s next time", operation.ID)
+		return false
+	}
+
+	return true
 }

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/Peripli/service-manager/operations"
 	"net/http"
 	"sync"
+
+	"github.com/Peripli/service-manager/operations"
 
 	secFilters "github.com/Peripli/service-manager/pkg/security/filters"
 
@@ -81,7 +82,7 @@ type ServiceManager struct {
 	NotificationCleaner *storage.NotificationCleaner
 }
 
-// New returns service-manager Server with default setup
+// New returns service-manager builder with default setup
 func New(ctx context.Context, cancel context.CancelFunc, e env.Environment, cfg *config.Settings) (*ServiceManagerBuilder, error) {
 	var err error
 	if err = cfg.Validate(); err != nil {
@@ -157,7 +158,7 @@ func New(ctx context.Context, cancel context.CancelFunc, e env.Environment, cfg 
 		Settings: *cfg.Storage,
 	}
 
-	operationMaintainer := operations.NewMaintainer(ctx, interceptableRepository, cfg.Operations)
+	operationMaintainer := operations.NewMaintainer(ctx, interceptableRepository, cfg.Operations, waitGroup)
 
 	smb := &ServiceManagerBuilder{
 		API:                 API,

--- a/test/maintainer_test/maintainer_test.go
+++ b/test/maintainer_test/maintainer_test.go
@@ -1,0 +1,166 @@
+/*
+ *    Copyright 2018 The Service Manager Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package notification_cleaner_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Peripli/service-manager/pkg/log"
+	"github.com/Peripli/service-manager/pkg/query"
+
+	"github.com/Peripli/service-manager/test/testutil"
+
+	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/Peripli/service-manager/test/common"
+	"github.com/gofrs/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
+)
+
+func TestMaintainer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Maintainer Tests Suite")
+}
+
+var _ = Describe("Maintainer", func() {
+	const (
+		eventuallyTimeout = time.Second * 5
+	)
+	var (
+		testContext    *common.TestContext
+		ctx            context.Context
+		logInterceptor *testutil.LogInterceptor
+	)
+
+	randomOperation := func() *types.Operation {
+		idBytes, err := uuid.NewV4()
+		Expect(err).ToNot(HaveOccurred())
+		return &types.Operation{
+			Base: types.Base{
+				ID:        idBytes.String(),
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			State: types.IN_PROGRESS,
+			Type:  types.DELETE,
+		}
+	}
+
+	AfterEach(func() {
+		testContext.Cleanup()
+	})
+
+	BeforeEach(func() {
+		logInterceptor = &testutil.LogInterceptor{}
+		ctx = context.Background()
+
+		testContext = common.NewTestContextBuilder().WithEnvPreExtensions(func(set *pflag.FlagSet) {
+			err := set.Set("log.level", "debug")
+			Expect(err).ToNot(HaveOccurred())
+			err = set.Set("operations.default_pool_size", "1")
+			Expect(err).ToNot(HaveOccurred())
+			err = set.Set("operations.job_timeout", "10m")
+			Expect(err).ToNot(HaveOccurred())
+			err = set.Set("operations.mark_orphans_interval", "10ms")
+			Expect(err).ToNot(HaveOccurred())
+		}).Build()
+	})
+
+	Context("When three operations are created", func() {
+		var first, second, third *types.Operation
+		BeforeEach(func() {
+			first = randomOperation()
+			second = randomOperation()
+			third = randomOperation()
+		})
+
+		JustBeforeEach(func() {
+			var err error
+			var new types.Object
+			new, err = testContext.SMRepository.Create(ctx, first)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(new.GetID()).ToNot(BeEmpty())
+			first.SetID(new.GetID())
+
+			new, err = testContext.SMRepository.Create(ctx, second)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(new.GetID()).ToNot(BeEmpty())
+			second.SetID(new.GetID())
+
+			new, err = testContext.SMRepository.Create(ctx, third)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(new.GetID()).ToNot(BeEmpty())
+			third.SetID(new.GetID())
+		})
+
+		Context("when second is long in progress", func() {
+			BeforeEach(func() {
+				second.CreatedAt = time.Now().Add(-(time.Hour))
+			})
+
+			It("should mark the second as failed", func() {
+				log.AddHook(logInterceptor)
+
+				Eventually(logInterceptor.String, eventuallyTimeout).
+					Should(ContainSubstring(fmt.Sprintf("Successfully marked orphan operation with id %s", second.ID)))
+
+				Eventually(func() types.OperationState {
+					byOldID := query.ByField(query.EqualsOperator, "id", second.GetID())
+					object, err := testContext.SMRepository.Get(ctx, types.OperationType, byOldID)
+					Expect(err).ShouldNot(HaveOccurred())
+					return (object.(*types.Operation)).State
+				}, eventuallyTimeout).Should(Equal(types.FAILED))
+
+				Eventually(func() types.OperationState {
+					byOldID := query.ByField(query.EqualsOperator, "id", first.GetID())
+					object, err := testContext.SMRepository.Get(ctx, types.OperationType, byOldID)
+					Expect(err).ShouldNot(HaveOccurred())
+					return (object.(*types.Operation)).State
+				}, eventuallyTimeout).Should(Equal(types.IN_PROGRESS))
+			})
+		})
+
+		Context("when maintainer is busy with other operations", func() {
+			BeforeEach(func() {
+				first.CreatedAt = time.Now().Add(-(time.Hour))
+				second.CreatedAt = time.Now().Add(-2 * (time.Hour))
+				third.CreatedAt = time.Now().Add(-3 * (time.Hour))
+			})
+
+			It("should log an appropriate error", func() {
+				log.AddHook(logInterceptor)
+
+				Eventually(logInterceptor.String, eventuallyTimeout).
+					Should(ContainSubstring(fmt.Sprintf("Successfully marked orphan operation with id %s", second.ID)))
+
+				Eventually(logInterceptor.String, eventuallyTimeout).
+					Should(ContainSubstring(fmt.Sprintf("Maintainer too busy. Will schedule operation with id %s next time", third.ID)))
+
+				Eventually(func() types.OperationState {
+					byOldID := query.ByField(query.EqualsOperator, "id", second.GetID())
+					object, err := testContext.SMRepository.Get(ctx, types.OperationType, byOldID)
+					Expect(err).ShouldNot(HaveOccurred())
+					return (object.(*types.Operation)).State
+				}, eventuallyTimeout).Should(Equal(types.FAILED))
+			})
+		})
+
+	})
+})


### PR DESCRIPTION
# Pull Request Template

## Approach

Executes maintainer orphan tasks in separate go routines with pool size. If there are no more workers, then the operations will be maintained on the next schedule of the maintainer