### PR TITLE
Fix label queries

### DIFF
--- a/storage/postgres/query_builder_test.go
+++ b/storage/postgres/query_builder_test.go
@@ -279,11 +279,11 @@ WITH matching_resources as (SELECT DISTINCT visibilities.paging_sequence
                             WHERE ((visibilities.id::text != ? AND
                                     visibilities.service_plan_id::text NOT IN (?, ?, ?) AND
                                     (visibilities.platform_id::text = ? OR platform_id IS NULL)) AND
-									(visibility_id IN (SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text = ?))
+									(visibility_id IN ((SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text = ?))
 										INTERSECT
 										(SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text IN (?, ?)))
 										INTERSECT
-										(SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text != ?))))
+										(SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text != ?)))))
                             ORDER BY visibilities.paging_sequence ASC
                             LIMIT ?)
 SELECT visibilities.*,
@@ -335,7 +335,7 @@ FROM visibilities ;`)))
 		})
 
 		Context("when label criteria is used", func() {
-			FIt("should build query with label criteria", func() {
+			It("should build query with label criteria", func() {
 				_, err := qb.NewQuery(entity).
 					WithCriteria(query.ByLabel(query.EqualsOperator, "labelKey", "labelValue")).
 					Count(ctx)
@@ -444,8 +444,11 @@ FROM visibilities
 WHERE ((visibilities.id::text != ? AND
 	visibilities.service_plan_id::text NOT IN (?, ?, ?) AND
 		(visibilities.platform_id::text = ? OR platform_id IS NULL)) AND
-		((key::text = ? AND val::text = ?) OR (key::text = ? AND val::text IN (?, ?)) OR
-		(key::text = ? AND val::text != ?)))
+		(visibility_id IN ((SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text = ?))
+										INTERSECT
+										(SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text IN (?, ?)))
+										INTERSECT
+										(SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text != ?)))))
 LIMIT ?;`)))
 				Expect(queryArgs).To(HaveLen(13))
 				Expect(queryArgs[0]).Should(Equal("1"))
@@ -494,7 +497,9 @@ DELETE
 FROM visibilities USING (SELECT visibilities.id
                          FROM visibilities
                                   JOIN visibility_labels ON visibilities.id = visibility_labels.visibility_id
-                         WHERE ((key::text = ? AND val::text = ?) OR (key::text = ? AND val::text IN (?, ?)))) t
+						 WHERE (visibility_id IN ((SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text = ?))
+										INTERSECT
+										(SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text IN (?, ?)))))) t
 WHERE visibilities.id = t.id ;`)))
 				Expect(queryArgs).To(HaveLen(5))
 				Expect(queryArgs[0]).Should(Equal("left1"))
@@ -586,8 +591,11 @@ FROM visibilities USING (SELECT visibilities.id
                                   JOIN visibility_labels ON visibilities.id = visibility_labels.visibility_id
                          WHERE ((visibilities.id::text != ? AND visibilities.service_plan_id::text NOT IN (?, ?, ?) AND
                                  (visibilities.platform_id::text = ? OR platform_id IS NULL)) AND
-                                ((key::text = ? AND val::text = ?) OR (key::text = ? AND val::text IN (?, ?)) OR
-                                 (key::text = ? AND val::text != ?)))) t
+								 (visibility_id IN ((SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text = ?))
+										INTERSECT
+										(SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text IN (?, ?)))
+										INTERSECT
+										(SELECT visibility_id FROM visibility_labels WHERE (key::text = ? AND val::text != ?)))))) t
 WHERE visibilities.id = t.id RETURNING *;`)))
 				Expect(queryArgs).To(HaveLen(12))
 				Expect(queryArgs[0]).Should(Equal("1"))

--- a/storage/postgres/where_clause_tree.go
+++ b/storage/postgres/where_clause_tree.go
@@ -30,12 +30,12 @@ const (
 	INTERSECT logicalOperator = "INTERSECT"
 )
 
-// queryFunc is a helper struct to allow for dynamic changing of the function that builds the sql template statements
-type queryFunc struct {
+// treeSqlBuilder is a helper struct to allow for dynamic changing of the function that builds the sql template statements
+type treeSqlBuilder struct {
 	buildSQL func(childrenSQL []string) string
 }
 
-var defaultQueryFunc = &queryFunc{
+var defaultTreeSqlBuilder = &treeSqlBuilder{
 	buildSQL: func(childrenSQL []string) string {
 		return fmt.Sprintf("(%s)", strings.Join(childrenSQL, fmt.Sprintf(" %s ", AND)))
 	},
@@ -47,8 +47,8 @@ type whereClauseTree struct {
 	dbTags    []tagType
 	tableName string
 
-	children  []*whereClauseTree
-	queryFunc *queryFunc
+	children   []*whereClauseTree
+	sqlBuilder *treeSqlBuilder
 }
 
 func (t *whereClauseTree) isLeaf() bool {
@@ -84,10 +84,10 @@ func (t *whereClauseTree) compileSQL() (string, []interface{}) {
 	case 1:
 		sql = childrenSQL[0]
 	default:
-		if t.queryFunc == nil {
-			t.queryFunc = defaultQueryFunc
+		if t.sqlBuilder == nil {
+			t.sqlBuilder = defaultTreeSqlBuilder
 		}
-		sql = t.queryFunc.buildSQL(childrenSQL)
+		sql = t.sqlBuilder.buildSQL(childrenSQL)
 	}
 
 	return sql, queryParams

--- a/test/delete_list.go
+++ b/test/delete_list.go
@@ -42,8 +42,8 @@ type deleteOpEntry struct {
 func DescribeDeleteListFor(ctx *common.TestContext, t TestCase) bool {
 	var r []common.Object
 	var rWithMandatoryFields common.Object
-	commonLabelKey := "commonLabelKey"
-	commonLabelValue := "1"
+	commonLabelKey := "labelKey2"
+	commonLabelValue := "str1"
 
 	entriesWithQuery := []TableEntry{
 		Entry("returns 200 for operator =",
@@ -374,18 +374,13 @@ func DescribeDeleteListFor(ctx *common.TestContext, t TestCase) bool {
 			},
 			{
 				Operation: query.AddLabelOperation,
-				Key:       "labelKey2",
+				Key:       commonLabelKey,
 				Values:    []string{fmt.Sprintf("str%d", i)},
 			},
 			{
 				Operation: query.AddLabelOperation,
 				Key:       "labelKey3",
 				Values:    []string{fmt.Sprintf(`{"key%d": "val%d"}`, i, i)},
-			},
-			{
-				Operation: query.AddLabelOperation,
-				Key:       commonLabelKey,
-				Values:    []string{commonLabelValue},
 			},
 		}
 		patchLabelsBody["labels"] = patchLabels
@@ -599,7 +594,7 @@ func DescribeDeleteListFor(ctx *common.TestContext, t TestCase) bool {
 						})
 
 						It("deletes only tenant specific resources without label query", func() {
-							labelQuery := fmt.Sprintf("labelQuery=%s eq %s", commonLabelKey, commonLabelValue)
+							labelQuery := fmt.Sprintf("labelQuery=%s eq '%s'", commonLabelKey, commonLabelValue)
 							resourceCntBeforeDelete := ctx.SMWithOAuth.ListWithQuery(t.API, labelQuery).Contains(rForTenant).Length().Raw()
 							verifyDeleteListOpHelperWithAuth(deleteOpEntry{
 								resourcesToExpectBeforeOp: func() []common.Object {

--- a/test/list.go
+++ b/test/list.go
@@ -450,7 +450,7 @@ func DescribeListTestsFor(ctx *common.TestContext, t TestCase, responseMode Resp
 							Status(http.StatusOK).JSON().Object().Raw()
 					})
 
-					It("returns only resource for this tenant", func() {
+					It("returns only tenant specific resources with common label query", func() {
 						verifyListOpWithAuth(listOpEntry{
 							resourcesToExpectAfterOp:    []common.Object{rForTenant},
 							resourcesNotToExpectAfterOp: r,
@@ -458,9 +458,9 @@ func DescribeListTestsFor(ctx *common.TestContext, t TestCase, responseMode Resp
 						}, fmt.Sprintf("labelQuery=%s eq %s", commonLabelKey, commonLabelValue), ctx.SMWithOAuthForTenant)
 					})
 
-					It("returns only tenant specific resources", func() {
+					It("returns only tenant specific resources without label query", func() {
 						verifyListOpWithAuth(listOpEntry{
-							resourcesToExpectBeforeOp: []common.Object{r[0], r[1], rForTenant},
+							resourcesToExpectBeforeOp: []common.Object{rForTenant},
 							resourcesToExpectAfterOp:  []common.Object{rForTenant},
 							expectedStatusCode:        http.StatusOK,
 						}, "", ctx.SMWithOAuthForTenant)


### PR DESCRIPTION
# Pull Request Template

## Motivation

Intersect all label queries instead of using `OR`.
Scenario:
### Entity 1 Labels
* color = red
* user = my_user

### Entity 2 Labels
* color = red
* user = your_user

If you want the `red` entities for `my_user` you'll execute `labelQuery=color eq 'red' and user eq 'my_user'`.  
Using `OR` this will return both entities.

