### PR TITLE
Exclude SM platform from health check platform indicators

### DIFF
--- a/api/filters/visibility_filtering_middleware.go
+++ b/api/filters/visibility_filtering_middleware.go
@@ -39,7 +39,7 @@ func (m visibilityFilteringMiddleware) Run(req *web.Request, next web.Handler) (
 	}
 
 	resourceID := req.PathParams["resource_id"]
-	isSingleResource := (resourceID != "")
+	isSingleResource := resourceID != ""
 
 	if isSingleResource {
 		if isResourceVisible, err := m.IsResourceVisible(ctx, resourceID, platform.ID); err != nil {

--- a/api/healthcheck/platform_indicator.go
+++ b/api/healthcheck/platform_indicator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/Peripli/service-manager/pkg/health"
+	"github.com/Peripli/service-manager/pkg/query"
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/storage"
 )
@@ -51,7 +52,7 @@ func (pi *platformIndicator) Name() string {
 
 // Status returns status of the health check
 func (pi *platformIndicator) Status() (interface{}, error) {
-	objList, err := pi.repository.List(pi.ctx, types.PlatformType)
+	objList, err := pi.repository.List(pi.ctx, types.PlatformType, query.ByField(query.NotEqualsOperator, "id", types.SMPlatform))
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch platforms health from storage: %v", err)
 	}

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -237,10 +237,10 @@ func (smb *ServiceManagerBuilder) registerSMPlatform() error {
 		Name: types.SMPlatform,
 	}); err != nil {
 		if err == util.ErrAlreadyExistsInStorage {
-			log.C(smb.ctx).Infof("platform %s already exists in SMDB...", "service-manager")
+			log.C(smb.ctx).Infof("platform %s already exists in SMDB...", types.SMPlatform)
 			return nil
 		}
-		return fmt.Errorf("could register service-manager platform during bootstrap: %s", err)
+		return fmt.Errorf("could not register %s platform during bootstrap: %s", types.SMPlatform, err)
 	}
 
 	return nil


### PR DESCRIPTION
# Exclude SM platform from health check platform indicators

## Motivation

Wasn't adapted with the initial introduction of the SM platform.

## Pull Request status

* [x] Initial implementation
* [x] Integration tests