### PR TITLE
Unique constraint for instance and binding names

### DIFF
--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -204,6 +204,17 @@ func New(ctx context.Context, cancel context.CancelFunc, e env.Environment, cfg 
 	}
 
 	smb.
+		WithCreateAroundTxInterceptorProvider(types.ServiceInstanceType, &interceptors.UniqueInstanceNameCreateInterceptorProvider{
+			TenantIdentifier: cfg.Multitenancy.LabelKey,
+			Repository:       interceptableRepository,
+		}).Register().
+		WithUpdateAroundTxInterceptorProvider(types.ServiceInstanceType, &interceptors.UniqueInstanceNameUpdateInterceptorProvider{
+			TenantIdentifier: cfg.Multitenancy.LabelKey,
+			Repository:       interceptableRepository,
+		}).Register().
+		WithCreateAroundTxInterceptorProvider(types.ServiceBindingType, &interceptors.UniqueBindingNameCreateInterceptorProvider{
+			Repository: interceptableRepository,
+		}).Register().
 		WithCreateAroundTxInterceptorProvider(types.ServiceInstanceType, &interceptors.ServiceInstanceCreateInterceptorProvider{
 			BaseSMAAPInterceptorProvider: baseSMAAPInterceptorProvider,
 		}).Register().

--- a/storage/interceptors/unique_binding_names_iterceptor.go
+++ b/storage/interceptors/unique_binding_names_iterceptor.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interceptors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Peripli/service-manager/pkg/util"
+
+	"github.com/Peripli/service-manager/pkg/query"
+
+	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/Peripli/service-manager/storage"
+)
+
+const (
+	UniqueBindingNameCreateInterceptorName = "UniqueBindingNameCreateInterceptor"
+)
+
+// UniqueBindingNameCreateInterceptorProvider provides an interceptor that forbids creation of bindings with the same name in a given tenant
+type UniqueBindingNameCreateInterceptorProvider struct {
+	Repository storage.TransactionalRepository
+}
+
+func (c *UniqueBindingNameCreateInterceptorProvider) Name() string {
+	return UniqueBindingNameCreateInterceptorName
+}
+
+func (c *UniqueBindingNameCreateInterceptorProvider) Provide() storage.CreateAroundTxInterceptor {
+	return &uniqueBindingNameInterceptor{
+		Repository: c.Repository,
+	}
+}
+
+type uniqueBindingNameInterceptor struct {
+	Repository storage.TransactionalRepository
+}
+
+func (c *uniqueBindingNameInterceptor) AroundTxCreate(h storage.InterceptCreateAroundTxFunc) storage.InterceptCreateAroundTxFunc {
+	return func(ctx context.Context, obj types.Object) (types.Object, error) {
+		if err := c.checkUniqueName(ctx, obj.(*types.ServiceBinding)); err != nil {
+			return nil, err
+		}
+		return h(ctx, obj)
+	}
+}
+
+func (c *uniqueBindingNameInterceptor) checkUniqueName(ctx context.Context, binding *types.ServiceBinding) error {
+	countCriteria := []query.Criterion{
+		query.ByField(query.EqualsOperator, "service_instance_id", binding.ServiceInstanceID),
+		query.ByField(query.EqualsOperator, nameProperty, binding.Name),
+	}
+	bindingCount, err := c.Repository.Count(ctx, types.ServiceBindingType, countCriteria...)
+
+	if err != nil {
+		return fmt.Errorf("could not get count of service bindings %s", err)
+	}
+	if bindingCount > 0 {
+		return &util.HTTPError{
+			ErrorType:   "Conflict",
+			Description: fmt.Sprintf("binding with same name exists for instance with id %s", binding.ServiceInstanceID),
+			StatusCode:  http.StatusConflict,
+		}
+	}
+	return nil
+}

--- a/storage/interceptors/unique_instance_names_iterceptor.go
+++ b/storage/interceptors/unique_instance_names_iterceptor.go
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interceptors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Peripli/service-manager/pkg/util"
+
+	"github.com/Peripli/service-manager/pkg/query"
+
+	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/Peripli/service-manager/storage"
+)
+
+const (
+	UniqueInstanceNameCreateInterceptorName = "UniqueInstanceNameCreateInterceptor"
+	UniqueInstanceNameUpdateInterceptorName = "UniqueInstanceNameUpdateInterceptor"
+	nameProperty                            = "name"
+)
+
+// UniqueInstanceNameCreateInterceptorProvider provides an interceptor that forbids creation of instances with the same name in a given tenant
+type UniqueInstanceNameCreateInterceptorProvider struct {
+	TenantIdentifier string
+	Repository       storage.TransactionalRepository
+}
+
+func (c *UniqueInstanceNameCreateInterceptorProvider) Name() string {
+	return UniqueInstanceNameCreateInterceptorName
+}
+
+func (c *UniqueInstanceNameCreateInterceptorProvider) Provide() storage.CreateAroundTxInterceptor {
+	return &uniqueInstanceNameInterceptor{
+		TenantIdentifier: c.TenantIdentifier,
+		Repository:       c.Repository,
+	}
+}
+
+// UniqueInstanceNameUpdateInterceptorProvider provides an interceptor that forbids updating an instance name that breaks uniqueness in a given tenant
+type UniqueInstanceNameUpdateInterceptorProvider struct {
+	TenantIdentifier string
+	Repository       storage.TransactionalRepository
+}
+
+func (c *UniqueInstanceNameUpdateInterceptorProvider) Name() string {
+	return UniqueInstanceNameUpdateInterceptorName
+}
+
+func (c *UniqueInstanceNameUpdateInterceptorProvider) Provide() storage.UpdateAroundTxInterceptor {
+	return &uniqueInstanceNameInterceptor{
+		TenantIdentifier: c.TenantIdentifier,
+		Repository:       c.Repository,
+	}
+}
+
+type uniqueInstanceNameInterceptor struct {
+	TenantIdentifier string
+	Repository       storage.TransactionalRepository
+}
+
+func (c *uniqueInstanceNameInterceptor) AroundTxCreate(h storage.InterceptCreateAroundTxFunc) storage.InterceptCreateAroundTxFunc {
+	return func(ctx context.Context, obj types.Object) (object types.Object, err error) {
+		if err := c.checkUniqueName(ctx, obj.GetLabels(), obj.(*types.ServiceInstance)); err != nil {
+			return nil, err
+		}
+		return h(ctx, obj)
+	}
+}
+
+func (c *uniqueInstanceNameInterceptor) AroundTxUpdate(h storage.InterceptUpdateAroundTxFunc) storage.InterceptUpdateAroundTxFunc {
+	return func(ctx context.Context, newObj types.Object, labelChanges ...*query.LabelChange) (object types.Object, err error) {
+		oldObj, err := c.Repository.Get(ctx, types.ServiceInstanceType, query.ByField(query.EqualsOperator, "id", newObj.GetID()))
+		if err != nil {
+			return nil, err
+		}
+		oldInstance := oldObj.(*types.ServiceInstance)
+		newInstance := newObj.(*types.ServiceInstance)
+		if newInstance.Name != oldInstance.Name {
+			if err := c.checkUniqueName(ctx, oldObj.GetLabels(), newInstance); err != nil {
+				return nil, err
+			}
+		}
+		return h(ctx, newObj, labelChanges...)
+	}
+}
+
+func (c *uniqueInstanceNameInterceptor) checkUniqueName(ctx context.Context, labels types.Labels, instance *types.ServiceInstance) error {
+	if instance.PlatformID != types.SMPlatform {
+		return nil
+	}
+	countCriteria := []query.Criterion{
+		query.ByField(query.EqualsOperator, "platform_id", types.SMPlatform),
+		query.ByField(query.EqualsOperator, nameProperty, instance.Name),
+	}
+	if len(c.TenantIdentifier) != 0 {
+		if labels == nil {
+			labels = types.Labels{}
+		}
+		tenantIDLabelValue, ok := labels[c.TenantIdentifier]
+		if ok && len(tenantIDLabelValue) != 0 {
+			tenantID := tenantIDLabelValue[0]
+			countCriteria = append(countCriteria, query.ByLabel(query.EqualsOperator, c.TenantIdentifier, tenantID))
+		}
+	}
+	instanceCount, err := c.Repository.Count(ctx, types.ServiceInstanceType, countCriteria...)
+
+	if err != nil {
+		return fmt.Errorf("could not get count of service instances %s", err)
+	}
+	if instanceCount > 0 {
+		return &util.HTTPError{
+			ErrorType:   "Conflict",
+			Description: "instance with same name exists for the current tenant",
+			StatusCode:  http.StatusConflict,
+		}
+	}
+	return nil
+}

--- a/test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_test/service_instance_test.go
@@ -198,13 +198,15 @@ var _ = DescribeTestsFor(TestCase{
 			}
 
 			BeforeEach(func() {
+				ID, err := uuid.NewV4()
+				Expect(err).ToNot(HaveOccurred())
 				var plans *httpexpect.Array
 				brokerID, brokerServer, plans = prepareBrokerWithCatalog(ctx, ctx.SMWithOAuth)
 				brokerServer.ShouldRecordRequests(false)
 				servicePlanID = plans.Element(0).Object().Value("id").String().Raw()
 				anotherServicePlanID = plans.Element(1).Object().Value("id").String().Raw()
 				postInstanceRequest = Object{
-					"name":             "test-instance",
+					"name":             "test-instance" + ID.String(),
 					"service_plan_id":  servicePlanID,
 					"maintenance_info": "{}",
 				}
@@ -417,6 +419,41 @@ var _ = DescribeTestsFor(TestCase{
 								It(fmt.Sprintf("for tenant returns %d", testCase.expectedCreateSuccessStatusCode), func() {
 									EnsurePublicPlanVisibility(ctx.SMRepository, servicePlanID)
 									createInstanceWithAsync(ctx.SMWithOAuthForTenant, testCase.async, testCase.expectedCreateSuccessStatusCode)
+								})
+							})
+
+							When("creating instance with same name", func() {
+								BeforeEach(func() {
+									EnsurePublicPlanVisibility(ctx.SMRepository, servicePlanID)
+									postInstanceRequest["name"] = "same-instance-name"
+									resp := createInstanceWithAsync(ctx.SMWithOAuthForTenant, testCase.async, testCase.expectedCreateSuccessStatusCode)
+									if testCase.async {
+										_, err := ExpectOperation(ctx.SMWithOAuthForTenant, resp, types.SUCCEEDED)
+										Expect(err).ToNot(HaveOccurred())
+									}
+								})
+
+								When("for the same tenant", func() {
+									It("should reject", func() {
+										if testCase.async {
+											resp := createInstanceWithAsync(ctx.SMWithOAuthForTenant, true, testCase.expectedCreateSuccessStatusCode)
+											_, err := ExpectOperationWithError(ctx.SMWithOAuthForTenant, resp, types.FAILED, "instance with same name exists for the current tenant")
+											Expect(err).ToNot(HaveOccurred())
+										} else {
+											createInstanceWithAsync(ctx.SMWithOAuthForTenant, false, http.StatusConflict)
+										}
+									})
+								})
+
+								When("for other tenant", func() {
+									It("should accept", func() {
+										otherTenantExpect := ctx.NewTenantExpect("other-tenant")
+										resp := createInstanceWithAsync(otherTenantExpect, testCase.async, testCase.expectedCreateSuccessStatusCode)
+										if testCase.async {
+											_, err := ExpectOperation(otherTenantExpect, resp, types.SUCCEEDED)
+											Expect(err).ToNot(HaveOccurred())
+										}
+									})
 								})
 							})
 						})
@@ -1043,6 +1080,55 @@ var _ = DescribeTestsFor(TestCase{
 								Expect().Status(http.StatusAccepted)
 
 							ExpectSuccessfulAsyncResourceCreation(resp, ctx.SMWithOAuth, web.ServiceInstancesURL)
+						})
+					})
+
+					When("changing instance name to existing instance name", func() {
+						Context("same tenant", func() {
+							It("fails to update", func() {
+								EnsurePlanVisibility(ctx.SMRepository, TenantIdentifier, types.SMPlatform, servicePlanID, TenantIDValue)
+
+								postInstanceRequest["name"] = "instance1"
+								resp := createInstance(ctx.SMWithOAuthForTenant, http.StatusAccepted)
+								instance := ExpectSuccessfulAsyncResourceCreation(resp, ctx.SMWithOAuth, web.ServiceInstancesURL)
+
+								postInstanceRequest["name"] = "instance2"
+								resp = createInstance(ctx.SMWithOAuthForTenant, http.StatusAccepted)
+								instance = ExpectSuccessfulAsyncResourceCreation(resp, ctx.SMWithOAuth, web.ServiceInstancesURL)
+								instanceID2 := instance["id"].(string)
+
+								resp = ctx.SMWithOAuthForTenant.PATCH(web.ServiceInstancesURL + "/" + instanceID2).
+									WithJSON(Object{"name": "instance1"}).
+									Expect().Status(http.StatusAccepted)
+
+								_, err := ExpectOperationWithError(ctx.SMWithOAuthForTenant, resp, types.FAILED, "instance with same name exists for the current tenant")
+								Expect(err).ToNot(HaveOccurred())
+								ctx.SMWithOAuthForTenant.GET(web.ServiceInstancesURL+"/"+instanceID2).Expect().Status(http.StatusOK).JSON().Object().ValueEqual("name", "instance2")
+							})
+						})
+
+						Context("different tenants", func() {
+							It("succeeds to update", func() {
+								EnsurePublicPlanVisibility(ctx.SMRepository, servicePlanID)
+
+								postInstanceRequest["name"] = "instance1"
+								otherTenant := ctx.NewTenantExpect("other-tenant")
+								resp := createInstance(otherTenant, http.StatusAccepted)
+								instance := ExpectSuccessfulAsyncResourceCreation(resp, ctx.SMWithOAuth, web.ServiceInstancesURL)
+
+								postInstanceRequest["name"] = "instance2"
+								resp = createInstance(ctx.SMWithOAuthForTenant, http.StatusAccepted)
+								instance = ExpectSuccessfulAsyncResourceCreation(resp, ctx.SMWithOAuth, web.ServiceInstancesURL)
+								instanceID2 := instance["id"].(string)
+
+								resp = ctx.SMWithOAuthForTenant.PATCH(web.ServiceInstancesURL + "/" + instanceID2).
+									WithJSON(Object{"name": "instance1"}).
+									Expect().Status(http.StatusAccepted)
+
+								_, err := ExpectOperation(ctx.SMWithOAuthForTenant, resp, types.SUCCEEDED)
+								Expect(err).ToNot(HaveOccurred())
+								ctx.SMWithOAuthForTenant.GET(web.ServiceInstancesURL+"/"+instanceID2).Expect().Status(http.StatusOK).JSON().Object().ValueEqual("name", "instance1")
+							})
 						})
 					})
 				})

--- a/test/test.go
+++ b/test/test.go
@@ -162,31 +162,32 @@ func ExpectOperationWithError(auth *common.SMExpect, asyncResp *httpexpect.Respo
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err := fmt.Errorf("unable to verify operation state (expected state = %s)", string(expectedState))
-	var operation *httpexpect.Object
+	var state string
+	expectedStateStr := string(expectedState)
 	for {
 		select {
 		case <-ctx.Done():
+			return nil, fmt.Errorf("unable to verify operation state (expected state = %s, last state = %s)", expectedStateStr, state)
 		default:
-			operation = auth.GET(operationURL).
+			operation := auth.GET(operationURL).
 				Expect().Status(http.StatusOK).JSON().Object()
-			state := operation.Value("state").String().Raw()
-			if state == string(expectedState) {
-				if expectedState == types.SUCCEEDED {
-				} else {
-					errs := operation.Value("errors")
-					errs.NotNull()
-					errMsg := errs.Object().Value("description").String().Raw()
-
-					if !strings.Contains(errMsg, expectedErrMsg) {
-						err = fmt.Errorf("unable to verify operation - expected error message (%s), but got (%s)", expectedErrMsg, errs.String().Raw())
-					}
+			state = operation.Value("state").String().Raw()
+			if state == expectedStateStr {
+				if expectedState == types.SUCCEEDED || len(expectedStateStr) == 0 {
+					return operation, nil
 				}
-				return operation, nil
+				errs := operation.Value("errors")
+				errs.NotNull()
+				errMsg := errs.Object().Value("description").String().Raw()
+
+				if !strings.Contains(errMsg, expectedErrMsg) {
+					return operation, fmt.Errorf("unable to verify operation - expected error message (%s), but got (%s)", expectedErrMsg, errMsg)
+				} else {
+					return operation, nil
+				}
 			}
 		}
 	}
-	return nil, err
 }
 
 func EnsurePublicPlanVisibility(repository storage.Repository, planID string) {


### PR DESCRIPTION
This constraint is currently done with interceptors but this might not work in some cases.
It should be done as a DB constraint.