### PR TITLE
Allow to create instances if there is public visibility for the plan

### DIFF
--- a/api/filters/check_instance_visibility_filter.go
+++ b/api/filters/check_instance_visibility_filter.go
@@ -17,6 +17,7 @@
 package filters
 
 import (
+	"github.com/Peripli/service-manager/pkg/util/slice"
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/query"
 	"github.com/Peripli/service-manager/pkg/types"
@@ -92,10 +93,8 @@ func (f *serviceInstanceVisibilityFilter) Run(req *web.Request, next web.Handler
 		}
 		tenantLabels, ok := v.Labels[f.tenantIdentifier]
 		if ok {
-			for _, tl := range tenantLabels {
-				if tl == tenantID {
-					return next.Handle(req)
-				}
+			if slice.StringsAnyEquals(tenantLabels, tenantID) {
+				return next.Handle(req)
 			}
 		}
 	}

--- a/api/filters/check_instance_visibility_filter.go
+++ b/api/filters/check_instance_visibility_filter.go
@@ -92,10 +92,8 @@ func (f *serviceInstanceVisibilityFilter) Run(req *web.Request, next web.Handler
 		return next.Handle(req)
 	}
 	tenantLabels, ok := visibility.Labels[f.tenantIdentifier]
-	if ok {
-		if slice.StringsAnyEquals(tenantLabels, tenantID) {
-			return next.Handle(req)
-		}
+	if ok && slice.StringsAnyEquals(tenantLabels, tenantID) {
+		return next.Handle(req)
 	}
 
 	return nil, visibilityError


### PR DESCRIPTION
# Pull Request Template

## Motivation

- When plan has public SM visibility, one should be able to create instances
- When plan does not have any visibility and OAuth without tenant is used, one should not be able to create instances 