### PR TITLE
Authz has scope

### DIFF
--- a/pkg/security/http/authz/oauth_scopes.go
+++ b/pkg/security/http/authz/oauth_scopes.go
@@ -65,11 +65,5 @@ func HasScope(user *web.UserContext, scope string) (bool, error) {
 	}
 	userScopes := claims.Scopes
 
-	for _, userScope := range userScopes {
-		if scope == userScope {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return slice.StringsAnyEquals(userScopes, scope), nil
 }

--- a/pkg/security/http/authz/oauth_scopes.go
+++ b/pkg/security/http/authz/oauth_scopes.go
@@ -53,3 +53,23 @@ func findMostRestrictiveAccessLevel(levels []web.AccessLevel) web.AccessLevel {
 	}
 	return min
 }
+
+// Checks whether the user has the requested scope
+func HasScope(user *web.UserContext, scope string) (bool, error) {
+	var claims struct {
+		Scopes []string `json:"scope"`
+	}
+
+	if err := user.Data(&claims); err != nil {
+		return false, fmt.Errorf("could not extract scopes from token: %v", err)
+	}
+	userScopes := claims.Scopes
+
+	for _, userScope := range userScopes {
+		if scope == userScope {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/security/http/authz/oauth_scopes_test.go
+++ b/pkg/security/http/authz/oauth_scopes_test.go
@@ -1,51 +1,125 @@
 package authz
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/Peripli/service-manager/pkg/web"
 
 	httpsec "github.com/Peripli/service-manager/pkg/security/http"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("ScopeAuthorizer", func() {
-	DescribeTable("Required", func(t testCase) {
-		runTestCase(t, NewScopesAuthorizer(t.params.([]string), web.GlobalAccess))
-	}, []TableEntry{
-		Entry("Fails if no user is authenticated", testCase{
-			params:           []string{""},
-			noUser:           true,
-			expectedDecision: httpsec.Abstain,
-			expectedAccess:   web.NoAccess,
-		}),
-		Entry("Fails if token claims cannot be extracted", testCase{
-			params:           []string{""},
-			claimsError:      errors.New("claims error"),
-			expectError:      "could not extract scopes",
-			expectedDecision: httpsec.Deny,
-			expectedAccess:   web.NoAccess,
-		}),
-		Entry("Fails if there are no scopes in the token", testCase{
-			params:           []string{"scope2"},
-			claims:           `{}`,
-			expectError:      `none of the scopes [scope2] are present`,
-			expectedDecision: httpsec.Deny,
-			expectedAccess:   web.NoAccess,
-		}),
-		Entry("Fails if scope does not match", testCase{
-			params:           []string{"scope2"},
-			claims:           `{"scope":["scope1","scope3"]}`,
-			expectError:      `none of the scopes [scope2] are present in the user token scopes [scope1 scope3]`,
-			expectedDecision: httpsec.Deny,
-			expectedAccess:   web.NoAccess,
-		}),
-		Entry("Succeeds if scope matches", testCase{
-			params:           []string{"scope2"},
-			claims:           `{"scope":["scope1","scope2","scope3"]}`,
-			expectedDecision: httpsec.Allow,
-			expectedAccess:   web.GlobalAccess,
-		}),
-	}...)
+var _ = Describe("Oauth Scopes", func() {
+	Describe("ScopeAuthorizer", func() {
+		DescribeTable("Required", func(t testCase) {
+			runTestCase(t, NewScopesAuthorizer(t.params.([]string), web.GlobalAccess))
+		}, []TableEntry{
+			Entry("Fails if no user is authenticated", testCase{
+				params:           []string{""},
+				noUser:           true,
+				expectedDecision: httpsec.Abstain,
+				expectedAccess:   web.NoAccess,
+			}),
+			Entry("Fails if token claims cannot be extracted", testCase{
+				params:           []string{""},
+				claimsError:      errors.New("claims error"),
+				expectError:      "could not extract scopes",
+				expectedDecision: httpsec.Deny,
+				expectedAccess:   web.NoAccess,
+			}),
+			Entry("Fails if there are no scopes in the token", testCase{
+				params:           []string{"scope2"},
+				claims:           `{}`,
+				expectError:      `none of the scopes [scope2] are present`,
+				expectedDecision: httpsec.Deny,
+				expectedAccess:   web.NoAccess,
+			}),
+			Entry("Fails if scope does not match", testCase{
+				params:           []string{"scope2"},
+				claims:           `{"scope":["scope1","scope3"]}`,
+				expectError:      `none of the scopes [scope2] are present in the user token scopes [scope1 scope3]`,
+				expectedDecision: httpsec.Deny,
+				expectedAccess:   web.NoAccess,
+			}),
+			Entry("Succeeds if scope matches", testCase{
+				params:           []string{"scope2"},
+				claims:           `{"scope":["scope1","scope2","scope3"]}`,
+				expectedDecision: httpsec.Allow,
+				expectedAccess:   web.GlobalAccess,
+			}),
+		}...)
+	})
+
+	Describe("HasScope", func() {
+		var (
+			tokenDataNoScopes              = `{"scope": []}`
+			tokenDataWithRequestedScope    = `{"scope": ["the-scope", "another-scope"]}`
+			tokenDataWithoutRequestedScope = `{"scope": ["another-scope"]}`
+		)
+
+		getUserContextWithToken := func(token string, err error) (*web.UserContext, error) {
+			ctx := web.ContextWithUser(context.Background(), &web.UserContext{
+				AuthenticationType: web.Bearer,
+				Data: func(data interface{}) error {
+					if err != nil {
+						return err
+					}
+					return json.Unmarshal([]byte(token), data)
+				},
+			})
+			user, ok := web.UserFromContext(ctx)
+			if !ok {
+				return nil, fmt.Errorf("Failed to retrieve user from context")
+			}
+
+			return user, nil
+		}
+
+		When("no scopes are available", func() {
+			user, err := getUserContextWithToken(tokenDataNoScopes, nil)
+
+			It("is not found", func() {
+				Expect(err).ToNot(HaveOccurred())
+				found, err := HasScope(user, "the-scope")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeFalse())
+			})
+		})
+
+		When("requested scope is not available", func() {
+			user, err := getUserContextWithToken(tokenDataWithoutRequestedScope, nil)
+
+			It("is not found", func() {
+				Expect(err).ToNot(HaveOccurred())
+				found, err := HasScope(user, "the-scope")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeFalse())
+			})
+		})
+
+		When("requested scope is available", func() {
+			user, err := getUserContextWithToken(tokenDataWithRequestedScope, nil)
+			It("is found", func() {
+				Expect(err).ToNot(HaveOccurred())
+				found, err := HasScope(user, "the-scope")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(found).To(BeTrue())
+			})
+		})
+
+		When("scope cannot be extracted from token", func() {
+			user, err := getUserContextWithToken(tokenDataWithRequestedScope, errors.New("failed to get user data"))
+			It("is fails with an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+				_, err := HasScope(user, "the-scope")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+	})
 })

--- a/pkg/security/http/authz/oauth_scopes_test.go
+++ b/pkg/security/http/authz/oauth_scopes_test.go
@@ -81,10 +81,9 @@ var _ = Describe("Oauth Scopes", func() {
 		}
 
 		When("no scopes are available", func() {
-			user, err := getUserContextWithToken(tokenDataNoScopes, nil)
+			user, _ := getUserContextWithToken(tokenDataNoScopes, nil)
 
 			It("is not found", func() {
-				Expect(err).ToNot(HaveOccurred())
 				found, err := HasScope(user, "the-scope")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeFalse())
@@ -92,10 +91,9 @@ var _ = Describe("Oauth Scopes", func() {
 		})
 
 		When("requested scope is not available", func() {
-			user, err := getUserContextWithToken(tokenDataWithoutRequestedScope, nil)
+			user, _ := getUserContextWithToken(tokenDataWithoutRequestedScope, nil)
 
 			It("is not found", func() {
-				Expect(err).ToNot(HaveOccurred())
 				found, err := HasScope(user, "the-scope")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeFalse())
@@ -103,9 +101,9 @@ var _ = Describe("Oauth Scopes", func() {
 		})
 
 		When("requested scope is available", func() {
-			user, err := getUserContextWithToken(tokenDataWithRequestedScope, nil)
+			user, _ := getUserContextWithToken(tokenDataWithRequestedScope, nil)
+
 			It("is found", func() {
-				Expect(err).ToNot(HaveOccurred())
 				found, err := HasScope(user, "the-scope")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
@@ -113,9 +111,9 @@ var _ = Describe("Oauth Scopes", func() {
 		})
 
 		When("scope cannot be extracted from token", func() {
-			user, err := getUserContextWithToken(tokenDataWithRequestedScope, errors.New("failed to get user data"))
+			user, _ := getUserContextWithToken(tokenDataWithRequestedScope, errors.New("failed to get user data"))
+
 			It("is fails with an error", func() {
-				Expect(err).ToNot(HaveOccurred())
 				_, err := HasScope(user, "the-scope")
 				Expect(err).To(HaveOccurred())
 			})


### PR DESCRIPTION
## Motivation

In some cases filters/interceptors need to know if a request has a specific scope, regardless of the request access level. At the moment there is no API for checking that. 

## Approach

the new utility function in the authz package provides simple API for checking if a request user has a specific scope, abstracting the actual scope retrieval from the token. 

## Pull Request status

* [x] Initial implementation
* [ ] Refactoring
* [x] Unit tests
* [ ] Integration tests