### PR TITLE
Allow Broker Catalog ID updates

### DIFF
--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -1273,17 +1273,47 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							var expectedCatalog string
 
 							BeforeEach(func() {
-								expectedCatalog = string(brokerServer.Catalog)
 								catalog, err := sjson.Set(string(brokerServer.Catalog), "services.0.id", "new-id")
 								Expect(err).ToNot(HaveOccurred())
+
+								expectedCatalog = catalog
 
 								brokerServer.Catalog = SBCatalog(catalog)
 							})
 
-							It("returns 409", func() {
-								ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL+"/"+brokerID).WithJSON(postBrokerRequestWithNoLabels).
+							It("returns 200", func() {
+								ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerID).WithJSON(postBrokerRequestWithNoLabels).
 									Expect().
-									Status(http.StatusConflict).JSON().Object().Keys().Contains("error", "description")
+									Status(http.StatusOK)
+
+								assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
+							})
+
+							Specify("the catalog before the modification is returned by the repository", func() {
+								assertRepositoryReturnsExpectedCatalogAfterPatching(brokerID, expectedCatalog)
+
+							})
+						})
+
+						Context("when both catalog service id and service plan id are modified but the catalog names are not", func() {
+							var expectedCatalog string
+
+							BeforeEach(func() {
+								catalog, err := sjson.Set(string(brokerServer.Catalog), "services.0.id", "new-svc-id")
+								Expect(err).ToNot(HaveOccurred())
+
+								catalog, err = sjson.Set(string(brokerServer.Catalog), "services.0.plans.0.id", "new-plan-id")
+								Expect(err).ToNot(HaveOccurred())
+
+								expectedCatalog = catalog
+
+								brokerServer.Catalog = SBCatalog(catalog)
+							})
+
+							It("returns 200", func() {
+								ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerID).WithJSON(postBrokerRequestWithNoLabels).
+									Expect().
+									Status(http.StatusOK)
 
 								assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
 							})
@@ -1454,18 +1484,18 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							var expectedCatalog string
 
 							BeforeEach(func() {
-								expectedCatalog = string(brokerServer.Catalog)
-
 								catalog, err := sjson.Set(string(brokerServer.Catalog), "services.0.plans.0.id", "new-id")
 								Expect(err).ToNot(HaveOccurred())
+
+								expectedCatalog = catalog
 
 								brokerServer.Catalog = SBCatalog(catalog)
 							})
 
-							It("returns 409", func() {
-								ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL+"/"+brokerID).WithJSON(postBrokerRequestWithNoLabels).
+							It("returns 200", func() {
+								ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerID).WithJSON(postBrokerRequestWithNoLabels).
 									Expect().
-									Status(http.StatusConflict).JSON().Object().Keys().Contains("error", "description")
+									Status(http.StatusOK)
 
 								assertInvocationCount(brokerServer.CatalogEndpointRequests, 1)
 							})


### PR DESCRIPTION
# Allow Broker Catalog ID updates

## Motivation

Brokers could have their service and plan catalog IDs updated. Currently SM doesn't allow this because when inserting the new offering/planas there will be duplicate (broker_id, service_offering_name) and (service_offering_id, name) pairs which violates the unique constraint in the DB.

## Approach

Ensure that the old offering/plan is deleted before trying to create the new one.

## Pull Request status

* [x] Initial implementation
* [x] Integration tests