### PR TITLE
Reorder error handling for catalog fetcher

### DIFF
--- a/api/osb/catalog_fetcher.go
+++ b/api/osb/catalog_fetcher.go
@@ -46,11 +46,6 @@ func CatalogFetcher(doRequestFunc util.DoRequestFunc, brokerAPIVersion string) f
 			}
 		}
 
-		var responseBytes []byte
-		if responseBytes, err = util.BodyToBytes(response.Body); err != nil {
-			return nil, fmt.Errorf("error getting content from body of response with status %s: %s", response.Status, err)
-		}
-
 		if response.StatusCode != http.StatusOK {
 			log.C(ctx).WithError(err).Errorf("error fetching catalog for broker with name %s: %s", broker.Name, util.HandleResponseError(response))
 			return nil, &util.HTTPError{
@@ -59,6 +54,12 @@ func CatalogFetcher(doRequestFunc util.DoRequestFunc, brokerAPIVersion string) f
 				StatusCode:  http.StatusBadRequest,
 			}
 		}
+
+		var responseBytes []byte
+		if responseBytes, err = util.BodyToBytes(response.Body); err != nil {
+			return nil, fmt.Errorf("error getting content from body of response with status %s: %s", response.Status, err)
+		}
+
 		log.C(ctx).Debugf("Successfully fetched catalog from broker with name %s and URL %s", broker.Name, broker.BrokerURL)
 
 		return responseBytes, nil

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -274,6 +274,20 @@ var _ = test.DescribeTestsFor(test.TestCase{
 					})
 				})
 
+				Context("when the broker returns 404 for catalog", func() {
+					BeforeEach(func() {
+						brokerServer.CatalogHandler = func(rw http.ResponseWriter, req *http.Request) {
+							common.SetResponse(rw, http.StatusNotFound, common.Object{})
+						}
+					})
+
+					It("returns 400", func() {
+						ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerRequestWithNoLabels).
+							Expect().
+							Status(http.StatusBadRequest)
+					})
+				})
+
 				Context("when the broker call for catalog times out", func() {
 					const (
 						timeoutDuration             = time.Millisecond * 500


### PR DESCRIPTION
## Motivation
We have error like this:
```
error fetching catalog for broker with name test-service-broker-tenant1: request GET https://test-service-broker.cfapps.stagingsc7.hanavlab.ondemand.com/v2/catalog failed: StatusCode: 404 Body: error reading response body: http: read on closed response body
```
which is misleading because actually we don't have problem reading response body