### PR TITLE
Fix instance dashboard url serialization

### DIFF
--- a/storage/postgres/keystore_test.go
+++ b/storage/postgres/keystore_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Secured Storage", func() {
 		mock.ExpectQuery(`SELECT CURRENT_DATABASE()`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("mock"))
 		mock.ExpectQuery(`SELECT COUNT(1)*`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("1"))
 		mock.ExpectExec("SELECT pg_advisory_lock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20200114101000,false"))
+		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20200116204800,false"))
 		mock.ExpectExec("SELECT pg_advisory_unlock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 		options := storage.DefaultSettings()
 		options.EncryptionKey = string(envEncryptionKey)

--- a/storage/postgres/migrations/20200116204800_dashboard_url_text.down.sql
+++ b/storage/postgres/migrations/20200116204800_dashboard_url_text.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE service_instances ALTER COLUMN dashboard_url TYPE varchar(16000);
+
+COMMIT;

--- a/storage/postgres/migrations/20200116204800_dashboard_url_text.up.sql
+++ b/storage/postgres/migrations/20200116204800_dashboard_url_text.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE service_instances ALTER COLUMN dashboard_url TYPE text;
+
+COMMIT;

--- a/storage/postgres/service_instance.go
+++ b/storage/postgres/service_instance.go
@@ -17,6 +17,8 @@
 package postgres
 
 import (
+	"database/sql"
+
 	"github.com/Peripli/service-manager/storage"
 	sqlxtypes "github.com/jmoiron/sqlx/types"
 
@@ -30,7 +32,7 @@ type ServiceInstance struct {
 	Name            string             `db:"name"`
 	ServicePlanID   string             `db:"service_plan_id"`
 	PlatformID      string             `db:"platform_id"`
-	DashboardURL    string             `db:"dashboard_url"`
+	DashboardURL    sql.NullString     `db:"dashboard_url"`
 	MaintenanceInfo sqlxtypes.JSONText `db:"maintenance_info"`
 	Context         sqlxtypes.JSONText `db:"context"`
 	PreviousValues  sqlxtypes.JSONText `db:"previous_values"`
@@ -50,7 +52,7 @@ func (si *ServiceInstance) ToObject() types.Object {
 		Name:            si.Name,
 		ServicePlanID:   si.ServicePlanID,
 		PlatformID:      si.PlatformID,
-		DashboardURL:    si.DashboardURL,
+		DashboardURL:    si.DashboardURL.String,
 		MaintenanceInfo: getJSONRawMessage(si.MaintenanceInfo),
 		Context:         getJSONRawMessage(si.Context),
 		PreviousValues:  getJSONRawMessage(si.PreviousValues),
@@ -75,7 +77,7 @@ func (*ServiceInstance) FromObject(object types.Object) (storage.Entity, bool) {
 		Name:            serviceInstance.Name,
 		ServicePlanID:   serviceInstance.ServicePlanID,
 		PlatformID:      serviceInstance.PlatformID,
-		DashboardURL:    serviceInstance.DashboardURL,
+		DashboardURL:    toNullString(serviceInstance.DashboardURL),
 		MaintenanceInfo: getJSONText(serviceInstance.MaintenanceInfo),
 		Context:         getJSONText(serviceInstance.Context),
 		PreviousValues:  getJSONText(serviceInstance.PreviousValues),

--- a/test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_test/service_instance_test.go
@@ -19,6 +19,7 @@ package service_test
 import (
 	"context"
 	"fmt"
+
 	"github.com/Peripli/service-manager/test/testutil/service_instance"
 
 	"net/http"
@@ -120,6 +121,19 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							_, tenantLabelExists := labels[TenantIdentifier]
 							Expect(tenantLabelExists).To(BeFalse())
 						}
+					})
+				})
+				When("service instance dashboard_url is not set", func() {
+					BeforeEach(func() {
+						_, serviceInstance = service_instance.Prepare(ctx, ctx.TestPlatform.ID, "", fmt.Sprintf(`{"%s":"%s"}`, TenantIdentifier, TenantValue))
+						serviceInstance.DashboardURL = ""
+						_, err := ctx.SMRepository.Create(context.Background(), serviceInstance)
+						Expect(err).ToNot(HaveOccurred())
+					})
+
+					It("doesn't return dashboard_url", func() {
+						ctx.SMWithOAuth.GET(web.ServiceInstancesURL + "/" + serviceInstance.ID).Expect().
+							Status(http.StatusOK).JSON().Object().NotContainsKey("dashboard_url")
 					})
 				})
 			})


### PR DESCRIPTION
# Fix instance dashboard url serialization

Service instance dashboard url is serialized from db into string.
There are some cases where this is actually null in the database (after db migration of existing service instances).
Therefore NullString should be used.