### PR TITLE
Add checkBrokerCredentials filter

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -20,9 +20,10 @@ package api
 import (
 	"context"
 	"fmt"
+	"sync"
+
 	"github.com/Peripli/service-manager/operations"
 	"github.com/Peripli/service-manager/pkg/env"
-	"sync"
 
 	"github.com/Peripli/service-manager/api/configuration"
 
@@ -131,6 +132,7 @@ func New(ctx context.Context, e env.Environment, options *Options) (*web.API, er
 			&filters.PatchOnlyLabelsFilter{},
 			filters.NewPlansFilterByVisibility(options.Repository),
 			filters.NewServicesFilterByVisibility(options.Repository),
+			&filters.CheckBrokerCredentialsFilter{},
 		},
 		Registry: health.NewDefaultRegistry(),
 	}, nil

--- a/api/filters/checkBrokerCredentials.go
+++ b/api/filters/checkBrokerCredentials.go
@@ -25,10 +25,10 @@ func (*CheckBrokerCredentialsFilter) Name() string {
 func (*CheckBrokerCredentialsFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
 	fields := gjson.GetManyBytes(req.Body, "broker_url", fmt.Sprintf(credentialsPath, "username"), fmt.Sprintf(credentialsPath, "password"))
 
-	if fields[0].Exists() && !fields[1].Exists() && !fields[2].Exists() {
+	if fields[0].Exists() && (!fields[1].Exists() || !fields[2].Exists()) {
 		return nil, &util.HTTPError{
 			ErrorType:   "BadRequest",
-			Description: "Updating an URl of a broker requires its basic credentials",
+			Description: "Updating an URL of a broker requires its basic credentials",
 			StatusCode:  http.StatusBadRequest,
 		}
 	}

--- a/api/filters/checkBrokerCredentials.go
+++ b/api/filters/checkBrokerCredentials.go
@@ -1,0 +1,47 @@
+package filters
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/Peripli/service-manager/pkg/util"
+	"github.com/Peripli/service-manager/pkg/web"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	CheckBrokerCredentialsFilterName = "CheckBrokerCredentialsFilter"
+	credentialsPath                  = "credentials.basic.%s"
+)
+
+// CheckBrokerCredentialsFilter checks patch request for the broker basic credentials
+type CheckBrokerCredentialsFilter struct {
+}
+
+func (*CheckBrokerCredentialsFilter) Name() string {
+	return CheckBrokerCredentialsFilterName
+}
+
+func (*CheckBrokerCredentialsFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
+	fields := gjson.GetManyBytes(req.Body, "broker_url", fmt.Sprintf(credentialsPath, "username"), fmt.Sprintf(credentialsPath, "password"))
+
+	if fields[0].Exists() && !fields[1].Exists() && !fields[2].Exists() {
+		return nil, &util.HTTPError{
+			ErrorType:   "BadRequest",
+			Description: "Updating an URl of a broker requires its basic credentials",
+			StatusCode:  http.StatusBadRequest,
+		}
+	}
+	return next.Handle(req)
+}
+
+func (*CheckBrokerCredentialsFilter) FilterMatchers() []web.FilterMatcher {
+	return []web.FilterMatcher{
+		{
+			Matchers: []web.Matcher{
+				web.Path(web.ServiceBrokersURL + "/**"),
+				web.Methods(http.MethodPatch),
+			},
+		},
+	}
+}

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -821,25 +821,12 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							}
 						})
 
-						missingCredsTest := func(updatedBrokerJSON common.Object) {
-							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL+"/"+brokerID).
-								WithJSON(updatedBrokerJSON).
-								Expect().
-								Status(http.StatusBadRequest).JSON().Object().Keys().Contains("error", "description")
-
-							assertInvocationCount(brokerServer.CatalogEndpointRequests, 0)
-
-							ctx.SMWithOAuth.GET(web.ServiceBrokersURL+"/"+brokerID).
-								Expect().
-								Status(http.StatusOK).
-								JSON().Object().
-								ContainsMap(expectedBrokerResponse).
-								Keys().NotContains("services", "credentials")
-						}
-
 						Context("credentials object is missing", func() {
 							It("returns 400", func() {
-								missingCredsTest(updatedBrokerJSON)
+								ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL+"/"+brokerID).
+									WithJSON(updatedBrokerJSON).
+									Expect().
+									Status(http.StatusBadRequest).JSON().Object().Keys().Contains("error", "description")
 							})
 						})
 
@@ -853,7 +840,10 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							})
 
 							It("returns 400", func() {
-								missingCredsTest(updatedBrokerJSON)
+								ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL+"/"+brokerID).
+									WithJSON(updatedBrokerJSON).
+									Expect().
+									Status(http.StatusBadRequest).JSON().Object().Keys().Contains("error", "description")
 							})
 						})
 
@@ -867,7 +857,10 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							})
 
 							It("returns 400", func() {
-								missingCredsTest(updatedBrokerJSON)
+								ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL+"/"+brokerID).
+									WithJSON(updatedBrokerJSON).
+									Expect().
+									Status(http.StatusBadRequest).JSON().Object().Keys().Contains("error", "description")
 							})
 						})
 					})

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -18,12 +18,13 @@ package broker_test
 import (
 	"context"
 	"fmt"
-	"github.com/gofrs/uuid"
 	"net/http"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gofrs/uuid"
 
 	"github.com/Peripli/service-manager/test/testutil/service_instance"
 
@@ -759,6 +760,12 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						It("returns 200", func() {
 							updatedBrokerJSON := common.Object{
 								"broker_url": updatedBrokerServer.URL(),
+								"credentials": common.Object{
+									"basic": common.Object{
+										"username": brokerServer.Username,
+										"password": brokerServer.Password,
+									},
+								},
 							}
 							updatedBrokerServer.Username = brokerServer.Username
 							updatedBrokerServer.Password = brokerServer.Password
@@ -768,7 +775,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON().Object().
-								ContainsMap(updatedBrokerJSON).
+								ContainsKey("broker_url").
 								Keys().NotContains("services", "credentials")
 
 							assertInvocationCount(brokerServer.CatalogEndpointRequests, 0)
@@ -778,7 +785,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Expect().
 								Status(http.StatusOK).
 								JSON().Object().
-								ContainsMap(updatedBrokerJSON).
+								ContainsKey("broker_url").
 								Keys().NotContains("services", "credentials")
 						})
 					})
@@ -788,6 +795,33 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							updatedBrokerJSON := common.Object{
 								"broker_url": updatedBrokerServer.URL(),
 							}
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL+"/"+brokerID).
+								WithJSON(updatedBrokerJSON).
+								Expect().
+								Status(http.StatusBadRequest).JSON().Object().Keys().
+								Contains("error", "description")
+
+							assertInvocationCount(brokerServer.CatalogEndpointRequests, 0)
+
+							ctx.SMWithOAuth.GET(web.ServiceBrokersURL+"/"+brokerID).
+								Expect().
+								Status(http.StatusOK).
+								JSON().Object().
+								ContainsMap(expectedBrokerResponse).
+								Keys().NotContains("services", "credentials")
+						})
+					})
+
+					Context("when broker_url is changed but the credentials are missing", func() {
+						var updatedBrokerJSON common.Object
+
+						BeforeEach(func() {
+							updatedBrokerJSON = common.Object{
+								"broker_url": updatedBrokerServer.URL(),
+							}
+						})
+
+						missingCredsTest := func(updatedBrokerJSON common.Object) {
 							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL+"/"+brokerID).
 								WithJSON(updatedBrokerJSON).
 								Expect().
@@ -801,9 +835,42 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								JSON().Object().
 								ContainsMap(expectedBrokerResponse).
 								Keys().NotContains("services", "credentials")
+						}
+
+						Context("credentials object is missing", func() {
+							It("returns 400", func() {
+								missingCredsTest(updatedBrokerJSON)
+							})
+						})
+
+						Context("username is missing", func() {
+							BeforeEach(func() {
+								updatedBrokerJSON["credentials"] = common.Object{
+									"basic": common.Object{
+										"password": "b",
+									},
+								}
+							})
+
+							It("returns 400", func() {
+								missingCredsTest(updatedBrokerJSON)
+							})
+						})
+
+						Context("password is missing", func() {
+							BeforeEach(func() {
+								updatedBrokerJSON["credentials"] = common.Object{
+									"basic": common.Object{
+										"username": "a",
+									},
+								}
+							})
+
+							It("returns 400", func() {
+								missingCredsTest(updatedBrokerJSON)
+							})
 						})
 					})
-
 				})
 
 				Context("when fields are updated one by one", func() {


### PR DESCRIPTION
# Pull Request Template

## Motivation

There may be cases when a user updates an existing service broker and provides only URL without the credentials, thus getting the real credentials of the broker.

## Approach

Introduce checkBrokerCredentials filter.

## Pull Request status

* [x] Initial implementation
* [x] Integration tests
