### PR TITLE
Forbid setting Instance/Binding ID from client-side

### DIFF
--- a/api/filters/service_binding_strip_filter.go
+++ b/api/filters/service_binding_strip_filter.go
@@ -17,6 +17,8 @@
 package filters
 
 import (
+	"github.com/Peripli/service-manager/pkg/util"
+	"github.com/tidwall/gjson"
 	"net/http"
 
 	"github.com/Peripli/service-manager/pkg/web"
@@ -37,6 +39,14 @@ func (*ServiceBindingStripFilter) Name() string {
 }
 
 func (*ServiceBindingStripFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
+	if gjson.GetBytes(req.Body, "id").Exists() {
+		return nil, &util.HTTPError{
+			ErrorType:   "BadRequest",
+			Description: "Invalid request body - providing specific resource id is forbidden",
+			StatusCode:  http.StatusBadRequest,
+		}
+	}
+
 	var err error
 	req.Body, err = removePropertiesFromRequest(req.Context(), req.Body, serviceBindingUnmodifiableProperties)
 	if err != nil {

--- a/api/filters/service_instance_strip_filter.go
+++ b/api/filters/service_instance_strip_filter.go
@@ -63,6 +63,14 @@ func (*ServiceInstanceStripFilter) FilterMatchers() []web.FilterMatcher {
 func removePropertiesFromRequest(ctx context.Context, body []byte, props []string) ([]byte, error) {
 	var err error
 	for _, prop := range props {
+		if prop == "id" {
+			return nil, &util.HTTPError{
+				ErrorType:   "BadRequest",
+				Description: "Invalid request body - providing specific resource id is forbidden",
+				StatusCode:  http.StatusBadRequest,
+			}
+		}
+
 		body, err = sjson.DeleteBytes(body, prop)
 		if err != nil {
 			log.C(ctx).Errorf("Could not remove %s from body %s", prop, err)

--- a/api/filters/service_instance_strip_filter.go
+++ b/api/filters/service_instance_strip_filter.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/util"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 	"net/http"
 
@@ -41,6 +42,14 @@ func (*ServiceInstanceStripFilter) Name() string {
 }
 
 func (*ServiceInstanceStripFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
+	if gjson.GetBytes(req.Body, "id").Exists() {
+		return nil, &util.HTTPError{
+			ErrorType:   "BadRequest",
+			Description: "Invalid request body - providing specific resource id is forbidden",
+			StatusCode:  http.StatusBadRequest,
+		}
+	}
+
 	var err error
 	req.Body, err = removePropertiesFromRequest(req.Context(), req.Body, serviceInstanceUnmodifiableProperties)
 	if err != nil {
@@ -63,14 +72,6 @@ func (*ServiceInstanceStripFilter) FilterMatchers() []web.FilterMatcher {
 func removePropertiesFromRequest(ctx context.Context, body []byte, props []string) ([]byte, error) {
 	var err error
 	for _, prop := range props {
-		if prop == "id" {
-			return nil, &util.HTTPError{
-				ErrorType:   "BadRequest",
-				Description: "Invalid request body - providing specific resource id is forbidden",
-				StatusCode:  http.StatusBadRequest,
-			}
-		}
-
 		body, err = sjson.DeleteBytes(body, prop)
 		if err != nil {
 			log.C(ctx).Errorf("Could not remove %s from body %s", prop, err)

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -18,7 +18,6 @@ package broker_test
 import (
 	"context"
 	"fmt"
-	"github.com/gofrs/uuid"
 	"net/http"
 	"strconv"
 	"strings"
@@ -1739,12 +1738,6 @@ func blueprint(setNullFieldsValues bool) func(ctx *common.TestContext, auth *com
 	return func(ctx *common.TestContext, auth *common.SMExpect, async bool) common.Object {
 		brokerJSON := common.GenerateRandomBroker()
 
-		brokerID, err := uuid.NewV4()
-		if err != nil {
-			panic(err)
-		}
-		brokerJSON["id"] = brokerID.String()
-
 		if !setNullFieldsValues {
 			delete(brokerJSON, "description")
 		}
@@ -1752,7 +1745,7 @@ func blueprint(setNullFieldsValues bool) func(ctx *common.TestContext, auth *com
 		var obj map[string]interface{}
 		resp := auth.POST(web.ServiceBrokersURL).WithQuery("async", strconv.FormatBool(async)).WithJSON(brokerJSON).Expect()
 		if async {
-			obj = test.ExpectSuccessfulAsyncResourceCreation(resp, auth, brokerID.String(), web.ServiceBrokersURL)
+			obj = test.ExpectSuccessfulAsyncResourceCreation(resp, auth, web.ServiceBrokersURL)
 		} else {
 			obj = resp.Status(http.StatusCreated).JSON().Object().Raw()
 			delete(obj, "credentials")

--- a/test/delete.go
+++ b/test/delete.go
@@ -78,7 +78,7 @@ func DescribeDeleteTestsfor(ctx *common.TestContext, t TestCase, responseMode Re
 					Status(deletionRequestResponseCode)
 
 				if responseMode == Async {
-					err := ExpectOperationWithError(auth, resp, expectedOpState, expectedErrMsg)
+					_, err := ExpectOperationWithError(auth, resp, expectedOpState, expectedErrMsg)
 					Expect(err).To(BeNil())
 				}
 
@@ -157,7 +157,7 @@ func DescribeDeleteTestsfor(ctx *common.TestContext, t TestCase, responseMode Re
 			verifyMissingResourceFailedDeletion := func(resp *httpexpect.Response, expectedErrMsg string) {
 				switch responseMode {
 				case Async:
-					err := ExpectOperationWithError(ctx.SMWithOAuth, resp, types.FAILED, expectedErrMsg)
+					_, err := ExpectOperationWithError(ctx.SMWithOAuth, resp, types.FAILED, expectedErrMsg)
 					Expect(err).To(BeNil())
 				case Sync:
 					resp.Status(http.StatusNotFound).JSON().Object().Keys().Contains("error", "description")

--- a/test/operations_test/operations_test.go
+++ b/test/operations_test/operations_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Operations", func() {
 					WithQuery("async", "true").
 					Expect().
 					Status(http.StatusAccepted)
-				err := test.ExpectOperationWithError(ctx.SMWithOAuth, resp, types.FAILED, "job timed out")
+				_, err := test.ExpectOperationWithError(ctx.SMWithOAuth, resp, types.FAILED, "job timed out")
 				Expect(err).To(BeNil())
 			})
 		})

--- a/test/patch.go
+++ b/test/patch.go
@@ -35,7 +35,7 @@ func DescribePatchTestsFor(ctx *common.TestContext, t TestCase, responseMode Res
 			case Async:
 				resp.Status(http.StatusAccepted)
 
-				err := ExpectOperation(ctx.SMWithOAuth, resp, types.SUCCEEDED)
+				_, err := ExpectOperation(ctx.SMWithOAuth, resp, types.SUCCEEDED)
 				Expect(err).To(BeNil())
 			case Sync:
 				resp.Status(http.StatusOK)

--- a/test/service_binding_test/service_binding_test.go
+++ b/test/service_binding_test/service_binding_test.go
@@ -189,14 +189,13 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				})
 
 				Context("when request body id field is provided", func() {
-					It("should still generate a different GUID", func() {
-						bindingID := "test-binding-id"
-						postBindingRequest["id"] = bindingID
+					It("should return 400", func() {
+						postBindingRequest["id"] = "test-binding-id"
 						resp := smExpect.POST(web.ServiceBindingsURL).
 							WithJSON(postBindingRequest).
-							Expect().Status(http.StatusCreated).JSON().Object()
+							Expect().Status(http.StatusBadRequest).JSON().Object()
 
-						resp.Value("id").NotEqual(bindingID)
+						Expect(resp.Value("description").String().Raw()).To(ContainSubstring("providing specific resource id is forbidden"))
 					})
 				})
 

--- a/test/service_binding_test/service_binding_test.go
+++ b/test/service_binding_test/service_binding_test.go
@@ -21,8 +21,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gofrs/uuid"
-
 	"testing"
 
 	"github.com/Peripli/service-manager/pkg/types"
@@ -79,26 +77,20 @@ var _ = test.DescribeTestsFor(test.TestCase{
 			)
 
 			createInstance := func(SM *common.SMExpect) string {
-				instanceID, err := uuid.NewV4()
-				if err != nil {
-					panic(err)
-				}
-
 				planID := newServicePlan(ctx)
 				test.EnsurePlanVisibility(ctx.SMRepository, TenantIdentifier, types.SMPlatform, planID, TenantIDValue)
 
 				instanceBody := common.Object{
-					"id":               instanceID.String(),
 					"name":             "test-instance",
 					"service_plan_id":  planID,
 					"maintenance_info": "{}",
 				}
 
-				SM.POST(web.ServiceInstancesURL).WithJSON(instanceBody).
+				resp := SM.POST(web.ServiceInstancesURL).WithJSON(instanceBody).
 					Expect().
 					Status(http.StatusCreated)
 
-				return instanceID.String()
+				return resp.JSON().Object().Value("id").String().Raw()
 			}
 
 			createBinding := func(SM *common.SMExpect, body common.Object) {
@@ -114,23 +106,15 @@ var _ = test.DescribeTestsFor(test.TestCase{
 			})
 
 			JustBeforeEach(func() {
-				var err error
 				instanceID := createInstance(smExpect)
-
-				bindingID, err := uuid.NewV4()
-				if err != nil {
-					panic(err)
-				}
 
 				bindingName := "test-binding"
 
 				postBindingRequest = common.Object{
-					"id":                  bindingID.String(),
 					"name":                bindingName,
 					"service_instance_id": instanceID,
 				}
 				expectedBindingResponse = common.Object{
-					"id":                  bindingID.String(),
 					"name":                bindingName,
 					"service_instance_id": instanceID,
 				}
@@ -204,14 +188,15 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 				})
 
-				Context("when request body id field is invalid", func() {
-					It("should return 400", func() {
-						postBindingRequest["id"] = "binding/1"
+				Context("when request body id field is provided", func() {
+					It("should still generate a different GUID", func() {
+						bindingID := "test-binding-id"
+						postBindingRequest["id"] = bindingID
 						resp := smExpect.POST(web.ServiceBindingsURL).
 							WithJSON(postBindingRequest).
-							Expect().Status(http.StatusBadRequest).JSON().Object()
+							Expect().Status(http.StatusCreated).JSON().Object()
 
-						resp.Value("description").Equal("binding/1 contains invalid character(s)")
+						resp.Value("id").NotEqual(bindingID)
 					})
 				})
 
@@ -222,9 +207,10 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							Expect().
 							Status(http.StatusAccepted)
 
-						test.ExpectOperation(smExpect, resp, types.SUCCEEDED)
+						op, err := test.ExpectOperation(smExpect, resp, types.SUCCEEDED)
+						Expect(err).To(BeNil())
 
-						smExpect.GET(fmt.Sprintf("%s/%s", web.ServiceBindingsURL, postBindingRequest["id"])).Expect().
+						smExpect.GET(fmt.Sprintf("%s/%s", web.ServiceBindingsURL, op.Value("resource_id").String().Raw())).Expect().
 							Status(http.StatusOK).
 							JSON().Object().
 							ContainsMap(expectedBindingResponse).ContainsKey("id")
@@ -273,11 +259,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						})
 
 						It("returns 200", func() {
-							smExpect.POST(web.ServiceBindingsURL).WithJSON(postBindingRequest).
+							obj := smExpect.POST(web.ServiceBindingsURL).WithJSON(postBindingRequest).
 								Expect().
-								Status(http.StatusCreated)
+								Status(http.StatusCreated).JSON().Object()
 
-							smExpect.DELETE(fmt.Sprintf("%s/%s", web.ServiceBindingsURL, postBindingRequest["id"])).
+							smExpect.DELETE(fmt.Sprintf("%s/%s", web.ServiceBindingsURL, obj.Value("id").String().Raw())).
 								Expect().Status(http.StatusOK)
 						})
 					})
@@ -289,42 +275,33 @@ var _ = test.DescribeTestsFor(test.TestCase{
 })
 
 func blueprint(ctx *common.TestContext, auth *common.SMExpect, async bool) common.Object {
-	ID, err := uuid.NewV4()
-	if err != nil {
-		Fail(fmt.Sprintf("failed to generate instance GUID: %s", err))
-	}
-	instanceID := "instance-" + ID.String()
-
 	servicePlanID := newServicePlan(ctx)
 	test.EnsurePlanVisibility(ctx.SMRepository, TenantIdentifier, types.SMPlatform, servicePlanID, "")
 	resp := ctx.SMWithOAuth.POST(web.ServiceInstancesURL).
 		WithQuery("async", strconv.FormatBool(async)).
 		WithJSON(common.Object{
-			"id":               instanceID,
-			"name":             instanceID + "name",
+			"name":             "test-service-instance",
 			"service_plan_id":  servicePlanID,
 			"maintenance_info": "{}",
 		}).Expect()
 
+	var instance map[string]interface{}
 	if async {
-		test.ExpectSuccessfulAsyncResourceCreation(resp, auth, instanceID, web.ServiceInstancesURL)
+		instance = test.ExpectSuccessfulAsyncResourceCreation(resp, auth, web.ServiceInstancesURL)
 	} else {
-		resp.Status(http.StatusCreated)
+		instance = resp.Status(http.StatusCreated).JSON().Object().Raw()
 	}
-
-	bindingID := "binding-" + ID.String()
 
 	resp = ctx.SMWithOAuth.POST(web.ServiceBindingsURL).
 		WithQuery("async", strconv.FormatBool(async)).
 		WithJSON(common.Object{
-			"id":                  bindingID,
-			"name":                bindingID + "name",
-			"service_instance_id": instanceID,
+			"name":                "test-service-binding",
+			"service_instance_id": instance["id"],
 		}).Expect()
 
 	var binding map[string]interface{}
 	if async {
-		binding = test.ExpectSuccessfulAsyncResourceCreation(resp, auth, bindingID, web.ServiceBindingsURL)
+		binding = test.ExpectSuccessfulAsyncResourceCreation(resp, auth, web.ServiceBindingsURL)
 	} else {
 		binding = resp.Status(http.StatusCreated).JSON().Object().Raw()
 	}

--- a/test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_test/service_instance_test.go
@@ -249,12 +249,12 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				When("request body id field is provided", func() {
 					It("should return 400", func() {
 						test.EnsurePlanVisibility(ctx.SMRepository, TenantIdentifier, types.SMPlatform, postInstanceRequest["service_plan_id"].(string), "")
-						postInstanceRequest["id"] = "instance/1"
+						postInstanceRequest["id"] = "test-instance-id"
 						resp := ctx.SMWithOAuth.POST(web.ServiceInstancesURL).
 							WithJSON(postInstanceRequest).
 							Expect().Status(http.StatusBadRequest).JSON().Object()
 
-						resp.Value("description").Equal("instance/1 contains invalid character(s)")
+						Expect(resp.Value("description").String().Raw()).To(ContainSubstring("providing specific resource id is forbidden"))
 					})
 				})
 

--- a/test/test.go
+++ b/test/test.go
@@ -106,7 +106,7 @@ func APIResourcePatch(ctx *common.TestContext, apiPath string, objID string, _ t
 
 	if async {
 		resp = resp.Status(http.StatusAccepted)
-		err := ExpectOperation(ctx.SMWithOAuth, resp, types.SUCCEEDED)
+		_, err := ExpectOperation(ctx.SMWithOAuth, resp, types.SUCCEEDED)
 		if err != nil {
 			panic(err)
 		}
@@ -128,23 +128,25 @@ func StorageResourcePatch(ctx *common.TestContext, _ string, objID string, resou
 	}
 }
 
-func ExpectSuccessfulAsyncResourceCreation(resp *httpexpect.Response, SM *common.SMExpect, resourceID, resourceURL string) map[string]interface{} {
+func ExpectSuccessfulAsyncResourceCreation(resp *httpexpect.Response, SM *common.SMExpect, resourceURL string) map[string]interface{} {
 	resp = resp.Status(http.StatusAccepted)
-	if err := ExpectOperation(SM, resp, types.SUCCEEDED); err != nil {
+
+	op, err := ExpectOperation(SM, resp, types.SUCCEEDED)
+	if err != nil {
 		panic(err)
 	}
 
-	obj := SM.GET(resourceURL + "/" + resourceID).
+	obj := SM.GET(resourceURL + "/" + op.Value("resource_id").String().Raw()).
 		Expect().Status(http.StatusOK).JSON().Object().Raw()
 
 	return obj
 }
 
-func ExpectOperation(auth *common.SMExpect, asyncResp *httpexpect.Response, expectedState types.OperationState) error {
+func ExpectOperation(auth *common.SMExpect, asyncResp *httpexpect.Response, expectedState types.OperationState) (*httpexpect.Object, error) {
 	return ExpectOperationWithError(auth, asyncResp, expectedState, "")
 }
 
-func ExpectOperationWithError(auth *common.SMExpect, asyncResp *httpexpect.Response, expectedState types.OperationState, expectedErrMsg string) error {
+func ExpectOperationWithError(auth *common.SMExpect, asyncResp *httpexpect.Response, expectedState types.OperationState, expectedErrMsg string) (*httpexpect.Object, error) {
 	operationURL := asyncResp.Header("Location").Raw()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -171,11 +173,11 @@ func ExpectOperationWithError(auth *common.SMExpect, asyncResp *httpexpect.Respo
 						err = fmt.Errorf("unable to verify operation - expected error message (%s), but got (%s)", expectedErrMsg, errs.String().Raw())
 					}
 				}
-				return nil
+				return operation, nil
 			}
 		}
 	}
-	return err
+	return nil, err
 }
 
 func EnsurePublicPlanVisibility(repository storage.Repository, planID string) {


### PR DESCRIPTION
# Forbid setting Instance/Binding ID from client-side

## Motivation

Clients should not specify IDs as this could risk data integrity and also could cause problems when storing instances/bindings from other platforms.

## Pull Request status

* [x] Initial implementation
* [x] Integration tests