### PR TITLE
Proxy only sm supported encodings in osb calls

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -135,6 +135,7 @@ func New(ctx context.Context, e env.Environment, options *Options) (*web.API, er
 		// Default filters - more filters can be registered using the relevant API methods
 		Filters: []web.Filter{
 			&filters.Logging{},
+			&filters.SupportedEncodingsFilter{},
 			&filters.SelectionCriteria{},
 			&filters.ServiceInstanceStripFilter{},
 			&filters.ServiceBindingStripFilter{},

--- a/api/filters/supported_encodings_filter.go
+++ b/api/filters/supported_encodings_filter.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import (
+	"github.com/Peripli/service-manager/pkg/web"
+)
+
+const (
+	SupportedEncodingsFilterName = "SupportedEncodingsFilter"
+)
+
+type SupportedEncodingsFilter struct {
+}
+
+func (*SupportedEncodingsFilter) Name() string {
+	return SupportedEncodingsFilterName
+}
+
+/** Allow to proxy only SM supported osb encodings (Identity/none are currently allowed)  */
+func (l *SupportedEncodingsFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
+	req.Header.Del("Accept-Encoding")
+	return next.Handle(req)
+}
+
+func (*SupportedEncodingsFilter) FilterMatchers() []web.FilterMatcher {
+	return []web.FilterMatcher{
+		{
+			Matchers: []web.Matcher{
+				web.Path(web.OSBURL + "/**"),
+			},
+		},
+	}
+}

--- a/test/osb_test/bind_test.go
+++ b/test/osb_test/bind_test.go
@@ -29,6 +29,13 @@ var _ = Describe("Bind", func() {
 			ctx.SMWithBasic.PUT(smBrokerURL+"/v2/service_instances/iid/service_bindings/bid").WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
 				WithJSON(provisionRequestBodyMap()()).Expect().Status(http.StatusCreated)
 		})
+
+		It("Binding to a server that supports gzip encoded responses", func() {
+			brokerServer.BindingHandler = gzipHandler(http.StatusCreated, `{}`)
+			ctx.SMWithBasic.PUT(smBrokerURL+"/v2/service_instances/iid/service_bindings/bid").WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
+				WithJSON(provisionRequestBodyMap()()).Expect().Status(http.StatusCreated)
+		})
+
 	})
 
 	Context("when call to failing service broker", func() {


### PR DESCRIPTION
## Motivation

The Accept-Encoding field is used in an HTTP request to indicate which encodings are accepted in a response message to the request. This field is used to specify the values of gzip, deflate, compress and identity.  A value of identity indicates that the data must not be compressed. A wildcard of * indicates that any encoding is accepted. The Accept-Encoding field can also be empty, indicating that no encoding is accepted.  SM needs to support the handling of broker responses when the Accept-Encoding header is present and provided by the OSB clients as svcat.

## Approach

The proposed changes add an Accept-Encoding header filter for OSB calls and filters out the Accept-Encoding header incase the request encoding is not supported.

## Pull Request status

* [x] Initial implementation
* [ ] Refactoring
* [x ] Unit tests
* [ ] Integration tests