### PR TITLE
Remove unnecessary log message

### DIFF
--- a/api/base_controller.go
+++ b/api/base_controller.go
@@ -313,7 +313,7 @@ func (c *BaseController) GetSingleObject(r *web.Request) (*web.Response, error) 
 		return nil, util.HandleStorageError(err, c.objectType.String())
 	}
 
-	cleanObject(ctx, object)
+	cleanObject(object)
 
 	if err := attachLastOperation(ctx, objectID, object, r, c.repository); err != nil {
 		return nil, err
@@ -489,15 +489,13 @@ func (c *BaseController) PatchObject(r *web.Request) (*web.Response, error) {
 		return nil, util.HandleStorageError(err, c.objectType.String())
 	}
 
-	cleanObject(ctx, object)
+	cleanObject(object)
 	return util.NewJSONResponse(http.StatusOK, object)
 }
 
-func cleanObject(ctx context.Context, object types.Object) {
+func cleanObject(object types.Object) {
 	if secured, ok := object.(types.Strip); ok {
 		secured.Sanitize()
-	} else {
-		log.C(ctx).Debugf("Object of type %s with id %s is not secured, so no credentials are cleaned up on response", object.GetType(), object.GetID())
 	}
 }
 
@@ -611,7 +609,7 @@ func pageFromObjectList(ctx context.Context, objectList types.ObjectList, count,
 
 	for i := 0; i < objectList.Len(); i++ {
 		obj := objectList.ItemAt(i)
-		cleanObject(ctx, obj)
+		cleanObject(obj)
 		page.Items = append(page.Items, obj)
 	}
 


### PR DESCRIPTION
When listing objects different from brokers or platforms we get many messages like these in the log
```
Mar 18, 2020 @ 09:33:37.786	service-manager-new	21f21e3f-b7e2-446e-5b32-a7322d4dfecb	DEBUG	api/base_controller.go:502	Object of type /v1/service_plans with id 0cfba1f9-71fb-4389-831a-e55dd781dbbf is not secured, so no credentials are cleaned up on response
Mar 18, 2020 @ 09:33:37.786	service-manager-new	21f21e3f-b7e2-446e-5b32-a7322d4dfecb	DEBUG	api/base_controller.go:502	Object of type /v1/service_plans with id 74441f5b-44c5-4b99-97ee-8ae04ab77edd is not secured, so no credentials are cleaned up on response
Mar 18, 2020 @ 09:33:37.786	service-manager-new	21f21e3f-b7e2-446e-5b32-a7322d4dfecb	DEBUG	api/base_controller.go:502	Object of type /v1/service_plans with id 1e63178a-356d-42ee-bd91-c2f29efda262 is not secured, so no credentials are cleaned up on response
Mar 18, 2020 @ 09:33:37.786	service-manager-new	21f21e3f-b7e2-446e-5b32-a7322d4dfecb	DEBUG	api/base_controller.go:502	Object of type /v1/service_plans with id 89feb0a4-8c22-42b3-b640-1628c7cb034a is not secured, so no credentials are cleaned up on response
```
Remove these