### PR TITLE
Add endpoint to fetch pprof profiles

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Peripli/service-manager/pkg/env"
 
 	"github.com/Peripli/service-manager/api/configuration"
+	"github.com/Peripli/service-manager/api/profile"
 
 	"github.com/Peripli/service-manager/pkg/query"
 
@@ -122,6 +123,7 @@ func New(ctx context.Context, e env.Environment, options *Options) (*web.API, er
 			&configuration.Controller{
 				Environment: e,
 			},
+			&profile.Controller{},
 		},
 		// Default filters - more filters can be registered using the relevant API methods
 		Filters: []web.Filter{

--- a/api/extensions/security/authn.go
+++ b/api/extensions/security/authn.go
@@ -51,7 +51,9 @@ func Register(ctx context.Context, cfg *config.Settings, smb *sm.ServiceManagerB
 		web.VisibilitiesURL+"/**",
 		web.NotificationsURL+"/**",
 		web.ServiceInstancesURL+"/**",
-		web.ConfigURL+"/**").
+		web.ConfigURL+"/**",
+		web.ProfileURL+"/**",
+	).
 		Method(http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete).
 		WithAuthentication(bearerAuthenticator).Required()
 

--- a/api/filters/oidc_authentication.go
+++ b/api/filters/oidc_authentication.go
@@ -55,6 +55,7 @@ func oidcAuthnMatchers() []web.FilterMatcher {
 					web.VisibilitiesURL+"/**",
 					web.ServiceInstancesURL+"/**",
 					web.ConfigURL+"/**",
+					web.ProfileURL+"/**",
 				),
 			},
 		},

--- a/api/profile/controller.go
+++ b/api/profile/controller.go
@@ -1,0 +1,33 @@
+package profile
+
+import (
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/Peripli/service-manager/pkg/web"
+)
+
+const profileNameParam = "profile_name"
+
+// Controller profile controller
+type Controller struct{}
+
+// Routes provides the REST endpoints
+func (c *Controller) Routes() []web.Route {
+	return []web.Route{
+		{
+			Endpoint: web.Endpoint{
+				Method: http.MethodGet,
+				Path:   web.ProfileURL + "/{" + profileNameParam + "}",
+			},
+			Handler: c.profile,
+		},
+	}
+}
+
+func (c *Controller) profile(req *web.Request) (*web.Response, error) {
+	profileName := req.PathParams[profileNameParam]
+	resp := req.HijackResponseWriter()
+	pprof.Handler(profileName).ServeHTTP(resp, req.Request)
+	return &web.Response{}, nil
+}

--- a/pkg/web/routes.go
+++ b/pkg/web/routes.go
@@ -41,4 +41,7 @@ const (
 
 	// OperationsURL is the URL path fetch operations
 	OperationsURL = "/operations"
+
+	// ProfileURL is the Configuration API base URL path
+	ProfileURL = "/" + apiVersion + "/profile"
 )

--- a/test/auth_test/auth_test.go
+++ b/test/auth_test/auth_test.go
@@ -263,6 +263,12 @@ var _ = Describe("Service Manager Authentication", func() {
 			{"Invalid authorization schema", "GET", web.ServiceInstancesURL, invalidBasicAuthHeader},
 			{"Missing token in authorization header", "GET", web.ServiceInstancesURL, emptyBearerAuthHeader},
 			{"Invalid token in authorization header", "GET", web.ServiceInstancesURL, invalidBearerAuthHeader},
+
+			// PROFILE
+			{"Missing authorization header", "GET", web.ProfileURL + "/heap", emptyAuthHeader},
+			{"Invalid authorization schema", "GET", web.ProfileURL + "/heap", invalidBasicAuthHeader},
+			{"Missing token in authorization header", "GET", web.ProfileURL + "/heap", emptyBearerAuthHeader},
+			{"Invalid token in authorization header", "GET", web.ProfileURL + "/heap", invalidBearerAuthHeader},
 		}
 
 		for _, request := range authRequests {

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -411,7 +411,7 @@ func Print(message string, args ...interface{}) {
 	if len(args) == 0 {
 		_, err = fmt.Fprint(ginkgo.GinkgoWriter, "\n"+message+"\n")
 	} else {
-		_, err = fmt.Fprintf(ginkgo.GinkgoWriter, "\n"+message+"\n", args)
+		_, err = fmt.Fprintf(ginkgo.GinkgoWriter, "\n"+message+"\n", args...)
 	}
 	if err != nil {
 		panic(err)

--- a/test/profile_test/profile_test.go
+++ b/test/profile_test/profile_test.go
@@ -77,8 +77,7 @@ var _ = Describe("Profile API", func() {
 			It("accepts "+name+" profile", func() {
 				profileURL := smURL + web.ProfileURL + "/" + name
 				cmd := exec.Command("go", "tool", "pprof", "-top", profileURL)
-				cmd.Env = append(os.Environ(),
-					"PPROF_TMPDIR="+tempDir)
+				cmd.Env = append(os.Environ(), "PPROF_TMPDIR="+tempDir)
 				cmd.Stdout = ginkgo.GinkgoWriter
 				cmd.Stderr = ginkgo.GinkgoWriter
 				common.Print("%s %s", cmd.Path, strings.Join(cmd.Args[1:], " "))

--- a/test/profile_test/profile_test.go
+++ b/test/profile_test/profile_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package profile_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Peripli/service-manager/pkg/web"
+
+	. "github.com/onsi/ginkgo"
+
+	"github.com/Peripli/service-manager/test/common"
+)
+
+func TestProfile(t *testing.T) {
+	RunSpecs(t, "Profile Suite")
+}
+
+var _ = Describe("Profile API", func() {
+
+	var ctx *common.TestContext
+
+	BeforeSuite(func() {
+		ctx = common.DefaultTestContext()
+	})
+
+	AfterSuite(func() {
+		ctx.Cleanup()
+	})
+
+	Describe("Get heap profile", func() {
+		It("Returns correct response", func() {
+			ctx.SM.GET(web.ProfileURL + "/heap").
+				Expect().
+				Status(http.StatusOK)
+		})
+	})
+
+	Describe("Get unknown profile", func() {
+		It("Returns 404 response", func() {
+			ctx.SM.GET(web.ProfileURL + "/unknown").
+				Expect().
+				Status(http.StatusNotFound)
+		})
+	})
+})


### PR DESCRIPTION
## Motivation

Sometimes SM consumes lots of memory but it is not possible tell what exactly occupies most of the heap.

## Approach

Expose pprof profiles on /v1/profile endpoint
* /v1/profile/goroutine
* /v1/profile/threadcreate
* /v1/profile/heap
* /v1/profile/allocs
* /v1/profile/block
* /v1/profile/mutex

See https://golang.org/pkg/net/http/pprof/
Once fetched these profiles can be analysed with `go tool pprof`.

The profiles above should not have significant impact on performance and should be safe to use in production, see
* https://github.com/golang/go/wiki/Performance
* https://groups.google.com/forum/#!topic/golang-nuts/e6lB8ENbIw8

## Pull Request status

* [x] Initial implementation
* [x] Component tests
