### PR TITLE
Return better message when plan is not visible

### DIFF
--- a/api/osb/check_visibility_plugin.go
+++ b/api/osb/check_visibility_plugin.go
@@ -16,9 +16,9 @@ import (
 const CheckVisibilityPluginName = "CheckVisibilityPlugin"
 
 var errPlanNotAccessible = &util.HTTPError{
-	ErrorType:   "ServicePlanNotAccessible",
-	Description: "service plan is not accessible",
-	StatusCode:  http.StatusForbidden,
+	ErrorType:   "ServicePlanNotFound",
+	Description: "service plan not found or not accessible",
+	StatusCode:  http.StatusNotFound,
 }
 
 type checkVisibilityPlugin struct {

--- a/api/osb/check_visibility_plugin.go
+++ b/api/osb/check_visibility_plugin.go
@@ -15,6 +15,12 @@ import (
 
 const CheckVisibilityPluginName = "CheckVisibilityPlugin"
 
+const errPlanNotAccessible = &util.HTTPError{
+	ErrorType:   "ServicePlanNotAccessible",
+	Description: "service plan is not accessible",
+	StatusCode:  http.StatusForbidden,
+}
+
 type checkVisibilityPlugin struct {
 	repository storage.Repository
 }
@@ -114,11 +120,7 @@ func (p *checkVisibilityPlugin) checkVisibility(req *web.Request, next web.Handl
 			}
 		}
 		log.C(ctx).Errorf("Service plan %v is not visible on platform %v", planID, platform.ID)
-		return nil, &util.HTTPError{
-			ErrorType:   "NotFound",
-			Description: "could not find such service plan",
-			StatusCode:  http.StatusNotFound,
-		}
+		return nil, errPlanNotAccessible
 	default:
 		for _, v := range visibilities.Visibilities {
 			if v.PlatformID == "" { // public visibility
@@ -129,10 +131,6 @@ func (p *checkVisibilityPlugin) checkVisibility(req *web.Request, next web.Handl
 			}
 		}
 		log.C(ctx).Errorf("Service plan %v is not visible on platform %v", planID, platform.ID)
-		return nil, &util.HTTPError{
-			ErrorType:   "NotFound",
-			Description: "could not find such service plan",
-			StatusCode:  http.StatusNotFound,
-		}
+		return nil, errPlanNotAccessible
 	}
 }

--- a/api/osb/check_visibility_plugin.go
+++ b/api/osb/check_visibility_plugin.go
@@ -15,7 +15,7 @@ import (
 
 const CheckVisibilityPluginName = "CheckVisibilityPlugin"
 
-const errPlanNotAccessible = &util.HTTPError{
+var errPlanNotAccessible = &util.HTTPError{
 	ErrorType:   "ServicePlanNotAccessible",
 	Description: "service plan is not accessible",
 	StatusCode:  http.StatusForbidden,


### PR DESCRIPTION
## Motivation

If a client tries to access a plan that is not visible in the current context, he gets the error
`could not find such service plan`
which is confusing

## Approach

Now we return error
`service plan not found or not accessible`
which describes better the reason

## Pull Request status

* [x] Initial implementation
