### PR TITLE
Change filter order of plugins

### DIFF
--- a/pkg/web/api.go
+++ b/pkg/web/api.go
@@ -167,8 +167,8 @@ func (api *API) RegisterPluginsBefore(beforePluginName string, plugins ...Plugin
 		}
 
 		pluginSegments := api.decomposePluginOrDie(plugin)
+		beforePluginFirstFilterName := api.getFirstFilterNameOfPlugin(beforePluginName)
 		for _, pluginSegment := range pluginSegments {
-			beforePluginFirstFilterName := api.getFirstFilterNameOfPlugin(beforePluginName)
 			api.registerFilterRelatively(beforePluginFirstFilterName, pluginSegment, func(beforeFilterPosition int) int {
 				return beforeFilterPosition
 			})

--- a/pkg/web/api.go
+++ b/pkg/web/api.go
@@ -168,12 +168,23 @@ func (api *API) RegisterPluginsBefore(beforePluginName string, plugins ...Plugin
 
 		pluginSegments := api.decomposePluginOrDie(plugin)
 		for _, pluginSegment := range pluginSegments {
-			split := strings.Split(pluginSegment.Name(), ":")
-			api.registerFilterRelatively(beforePluginName+":"+split[1], pluginSegment, func(beforeFilterPosition int) int {
+			beforePluginFirstFilterName := api.getFirstFilterNameOfPlugin(beforePluginName)
+			api.registerFilterRelatively(beforePluginFirstFilterName, pluginSegment, func(beforeFilterPosition int) int {
 				return beforeFilterPosition
 			})
 		}
 	}
+}
+
+func (api *API) getFirstFilterNameOfPlugin(pluginName string) string {
+	for _, name := range api.filterNames(api.Filters) {
+		nameParts := strings.Split(name, ":")
+		if nameParts[0] == pluginName {
+			return name
+		}
+	}
+
+	return ""
 }
 
 func (api *API) validateFilters(filters ...Filter) {

--- a/pkg/web/api_test.go
+++ b/pkg/web/api_test.go
@@ -129,7 +129,7 @@ var _ = Describe("API", func() {
 				})
 			})
 			When("the plugins are ordered relatively", func() {
-				It("adds all plugin filters before all filters of the plugin before it", func() {
+				It("adds all plugin filters before all filters of the plugins before it", func() {
 					api.RegisterPlugins(&validPlugin{"third-plugin"})
 					api.RegisterPluginsBefore("third-plugin", &partialPlugin{"second-plugin"})
 					api.RegisterPluginsBefore("second-plugin", &validPlugin{"first-plugin"})

--- a/pkg/web/api_test.go
+++ b/pkg/web/api_test.go
@@ -128,6 +128,34 @@ var _ = Describe("API", func() {
 					}))
 				})
 			})
+			When("the plugins are ordered relatively", func() {
+				It("adds all plugin filters before all filters of the plugin before it", func() {
+					api.RegisterPlugins(&validPlugin{"third-plugin"})
+					api.RegisterPluginsBefore("third-plugin", &partialPlugin{"second-plugin"})
+					api.RegisterPluginsBefore("second-plugin", &validPlugin{"first-plugin"})
+					names := filterNames()
+					Expect(names).To(Equal([]string{
+						"first-plugin:FetchCatalog",
+						"first-plugin:FetchService",
+						"first-plugin:Provision",
+						"first-plugin:UpdateService",
+						"first-plugin:Deprovision",
+						"first-plugin:FetchBinding",
+						"first-plugin:Bind",
+						"first-plugin:Unbind",
+						"second-plugin:Provision",
+						"second-plugin:Deprovision",
+						"third-plugin:FetchCatalog",
+						"third-plugin:FetchService",
+						"third-plugin:Provision",
+						"third-plugin:UpdateService",
+						"third-plugin:Deprovision",
+						"third-plugin:FetchBinding",
+						"third-plugin:Bind",
+						"third-plugin:Unbind",
+					}))
+				})
+			})
 		})
 	})
 

--- a/pkg/web/api_test.go
+++ b/pkg/web/api_test.go
@@ -91,22 +91,42 @@ var _ = Describe("API", func() {
 				names := filterNames()
 				Expect(names).To(Equal([]string{
 					"before-existing-plugin:FetchCatalog",
-					"existing-plugin:FetchCatalog",
 					"before-existing-plugin:FetchService",
-					"existing-plugin:FetchService",
 					"before-existing-plugin:Provision",
-					"existing-plugin:Provision",
 					"before-existing-plugin:UpdateService",
-					"existing-plugin:UpdateService",
 					"before-existing-plugin:Deprovision",
-					"existing-plugin:Deprovision",
 					"before-existing-plugin:FetchBinding",
-					"existing-plugin:FetchBinding",
 					"before-existing-plugin:Bind",
-					"existing-plugin:Bind",
 					"before-existing-plugin:Unbind",
+					"existing-plugin:FetchCatalog",
+					"existing-plugin:FetchService",
+					"existing-plugin:Provision",
+					"existing-plugin:UpdateService",
+					"existing-plugin:Deprovision",
+					"existing-plugin:FetchBinding",
+					"existing-plugin:Bind",
 					"existing-plugin:Unbind",
 				}))
+			})
+
+			When("the existing plugin does not implement all plugin interfaces", func() {
+				It("adds the plugin before it", func() {
+					api.RegisterPlugins(&partialPlugin{"partial-plugin"})
+					api.RegisterPluginsBefore("partial-plugin", &validPlugin{"before-partial-plugin"})
+					names := filterNames()
+					Expect(names).To(Equal([]string{
+						"before-partial-plugin:FetchCatalog",
+						"before-partial-plugin:FetchService",
+						"before-partial-plugin:Provision",
+						"before-partial-plugin:UpdateService",
+						"before-partial-plugin:Deprovision",
+						"before-partial-plugin:FetchBinding",
+						"before-partial-plugin:Bind",
+						"before-partial-plugin:Unbind",
+						"partial-plugin:Provision",
+						"partial-plugin:Deprovision",
+					}))
+				})
 			})
 		})
 	})
@@ -324,4 +344,20 @@ func (c *validPlugin) FetchCatalog(request *web.Request, next web.Handler) (*web
 
 func (c *validPlugin) Name() string {
 	return c.name
+}
+
+type partialPlugin struct {
+	name string
+}
+
+func (c *partialPlugin) Name() string {
+	return c.name
+}
+
+func (c *partialPlugin) Provision(request *web.Request, next web.Handler) (*web.Response, error) {
+	return next.Handle(request)
+}
+
+func (c *partialPlugin) Deprovision(request *web.Request, next web.Handler) (*web.Response, error) {
+	return next.Handle(request)
 }


### PR DESCRIPTION
## Motivation

When we want to register one plugin after another, the plugins are decomposed and their filters are ordered with respect to the implemented plugin interfaces.

Let's say we have three plugins: `First`, `Second` and `Third`.
`First` implements `Provisioner`, `InstanceUpdater` and `Deprovisioner`
`Second` implements only `Provisioner`
`Third` implements `Provisioner` and `Deprovisioner`. 

Currently, if we want to register the plugins as `First`, `Second` and then `Third` using the `RegisterPluginsBefore` method, their filters will have the following order:
- `First:Provision`
- `Second:Provision`
- `Third:Provision`
- `Third:Deprovision`
- `First:InstanceUpdater`
- `First:Deprovision`

## Approach

This PR changes the ordering logic as it places all filters that belong to a plugin one after another, and does not allow filters from other plugins between them.

## Pull Request status

* [x] Refactoring
* [x] Unit tests
* [ ] Integration tests
