### PR TITLE
Fix Rescheduling of Instance/Binding operations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -588,7 +588,7 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "2aa609cf4a9d7d1126360de73b55b6002f9e052a"
+  revision = "78000ba7a073cafc0278790f6bce552a0f25850e"
 
 [[projects]]
   branch = "master"
@@ -619,11 +619,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a70084a3b2539ae837aa84c5ab561c6eddfc48eb64737d4f4414405694e47b0e"
+  digest = "1:8d59aa6f03198132e0ca3bf998677f9698e1e27fc67976c85d85086ac3496530"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "5d559ad92b82f3696a2a2f23108ac03758aabedb"
+  revision = "5c8b2ff67527cb88b770f693cebf3799036d8bc0"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"

--- a/operations/maintainer.go
+++ b/operations/maintainer.go
@@ -159,10 +159,11 @@ func (om *Maintainer) processOperations(functor func(), functorName string, inte
 
 // cleanUpExternalOperations cleans up periodically all external operations which are older than some specified time
 func (om *Maintainer) cleanupExternalOperations() {
+	currentTime := time.Now()
 	criteria := []query.Criterion{
 		query.ByField(query.NotEqualsOperator, "platform_id", types.SMPlatform),
 		// check if operation hasn't been updated for the operation's maximum allowed time to live in DB
-		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(time.Now().Add(-om.settings.Lifespan))),
+		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(currentTime.Add(-om.settings.Lifespan))),
 	}
 
 	if err := om.repository.Delete(om.smCtx, types.OperationType, criteria...); err != nil && err != util.ErrNotFoundInStorage {
@@ -174,11 +175,12 @@ func (om *Maintainer) cleanupExternalOperations() {
 
 // cleanupInternalSuccessfulOperations cleans up all successful internal operations which are older than some specified time
 func (om *Maintainer) cleanupInternalSuccessfulOperations() {
+	currentTime := time.Now()
 	criteria := []query.Criterion{
 		query.ByField(query.EqualsOperator, "platform_id", types.SMPlatform),
 		query.ByField(query.EqualsOperator, "state", string(types.SUCCEEDED)),
 		// check if operation hasn't been updated for the operation's maximum allowed time to live in DB
-		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(time.Now().Add(-om.settings.Lifespan))),
+		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(currentTime.Add(-om.settings.Lifespan))),
 	}
 
 	if err := om.repository.Delete(om.smCtx, types.OperationType, criteria...); err != nil && err != util.ErrNotFoundInStorage {
@@ -190,13 +192,14 @@ func (om *Maintainer) cleanupInternalSuccessfulOperations() {
 
 // cleanupInternalFailedOperations cleans up all failed internal operations which are older than some specified time
 func (om *Maintainer) cleanupInternalFailedOperations() {
+	currentTime := time.Now()
 	criteria := []query.Criterion{
 		query.ByField(query.EqualsOperator, "platform_id", types.SMPlatform),
 		query.ByField(query.EqualsOperator, "state", string(types.FAILED)),
 		query.ByField(query.EqualsOperator, "reschedule", "false"),
 		query.ByField(query.EqualsOperator, "deletion_scheduled", ZeroTime),
 		// check if operation hasn't been updated for the operation's maximum allowed time to live in DB
-		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(time.Now().Add(-om.settings.Lifespan))),
+		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(currentTime.Add(-om.settings.Lifespan))),
 	}
 
 	if err := om.repository.Delete(om.smCtx, types.OperationType, criteria...); err != nil && err != util.ErrNotFoundInStorage {
@@ -208,15 +211,16 @@ func (om *Maintainer) cleanupInternalFailedOperations() {
 
 // rescheduleUnprocessedOperations reschedules IN_PROGRESS operations which are reschedulable, not scheduled for deletion and no goroutine is processing at the moment
 func (om *Maintainer) rescheduleUnprocessedOperations() {
+	currentTime := time.Now()
 	criteria := []query.Criterion{
 		query.ByField(query.EqualsOperator, "platform_id", types.SMPlatform),
 		query.ByField(query.EqualsOperator, "state", string(types.IN_PROGRESS)),
 		query.ByField(query.EqualsOperator, "reschedule", "true"),
 		query.ByField(query.EqualsOperator, "deletion_scheduled", ZeroTime),
 		// check if operation hasn't been updated for the operation's maximum allowed time to execute
-		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(time.Now().Add(-om.settings.ActionTimeout))),
+		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(currentTime.Add(-om.settings.ActionTimeout))),
 		// check if operation is still eligible for processing
-		query.ByField(query.GreaterThanOperator, "created_at", util.ToRFCNanoFormat(time.Now().Add(-om.settings.ReconciliationOperationTimeout))),
+		query.ByField(query.GreaterThanOperator, "created_at", util.ToRFCNanoFormat(currentTime.Add(-om.settings.ReconciliationOperationTimeout))),
 	}
 
 	objectList, err := om.repository.List(om.smCtx, types.OperationType, criteria...)
@@ -280,13 +284,14 @@ func (om *Maintainer) rescheduleUnprocessedOperations() {
 
 // rescheduleOrphanMitigationOperations reschedules orphan mitigation operations which no goroutine is processing at the moment
 func (om *Maintainer) rescheduleOrphanMitigationOperations() {
+	currentTime := time.Now()
 	criteria := []query.Criterion{
 		query.ByField(query.EqualsOperator, "platform_id", types.SMPlatform),
 		query.ByField(query.NotEqualsOperator, "deletion_scheduled", ZeroTime),
 		// check if operation hasn't been updated for the operation's maximum allowed time to execute
-		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(time.Now().Add(-om.settings.ActionTimeout))),
+		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(currentTime.Add(-om.settings.ActionTimeout))),
 		// check if operation is still eligible for processing
-		query.ByField(query.GreaterThanOperator, "created_at", util.ToRFCNanoFormat(time.Now().Add(-om.settings.ReconciliationOperationTimeout))),
+		query.ByField(query.GreaterThanOperator, "created_at", util.ToRFCNanoFormat(currentTime.Add(-om.settings.ReconciliationOperationTimeout))),
 	}
 
 	objectList, err := om.repository.List(om.smCtx, types.OperationType, criteria...)
@@ -323,13 +328,14 @@ func (om *Maintainer) rescheduleOrphanMitigationOperations() {
 
 // markOrphanOperationsFailed checks for operations which are stuck in state IN_PROGRESS, updates their status to FAILED and schedules a delete action
 func (om *Maintainer) markOrphanOperationsFailed() {
+	currentTime := time.Now()
 	criteria := []query.Criterion{
 		query.ByField(query.EqualsOperator, "platform_id", types.SMPlatform),
 		query.ByField(query.EqualsOperator, "state", string(types.IN_PROGRESS)),
 		query.ByField(query.EqualsOperator, "reschedule", "false"),
 		query.ByField(query.EqualsOperator, "deletion_scheduled", ZeroTime),
 		// check if operation hasn't been updated for the operation's maximum allowed time to execute
-		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(time.Now().Add(-om.settings.ActionTimeout))),
+		query.ByField(query.LessThanOperator, "updated_at", util.ToRFCNanoFormat(currentTime.Add(-om.settings.ActionTimeout))),
 	}
 
 	objectList, err := om.repository.List(om.smCtx, types.OperationType, criteria...)

--- a/storage/interceptors/unique_binding_names_iterceptor.go
+++ b/storage/interceptors/unique_binding_names_iterceptor.go
@@ -65,7 +65,7 @@ func (c *uniqueBindingNameInterceptor) AroundTxCreate(h storage.InterceptCreateA
 
 func (c *uniqueBindingNameInterceptor) checkUniqueName(ctx context.Context, binding *types.ServiceBinding) error {
 	operation, operationFound := operations.GetFromContext(ctx)
-	if operationFound {
+	if !operationFound {
 		log.C(ctx).Debug("operation missing from context")
 	}
 

--- a/storage/interceptors/unique_binding_names_iterceptor.go
+++ b/storage/interceptors/unique_binding_names_iterceptor.go
@@ -70,7 +70,7 @@ func (c *uniqueBindingNameInterceptor) checkUniqueName(ctx context.Context, bind
 	}
 
 	if operationFound && operation.Reschedule {
-		log.C(ctx).Debug("skipping unique check of binding name as this is a rescheduled operation")
+		log.C(ctx).Info("skipping unique check of binding name as this is a rescheduled operation")
 		return nil
 	}
 

--- a/storage/interceptors/unique_binding_names_iterceptor.go
+++ b/storage/interceptors/unique_binding_names_iterceptor.go
@@ -19,6 +19,8 @@ package interceptors
 import (
 	"context"
 	"fmt"
+	"github.com/Peripli/service-manager/operations"
+	"github.com/Peripli/service-manager/pkg/log"
 	"net/http"
 
 	"github.com/Peripli/service-manager/pkg/util"
@@ -62,16 +64,25 @@ func (c *uniqueBindingNameInterceptor) AroundTxCreate(h storage.InterceptCreateA
 }
 
 func (c *uniqueBindingNameInterceptor) checkUniqueName(ctx context.Context, binding *types.ServiceBinding) error {
+	operation, operationFound := operations.GetFromContext(ctx)
+	if operationFound {
+		log.C(ctx).Debug("operation missing from context")
+	}
+
+	if operationFound && operation.Reschedule {
+		log.C(ctx).Debug("skipping unique check of binding name as this is a rescheduled operation")
+		return nil
+	}
+
 	countCriteria := []query.Criterion{
 		query.ByField(query.EqualsOperator, "service_instance_id", binding.ServiceInstanceID),
 		query.ByField(query.EqualsOperator, nameProperty, binding.Name),
-		query.ByField(query.EqualsOperator, "ready", "true"),
 	}
 	bindingCount, err := c.Repository.Count(ctx, types.ServiceBindingType, countCriteria...)
-
 	if err != nil {
 		return fmt.Errorf("could not get count of service bindings %s", err)
 	}
+
 	if bindingCount > 0 {
 		return &util.HTTPError{
 			ErrorType:   "Conflict",
@@ -79,5 +90,6 @@ func (c *uniqueBindingNameInterceptor) checkUniqueName(ctx context.Context, bind
 			StatusCode:  http.StatusConflict,
 		}
 	}
+
 	return nil
 }

--- a/storage/interceptors/unique_binding_names_iterceptor.go
+++ b/storage/interceptors/unique_binding_names_iterceptor.go
@@ -65,6 +65,7 @@ func (c *uniqueBindingNameInterceptor) checkUniqueName(ctx context.Context, bind
 	countCriteria := []query.Criterion{
 		query.ByField(query.EqualsOperator, "service_instance_id", binding.ServiceInstanceID),
 		query.ByField(query.EqualsOperator, nameProperty, binding.Name),
+		query.ByField(query.EqualsOperator, "ready", "true"),
 	}
 	bindingCount, err := c.Repository.Count(ctx, types.ServiceBindingType, countCriteria...)
 

--- a/storage/interceptors/unique_instance_names_iterceptor.go
+++ b/storage/interceptors/unique_instance_names_iterceptor.go
@@ -107,6 +107,7 @@ func (c *uniqueInstanceNameInterceptor) checkUniqueName(ctx context.Context, lab
 	countCriteria := []query.Criterion{
 		query.ByField(query.EqualsOperator, "platform_id", types.SMPlatform),
 		query.ByField(query.EqualsOperator, nameProperty, instance.Name),
+		query.ByField(query.EqualsOperator, "ready", "true"),
 	}
 	if len(c.TenantIdentifier) != 0 {
 		if labels == nil {

--- a/storage/interceptors/unique_instance_names_iterceptor.go
+++ b/storage/interceptors/unique_instance_names_iterceptor.go
@@ -104,7 +104,7 @@ func (c *uniqueInstanceNameInterceptor) AroundTxUpdate(h storage.InterceptUpdate
 
 func (c *uniqueInstanceNameInterceptor) checkUniqueName(ctx context.Context, labels types.Labels, instance *types.ServiceInstance) error {
 	operation, operationFound := operations.GetFromContext(ctx)
-	if operationFound {
+	if !operationFound {
 		log.C(ctx).Debug("operation missing from context")
 	}
 

--- a/storage/interceptors/unique_instance_names_iterceptor.go
+++ b/storage/interceptors/unique_instance_names_iterceptor.go
@@ -111,7 +111,7 @@ func (c *uniqueInstanceNameInterceptor) checkUniqueName(ctx context.Context, lab
 	rescheduledOperation := operationFound && operation.Reschedule
 	if instance.PlatformID != types.SMPlatform || rescheduledOperation {
 		if rescheduledOperation {
-			log.C(ctx).Debug("skipping unique check of instance name as this is a rescheduled operation")
+			log.C(ctx).Info("skipping unique check of instance name as this is a rescheduled operation")
 		}
 		return nil
 	}

--- a/test/service_binding_test/service_binding_test.go
+++ b/test/service_binding_test/service_binding_test.go
@@ -19,15 +19,14 @@ package service_binding_test
 import (
 	"context"
 	"fmt"
+	"github.com/Peripli/service-manager/operations"
+	"github.com/Peripli/service-manager/pkg/query"
 	"net/http"
 	"strconv"
 	"sync/atomic"
 	"time"
 
-	"github.com/Peripli/service-manager/operations"
 	"github.com/Peripli/service-manager/pkg/env"
-	"github.com/Peripli/service-manager/pkg/query"
-
 	"github.com/gofrs/uuid"
 
 	"github.com/spf13/pflag"
@@ -571,77 +570,6 @@ var _ = DescribeTestsFor(TestCase{
 								})
 							})
 
-							XWhen("SM crashes after storing operation before storing resource", func() {
-								var newCtx *TestContext
-
-								postHookWithShutdownTimeout := func() func(e env.Environment, servers map[string]FakeServer) {
-									return func(e env.Environment, servers map[string]FakeServer) {
-										e.Set("server.shutdown_timeout", 1*time.Second)
-										e.Set("httpclient.response_header_timeout", 1*time.Second)
-									}
-								}
-
-								BeforeEach(func() {
-									ctxMaintainerBuilder := t.ContextBuilder.WithEnvPostExtensions(postHookWithShutdownTimeout())
-									newCtx = ctxMaintainerBuilder.BuildWithoutCleanup()
-
-									brokerServer.BindingHandlerFunc(http.MethodPut, http.MethodPut+"3", func(_ *http.Request) (int, map[string]interface{}) {
-										defer newCtx.CleanupAll(false)
-										return http.StatusOK, Object{"state": types.IN_PROGRESS}
-									})
-
-									brokerServer.BindingHandlerFunc(http.MethodDelete, http.MethodDelete+"3", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))
-									brokerServer.BindingLastOpHandlerFunc(http.MethodDelete+"3", func(_ *http.Request) (int, map[string]interface{}) {
-										return http.StatusOK, Object{"state": types.SUCCEEDED}
-									})
-								})
-
-								It("Should mark operation as failed and trigger orphan mitigation", func() {
-									opChan := make(chan *types.Operation)
-									defer close(opChan)
-
-									opCriteria := []query.Criterion{
-										query.ByField(query.EqualsOperator, "type", string(types.CREATE)),
-										query.ByField(query.EqualsOperator, "state", string(types.IN_PROGRESS)),
-										query.ByField(query.EqualsOperator, "resource_type", string(types.ServiceBindingType)),
-										query.ByField(query.EqualsOperator, "reschedule", "false"),
-										query.ByField(query.EqualsOperator, "deletion_scheduled", operations.ZeroTime),
-									}
-
-									go func() {
-										for {
-											object, err := ctx.SMRepository.Get(context.TODO(), types.OperationType, opCriteria...)
-											if err == nil {
-												opChan <- object.(*types.Operation)
-												break
-											}
-										}
-									}()
-
-									createBinding(newCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedSMCrashStatusCode)
-									operation := <-opChan
-
-									VerifyResourceDoesNotExist(ctx.SMWithOAuthForTenant, ResourceExpectations{
-										ID:   operation.ResourceID,
-										Type: types.ServiceBindingType,
-									})
-
-									operationExpectation := OperationExpectations{
-										Category:          types.CREATE,
-										State:             types.FAILED,
-										ResourceType:      types.ServiceBindingType,
-										Reschedulable:     false,
-										DeletionScheduled: false,
-									}
-
-									bindingID, _ = VerifyOperationExists(ctx, fmt.Sprintf("%s/%s%s/%s", web.ServiceBindingsURL, operation.ResourceID, web.OperationsURL, operation.ID), operationExpectation)
-									VerifyResourceDoesNotExist(ctx.SMWithOAuthForTenant, ResourceExpectations{
-										ID:   bindingID,
-										Type: types.ServiceBindingType,
-									})
-								})
-							})
-
 							When("broker responds with synchronous success", func() {
 								BeforeEach(func() {
 									brokerServer.BindingHandlerFunc(http.MethodPut, http.MethodPut+"1", ParameterizedHandler(http.StatusCreated, syncBindingResponse))
@@ -726,19 +654,14 @@ var _ = DescribeTestsFor(TestCase{
 										})
 									})
 
-									XWhen("SM crashes while polling", func() {
-										var newCtx *TestContext
+									When("SM crashes while polling", func() {
+										var newSMCtx *TestContext
 										var isBound atomic.Value
 
-										postHookWithShutdownTimeout := func() func(e env.Environment, servers map[string]FakeServer) {
-											return func(e env.Environment, servers map[string]FakeServer) {
-												e.Set("server.shutdown_timeout", 1*time.Second)
-											}
-										}
-
 										BeforeEach(func() {
-											ctxMaintainerBuilder := t.ContextBuilder.WithEnvPostExtensions(postHookWithShutdownTimeout())
-											newCtx = ctxMaintainerBuilder.BuildWithoutCleanup()
+											newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+												e.Set("server.shutdown_timeout", 1*time.Second)
+											}).BuildWithoutCleanup()
 
 											brokerServer.BindingHandlerFunc(http.MethodPut, http.MethodPut+"1", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))
 											brokerServer.BindingLastOpHandlerFunc(http.MethodPut+"1", func(_ *http.Request) (int, map[string]interface{}) {
@@ -752,7 +675,7 @@ var _ = DescribeTestsFor(TestCase{
 										})
 
 										It("should start restart polling through maintainer and eventually binding is set to ready", func() {
-											resp := createBinding(newCtx.SMWithOAuthForTenant, true, http.StatusAccepted)
+											resp := createBinding(newSMCtx.SMWithOAuthForTenant, true, http.StatusAccepted)
 
 											operationExpectations := OperationExpectations{
 												Category:          types.CREATE,
@@ -762,16 +685,20 @@ var _ = DescribeTestsFor(TestCase{
 												DeletionScheduled: false,
 											}
 
-											bindingID, _ = VerifyOperationExists(newCtx, resp.Header("Location").Raw(), operationExpectations)
+											bindingID, _ = VerifyOperationExists(newSMCtx, resp.Header("Location").Raw(), operationExpectations)
 											VerifyResourceExists(ctx.SMWithOAuthForTenant, ResourceExpectations{
 												ID:    bindingID,
 												Type:  types.ServiceBindingType,
 												Ready: false,
 											})
 
-											newCtx.CleanupAll(false)
-
+											newSMCtx.CleanupAll(false)
 											isBound.Store(true)
+
+											newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+												e.Set("operations.action_timeout", 2*time.Second)
+											}).BuildWithoutCleanup()
+											defer newSMCtx.CleanupAll(false)
 
 											operationExpectations.State = types.SUCCEEDED
 											operationExpectations.Reschedulable = false
@@ -916,6 +843,75 @@ var _ = DescribeTestsFor(TestCase{
 								})
 							})
 
+							if testCase.async {
+								When("SM crashes after storing operation before storing resource", func() {
+									var newSMCtx *TestContext
+
+									BeforeEach(func() {
+										newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+											e.Set("server.shutdown_timeout", 1*time.Second)
+										}).BuildWithoutCleanup()
+
+										brokerServer.BindingHandlerFunc(http.MethodDelete, http.MethodDelete+"3", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))
+										brokerServer.BindingLastOpHandlerFunc(http.MethodDelete+"3", func(_ *http.Request) (int, map[string]interface{}) {
+											return http.StatusOK, Object{"state": types.SUCCEEDED}
+										})
+									})
+
+									It("Should mark operation as failed and trigger orphan mitigation", func() {
+										opChan := make(chan *types.Operation)
+										defer close(opChan)
+
+										opCriteria := []query.Criterion{
+											query.ByField(query.EqualsOperator, "type", string(types.CREATE)),
+											query.ByField(query.EqualsOperator, "state", string(types.IN_PROGRESS)),
+											query.ByField(query.EqualsOperator, "resource_type", string(types.ServiceBindingType)),
+											query.ByField(query.EqualsOperator, "reschedule", "false"),
+											query.ByField(query.EqualsOperator, "deletion_scheduled", operations.ZeroTime),
+										}
+
+										go func() {
+											for {
+												object, err := ctx.SMRepository.Get(context.TODO(), types.OperationType, opCriteria...)
+												if err == nil {
+													newSMCtx.CleanupAll(false)
+													opChan <- object.(*types.Operation)
+													break
+												}
+											}
+										}()
+
+										createBinding(newSMCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedSMCrashStatusCode)
+										operation := <-opChan
+
+										VerifyResourceDoesNotExist(ctx.SMWithOAuthForTenant, ResourceExpectations{
+											ID:   operation.ResourceID,
+											Type: types.ServiceBindingType,
+										})
+
+										anotherSMCtx := t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+											e.Set("operations.action_timeout", 2*time.Second)
+											e.Set("operations.cleanup_interval", 2*time.Second)
+										}).BuildWithoutCleanup()
+										defer anotherSMCtx.CleanupAll(false)
+
+										operationExpectation := OperationExpectations{
+											Category:          types.CREATE,
+											State:             types.FAILED,
+											ResourceType:      types.ServiceBindingType,
+											Reschedulable:     false,
+											DeletionScheduled: false,
+										}
+
+										bindingID, _ = VerifyOperationExists(ctx, fmt.Sprintf("%s/%s%s/%s", web.ServiceBindingsURL, operation.ResourceID, web.OperationsURL, operation.ID), operationExpectation)
+										VerifyResourceDoesNotExist(ctx.SMWithOAuthForTenant, ResourceExpectations{
+											ID:   bindingID,
+											Type: types.ServiceBindingType,
+										})
+									})
+								})
+							}
+
 							When("bind responds with error due to stopped broker", func() {
 								BeforeEach(func() {
 									brokerServer.Close()
@@ -1031,19 +1027,14 @@ var _ = DescribeTestsFor(TestCase{
 									})
 								}
 
-								XWhen("SM crashes while orphan mitigating", func() {
-									var newCtx *TestContext
+								When("SM crashes while orphan mitigating", func() {
+									var newSMCtx *TestContext
 									var isUnbound atomic.Value
 
-									postHookWithShutdownTimeout := func() func(e env.Environment, servers map[string]FakeServer) {
-										return func(e env.Environment, servers map[string]FakeServer) {
-											e.Set("server.shutdown_timeout", 1*time.Second)
-										}
-									}
-
 									BeforeEach(func() {
-										ctxMaintainerBuilder := t.ContextBuilder.WithEnvPostExtensions(postHookWithShutdownTimeout())
-										newCtx = ctxMaintainerBuilder.BuildWithoutCleanup()
+										newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+											e.Set("server.shutdown_timeout", 1*time.Second)
+										}).BuildWithoutCleanup()
 
 										brokerServer.BindingHandlerFunc(http.MethodDelete, http.MethodDelete+"3", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))
 										brokerServer.BindingLastOpHandlerFunc(http.MethodDelete+"3", func(_ *http.Request) (int, map[string]interface{}) {
@@ -1056,7 +1047,7 @@ var _ = DescribeTestsFor(TestCase{
 									})
 
 									It("should restart orphan mitigation through maintainer and eventually succeeds", func() {
-										resp := createBinding(newCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedBrokerFailureStatusCode)
+										resp := createBinding(newSMCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedBrokerFailureStatusCode)
 
 										operationExpectations := OperationExpectations{
 											Category:          types.CREATE,
@@ -1066,10 +1057,15 @@ var _ = DescribeTestsFor(TestCase{
 											DeletionScheduled: true,
 										}
 
-										bindingID, _ = VerifyOperationExists(newCtx, resp.Header("Location").Raw(), operationExpectations)
+										bindingID, _ = VerifyOperationExists(newSMCtx, resp.Header("Location").Raw(), operationExpectations)
 
-										newCtx.CleanupAll(false)
+										newSMCtx.CleanupAll(false)
 										isUnbound.Store(true)
+
+										newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+											e.Set("operations.action_timeout", 2*time.Second)
+										}).BuildWithoutCleanup()
+										defer newSMCtx.CleanupAll(false)
 
 										operationExpectations.DeletionScheduled = false
 										operationExpectations.Reschedulable = false
@@ -1406,19 +1402,14 @@ var _ = DescribeTestsFor(TestCase{
 								})
 
 								if testCase.async {
-									XWhen("SM crashes while polling", func() {
-										var newCtx *TestContext
+									When("SM crashes while polling", func() {
+										var newSMCtx *TestContext
 										var isBound atomic.Value
 
-										postHookWithShutdownTimeout := func() func(e env.Environment, servers map[string]FakeServer) {
-											return func(e env.Environment, servers map[string]FakeServer) {
-												e.Set("server.shutdown_timeout", 1*time.Second)
-											}
-										}
-
 										BeforeEach(func() {
-											ctxMaintainerBuilder := t.ContextBuilder.WithEnvPostExtensions(postHookWithShutdownTimeout())
-											newCtx = ctxMaintainerBuilder.BuildWithoutCleanup()
+											newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+												e.Set("server.shutdown_timeout", 1*time.Second)
+											}).BuildWithoutCleanup()
 
 											brokerServer.BindingHandlerFunc(http.MethodDelete, http.MethodDelete+"1", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))
 											brokerServer.BindingLastOpHandlerFunc(http.MethodDelete+"1", func(_ *http.Request) (int, map[string]interface{}) {
@@ -1432,7 +1423,7 @@ var _ = DescribeTestsFor(TestCase{
 										})
 
 										It("should start restart polling through maintainer and eventually binding is set to ready", func() {
-											resp := deleteBinding(newCtx.SMWithOAuthForTenant, true, http.StatusAccepted)
+											resp := deleteBinding(newSMCtx.SMWithOAuthForTenant, true, http.StatusAccepted)
 
 											operationExpectations := OperationExpectations{
 												Category:          types.DELETE,
@@ -1442,15 +1433,20 @@ var _ = DescribeTestsFor(TestCase{
 												DeletionScheduled: false,
 											}
 
-											bindingID, _ = VerifyOperationExists(newCtx, resp.Header("Location").Raw(), operationExpectations)
+											bindingID, _ = VerifyOperationExists(newSMCtx, resp.Header("Location").Raw(), operationExpectations)
 											VerifyResourceExists(ctx.SMWithOAuthForTenant, ResourceExpectations{
 												ID:    bindingID,
 												Type:  types.ServiceBindingType,
 												Ready: true,
 											})
 
-											newCtx.CleanupAll(false)
+											newSMCtx.CleanupAll(false)
 											isBound.Store(true)
+
+											newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+												e.Set("operations.action_timeout", 2*time.Second)
+											}).BuildWithoutCleanup()
+											defer newSMCtx.CleanupAll(false)
 
 											operationExpectations.State = types.SUCCEEDED
 											operationExpectations.Reschedulable = false

--- a/test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_test/service_instance_test.go
@@ -19,13 +19,12 @@ package service_test
 import (
 	"context"
 	"fmt"
+	"github.com/Peripli/service-manager/operations"
+	"github.com/Peripli/service-manager/pkg/query"
 	"sync/atomic"
 	"time"
 
-	"github.com/Peripli/service-manager/operations"
 	"github.com/Peripli/service-manager/pkg/env"
-	"github.com/Peripli/service-manager/pkg/query"
-
 	"github.com/tidwall/gjson"
 
 	"github.com/Peripli/service-manager/pkg/util"
@@ -117,14 +116,6 @@ var _ = DescribeTestsFor(TestCase{
 					expectedDeleteSuccessStatusCode: http.StatusOK,
 					expectedBrokerFailureStatusCode: http.StatusBadGateway,
 					expectedSMCrashStatusCode:       http.StatusBadGateway,
-				},
-				{
-					async:                           true,
-					expectedCreateSuccessStatusCode: http.StatusAccepted,
-					expectedUpdateSuccessStatusCode: http.StatusAccepted,
-					expectedDeleteSuccessStatusCode: http.StatusAccepted,
-					expectedBrokerFailureStatusCode: http.StatusAccepted,
-					expectedSMCrashStatusCode:       http.StatusAccepted,
 				},
 			}
 
@@ -536,77 +527,6 @@ var _ = DescribeTestsFor(TestCase{
 								})
 							})
 
-							XWhen("SM crashes after storing operation before storing resource", func() {
-								var newCtx *TestContext
-
-								postHookWithShutdownTimeout := func() func(e env.Environment, servers map[string]FakeServer) {
-									return func(e env.Environment, servers map[string]FakeServer) {
-										e.Set("server.shutdown_timeout", 1*time.Second)
-										e.Set("httpclient.response_header_timeout", 1*time.Second)
-									}
-								}
-
-								BeforeEach(func() {
-									ctxMaintainerBuilder := t.ContextBuilder.WithEnvPostExtensions(postHookWithShutdownTimeout())
-									newCtx = ctxMaintainerBuilder.BuildWithoutCleanup()
-
-									brokerServer.ServiceInstanceHandlerFunc(http.MethodPut, http.MethodPut+"3", func(_ *http.Request) (int, map[string]interface{}) {
-										defer newCtx.CleanupAll(false)
-										return http.StatusOK, Object{"state": "in progress"}
-									})
-
-									brokerServer.ServiceInstanceHandlerFunc(http.MethodDelete, http.MethodDelete+"3", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))
-									brokerServer.ServiceInstanceLastOpHandlerFunc(http.MethodDelete+"3", func(_ *http.Request) (int, map[string]interface{}) {
-										return http.StatusOK, Object{"state": "succeeded"}
-									})
-								})
-
-								It("Should mark operation as failed and trigger orphan mitigation", func() {
-									opChan := make(chan *types.Operation)
-									defer close(opChan)
-
-									opCriteria := []query.Criterion{
-										query.ByField(query.EqualsOperator, "type", string(types.CREATE)),
-										query.ByField(query.EqualsOperator, "state", string(types.IN_PROGRESS)),
-										query.ByField(query.EqualsOperator, "resource_type", string(types.ServiceInstanceType)),
-										query.ByField(query.EqualsOperator, "reschedule", "false"),
-										query.ByField(query.EqualsOperator, "deletion_scheduled", operations.ZeroTime),
-									}
-
-									go func() {
-										for {
-											object, err := ctx.SMRepository.Get(context.TODO(), types.OperationType, opCriteria...)
-											if err == nil {
-												opChan <- object.(*types.Operation)
-												break
-											}
-										}
-									}()
-
-									createInstance(newCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedSMCrashStatusCode)
-									operation := <-opChan
-
-									VerifyResourceDoesNotExist(ctx.SMWithOAuthForTenant, ResourceExpectations{
-										ID:   operation.ResourceID,
-										Type: types.ServiceInstanceType,
-									})
-
-									operationExpectation := OperationExpectations{
-										Category:          types.CREATE,
-										State:             types.FAILED,
-										ResourceType:      types.ServiceInstanceType,
-										Reschedulable:     false,
-										DeletionScheduled: false,
-									}
-
-									instanceID, _ = VerifyOperationExists(ctx, fmt.Sprintf("%s/%s%s/%s", web.ServiceInstancesURL, operation.ResourceID, web.OperationsURL, operation.ID), operationExpectation)
-									VerifyResourceDoesNotExist(ctx.SMWithOAuthForTenant, ResourceExpectations{
-										ID:   instanceID,
-										Type: types.ServiceInstanceType,
-									})
-								})
-							})
-
 							When("broker responds with synchronous success", func() {
 								BeforeEach(func() {
 									brokerServer.ServiceInstanceHandlerFunc(http.MethodPut, http.MethodPut+"1", ParameterizedHandler(http.StatusCreated, Object{"async": false}))
@@ -692,19 +612,14 @@ var _ = DescribeTestsFor(TestCase{
 										})
 									})
 
-									XWhen("SM crashes while polling", func() {
-										var newCtx *TestContext
+									When("SM crashes while polling", func() {
+										var newSMCtx *TestContext
 										var isProvisioned atomic.Value
 
-										postHookWithShutdownTimeout := func() func(e env.Environment, servers map[string]FakeServer) {
-											return func(e env.Environment, servers map[string]FakeServer) {
-												e.Set("server.shutdown_timeout", 1*time.Second)
-											}
-										}
-
 										BeforeEach(func() {
-											ctxMaintainerBuilder := t.ContextBuilder.WithEnvPostExtensions(postHookWithShutdownTimeout())
-											newCtx = ctxMaintainerBuilder.BuildWithoutCleanup()
+											newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+												e.Set("server.shutdown_timeout", 1*time.Second)
+											}).BuildWithoutCleanup()
 
 											brokerServer.ServiceInstanceLastOpHandlerFunc(http.MethodPut+"1", func(_ *http.Request) (int, map[string]interface{}) {
 												if isProvisioned.Load() != nil {
@@ -715,8 +630,8 @@ var _ = DescribeTestsFor(TestCase{
 											})
 										})
 
-										It("should start restart polling through maintainer and eventually instance is set to ready", func() {
-											resp := createInstance(newCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedCreateSuccessStatusCode)
+										It("should restart polling through maintainer and eventually instance is set to ready", func() {
+											resp := createInstance(newSMCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedCreateSuccessStatusCode)
 
 											operationExpectation := OperationExpectations{
 												Category:          types.CREATE,
@@ -726,16 +641,20 @@ var _ = DescribeTestsFor(TestCase{
 												DeletionScheduled: false,
 											}
 
-											instanceID, _ = VerifyOperationExists(newCtx, resp.Header("Location").Raw(), operationExpectation)
-											VerifyResourceExists(newCtx.SMWithOAuthForTenant, ResourceExpectations{
+											instanceID, _ = VerifyOperationExists(newSMCtx, resp.Header("Location").Raw(), operationExpectation)
+											VerifyResourceExists(newSMCtx.SMWithOAuthForTenant, ResourceExpectations{
 												ID:    instanceID,
 												Type:  types.ServiceInstanceType,
 												Ready: false,
 											})
 
-											newCtx.CleanupAll(false)
-
+											newSMCtx.CleanupAll(false)
 											isProvisioned.Store(true)
+
+											newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+												e.Set("operations.action_timeout", 2*time.Second)
+											}).BuildWithoutCleanup()
+											defer newSMCtx.CleanupAll(false)
 
 											operationExpectation.State = types.SUCCEEDED
 											operationExpectation.Reschedulable = false
@@ -884,6 +803,75 @@ var _ = DescribeTestsFor(TestCase{
 								})
 							})
 
+							if testCase.async {
+								When("SM crashes after storing operation before storing resource", func() {
+									var newSMCtx *TestContext
+
+									BeforeEach(func() {
+										newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+											e.Set("server.shutdown_timeout", 1*time.Second)
+										}).BuildWithoutCleanup()
+
+										brokerServer.ServiceInstanceHandlerFunc(http.MethodDelete, http.MethodDelete+"3", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))
+										brokerServer.ServiceInstanceLastOpHandlerFunc(http.MethodDelete+"3", func(_ *http.Request) (int, map[string]interface{}) {
+											return http.StatusOK, Object{"state": "succeeded"}
+										})
+									})
+
+									It("Should mark operation as failed and trigger orphan mitigation", func() {
+										opChan := make(chan *types.Operation)
+										defer close(opChan)
+
+										opCriteria := []query.Criterion{
+											query.ByField(query.EqualsOperator, "type", string(types.CREATE)),
+											query.ByField(query.EqualsOperator, "state", string(types.IN_PROGRESS)),
+											query.ByField(query.EqualsOperator, "resource_type", string(types.ServiceInstanceType)),
+											query.ByField(query.EqualsOperator, "reschedule", "false"),
+											query.ByField(query.EqualsOperator, "deletion_scheduled", operations.ZeroTime),
+										}
+
+										go func() {
+											for {
+												object, err := ctx.SMRepository.Get(context.TODO(), types.OperationType, opCriteria...)
+												if err == nil {
+													newSMCtx.CleanupAll(false)
+													opChan <- object.(*types.Operation)
+													break
+												}
+											}
+										}()
+
+										createInstance(newSMCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedSMCrashStatusCode)
+										operation := <-opChan
+
+										VerifyResourceDoesNotExist(ctx.SMWithOAuthForTenant, ResourceExpectations{
+											ID:   operation.ResourceID,
+											Type: types.ServiceInstanceType,
+										})
+
+										anotherSMCtx := t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+											e.Set("operations.action_timeout", 2*time.Second)
+											e.Set("operations.cleanup_interval", 2*time.Second)
+										}).BuildWithoutCleanup()
+										defer anotherSMCtx.CleanupAll(false)
+
+										operationExpectation := OperationExpectations{
+											Category:          types.CREATE,
+											State:             types.FAILED,
+											ResourceType:      types.ServiceInstanceType,
+											Reschedulable:     false,
+											DeletionScheduled: false,
+										}
+
+										instanceID, _ = VerifyOperationExists(ctx, fmt.Sprintf("%s/%s%s/%s", web.ServiceInstancesURL, operation.ResourceID, web.OperationsURL, operation.ID), operationExpectation)
+										VerifyResourceDoesNotExist(ctx.SMWithOAuthForTenant, ResourceExpectations{
+											ID:   instanceID,
+											Type: types.ServiceInstanceType,
+										})
+									})
+								})
+							}
+
 							When("provision responds with error due to stopped broker", func() {
 								BeforeEach(func() {
 									brokerServer.Close()
@@ -1023,19 +1011,14 @@ var _ = DescribeTestsFor(TestCase{
 									})
 								}
 
-								XWhen("SM crashes while orphan mitigating", func() {
-									var newCtx *TestContext
+								When("SM crashes while orphan mitigating", func() {
+									var newSMCtx *TestContext
 									var isDeprovisioned atomic.Value
 
-									postHookWithShutdownTimeout := func() func(e env.Environment, servers map[string]FakeServer) {
-										return func(e env.Environment, servers map[string]FakeServer) {
-											e.Set("server.shutdown_timeout", 1*time.Second)
-										}
-									}
-
 									BeforeEach(func() {
-										ctxMaintainerBuilder := t.ContextBuilder.WithEnvPostExtensions(postHookWithShutdownTimeout())
-										newCtx = ctxMaintainerBuilder.BuildWithoutCleanup()
+										newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+											e.Set("server.shutdown_timeout", 1*time.Second)
+										}).BuildWithoutCleanup()
 
 										brokerServer.ServiceInstanceHandlerFunc(http.MethodDelete, http.MethodDelete+"3", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))
 										brokerServer.ServiceInstanceLastOpHandlerFunc(http.MethodDelete+"3", func(_ *http.Request) (int, map[string]interface{}) {
@@ -1048,7 +1031,7 @@ var _ = DescribeTestsFor(TestCase{
 									})
 
 									It("should restart orphan mitigation through maintainer and eventually succeeds", func() {
-										resp := createInstance(newCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedBrokerFailureStatusCode)
+										resp := createInstance(newSMCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedBrokerFailureStatusCode)
 
 										operationExpectations := OperationExpectations{
 											Category:          types.CREATE,
@@ -1058,11 +1041,15 @@ var _ = DescribeTestsFor(TestCase{
 											DeletionScheduled: true,
 										}
 
-										instanceID, _ = VerifyOperationExists(newCtx, resp.Header("Location").Raw(), operationExpectations)
+										instanceID, _ = VerifyOperationExists(newSMCtx, resp.Header("Location").Raw(), operationExpectations)
 
-										newCtx.CleanupAll(false)
-
+										newSMCtx.CleanupAll(false)
 										isDeprovisioned.Store(true)
+
+										newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+											e.Set("operations.action_timeout", 2*time.Second)
+										}).BuildWithoutCleanup()
+										defer newSMCtx.CleanupAll(false)
 
 										operationExpectations.DeletionScheduled = false
 										operationExpectations.Reschedulable = false
@@ -2117,19 +2104,14 @@ var _ = DescribeTestsFor(TestCase{
 								})
 
 								if testCase.async {
-									XWhen("SM crashes while polling", func() {
-										var newCtx *TestContext
+									When("SM crashes while polling", func() {
+										var newSMCtx *TestContext
 										var isDeprovisioned atomic.Value
 
-										postHookWithShutdownTimeout := func() func(e env.Environment, servers map[string]FakeServer) {
-											return func(e env.Environment, servers map[string]FakeServer) {
-												e.Set("server.shutdown_timeout", 1*time.Second)
-											}
-										}
-
 										BeforeEach(func() {
-											ctxMaintainerBuilder := t.ContextBuilder.WithEnvPostExtensions(postHookWithShutdownTimeout())
-											newCtx = ctxMaintainerBuilder.BuildWithoutCleanup()
+											newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+												e.Set("server.shutdown_timeout", 1*time.Second)
+											}).BuildWithoutCleanup()
 
 											brokerServer.ServiceInstanceLastOpHandlerFunc(http.MethodDelete+"1", func(_ *http.Request) (int, map[string]interface{}) {
 												if isDeprovisioned.Load() != nil {
@@ -2141,7 +2123,7 @@ var _ = DescribeTestsFor(TestCase{
 										})
 
 										It("should restart polling through maintainer and eventually deletes the instance", func() {
-											resp := deleteInstance(newCtx.SMWithOAuthForTenant, true, http.StatusAccepted)
+											resp := deleteInstance(newSMCtx.SMWithOAuthForTenant, true, http.StatusAccepted)
 
 											operationExpectations := OperationExpectations{
 												Category:          types.DELETE,
@@ -2151,16 +2133,20 @@ var _ = DescribeTestsFor(TestCase{
 												DeletionScheduled: false,
 											}
 
-											instanceID, _ = VerifyOperationExists(newCtx, resp.Header("Location").Raw(), operationExpectations)
-											VerifyResourceExists(newCtx.SMWithOAuthForTenant, ResourceExpectations{
+											instanceID, _ = VerifyOperationExists(newSMCtx, resp.Header("Location").Raw(), operationExpectations)
+											VerifyResourceExists(newSMCtx.SMWithOAuthForTenant, ResourceExpectations{
 												ID:    instanceID,
 												Type:  types.ServiceInstanceType,
 												Ready: true,
 											})
 
-											newCtx.CleanupAll(false)
-
+											newSMCtx.CleanupAll(false)
 											isDeprovisioned.Store(true)
+
+											newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
+												e.Set("operations.action_timeout", 2*time.Second)
+											}).BuildWithoutCleanup()
+											defer newSMCtx.CleanupAll(false)
 
 											operationExpectations.State = types.SUCCEEDED
 											operationExpectations.Reschedulable = false
@@ -2530,13 +2516,13 @@ var _ = DescribeTestsFor(TestCase{
 							})
 
 							When("deprovision responds with error due to times out", func() {
-								var newCtx *TestContext
+								var newSMCtx *TestContext
 								var doneChannel chan interface{}
 
 								BeforeEach(func() {
 									doneChannel = make(chan interface{})
 
-									newCtx = t.ContextBuilder.WithEnvPreExtensions(func(set *pflag.FlagSet) {
+									newSMCtx = t.ContextBuilder.WithEnvPreExtensions(func(set *pflag.FlagSet) {
 										Expect(set.Set("httpclient.response_header_timeout", (1 * time.Second).String())).ToNot(HaveOccurred())
 									}).BuildWithoutCleanup()
 
@@ -2544,15 +2530,15 @@ var _ = DescribeTestsFor(TestCase{
 								})
 
 								AfterEach(func() {
-									newCtx.CleanupAll(false)
+									newSMCtx.CleanupAll(false)
 								})
 
 								It("orphan mitigates the instance", func() {
-									resp := deleteInstance(newCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedBrokerFailureStatusCode)
+									resp := deleteInstance(newSMCtx.SMWithOAuthForTenant, testCase.async, testCase.expectedBrokerFailureStatusCode)
 									<-time.After(1100 * time.Millisecond)
 									close(doneChannel)
 
-									instanceID, _ = VerifyOperationExists(newCtx, resp.Header("Location").Raw(), OperationExpectations{
+									instanceID, _ = VerifyOperationExists(newSMCtx, resp.Header("Location").Raw(), OperationExpectations{
 										Category:          types.DELETE,
 										State:             types.FAILED,
 										ResourceType:      types.ServiceInstanceType,
@@ -2562,7 +2548,7 @@ var _ = DescribeTestsFor(TestCase{
 
 									brokerServer.ServiceInstanceHandlerFunc(http.MethodDelete, http.MethodDelete+"1", ParameterizedHandler(http.StatusOK, Object{"async": false}))
 
-									instanceID, _ = VerifyOperationExists(newCtx, resp.Header("Location").Raw(), OperationExpectations{
+									instanceID, _ = VerifyOperationExists(newSMCtx, resp.Header("Location").Raw(), OperationExpectations{
 										Category:          types.DELETE,
 										State:             types.SUCCEEDED,
 										ResourceType:      types.ServiceInstanceType,

--- a/test/test.go
+++ b/test/test.go
@@ -62,20 +62,7 @@ const (
 
 	Sync  ResponseMode = false
 	Async ResponseMode = true
-
-	JobTimeout          = 15 * time.Second
-	cleanupInterval     = 60 * time.Second
-	operationExpiration = 60 * time.Second
 )
-
-func postHookWithOperationsConfig() func(e env.Environment, servers map[string]common.FakeServer) {
-	return func(e env.Environment, servers map[string]common.FakeServer) {
-		e.Set("operations.action_timeout", JobTimeout)
-		e.Set("operations.cleanup_interval", cleanupInterval)
-		e.Set("operations.lifespan", operationExpiration)
-		e.Set("operations.reconciliation_operation_timeout", 9999*time.Hour)
-	}
-}
 
 type MultitenancySettings struct {
 	ClientID           string
@@ -221,7 +208,7 @@ func DescribeTestsFor(t TestCase) bool {
 		})
 
 		ctxBuilder := func() *common.TestContextBuilder {
-			ctxBuilder := common.NewTestContextBuilderWithSecurity().WithEnvPostExtensions(postHookWithOperationsConfig())
+			ctxBuilder := common.NewTestContextBuilderWithSecurity()
 
 			if t.MultitenancySettings != nil {
 				ctxBuilder.


### PR DESCRIPTION
# Fix Rescheduling of Instance/Binding operations

## Motivation

Rescheduling of CREATE/UPDATE operation by maintainer fails for instance/binding resources due to unique constraint violation as the interceptors enforcing uniqueness of instance/binding names find the instance/binding resources in SM DB (they are with ready=false) when trying to reschedule the operation.

This change tweaks the two uniqueness interceptors, but also more importantly enables the previously disabled maintainer tests (which test the rescheduling mechanism), which had been previously failing remotely on Travis. Due to those tests having been disabled we weren't able to detect the rescheduling bug when the unique instance/binding name interceptors were initially introduced.

## Pull Request status

* [x] Initial implementation
* [x] Integration tests