### PR TITLE
Configure default http client timeout

### DIFF
--- a/api/osb/catalog_fetcher.go
+++ b/api/osb/catalog_fetcher.go
@@ -63,7 +63,7 @@ func CatalogFetcher(doRequestFunc util.DoRequestFunc, brokerAPIVersion string) f
 				return nil, &util.HTTPError{
 					ErrorType:   "ServiceBrokerErr",
 					Description: fmt.Sprintf("error fetching catalog for broker with name %s: timed out", broker.Name),
-					StatusCode:  http.StatusBadGateway,
+					StatusCode:  http.StatusGatewayTimeout,
 				}
 			}
 			return nil, fmt.Errorf("error getting content from body of response with status %s: %s", response.Status, err)

--- a/application.yml
+++ b/application.yml
@@ -5,6 +5,7 @@ server:
   # max_body_bytes: 4000
   # max_header_bytes: 1000
 httpclient:
+  timeout: 15000ms
   response_header_timeout: 10000ms
   tls_handshake_timeout: 10000ms
   idle_conn_timeout: 10000ms

--- a/storage/interceptable_repository.go
+++ b/storage/interceptable_repository.go
@@ -273,7 +273,7 @@ func (ir *queryScopedInterceptableRepository) Update(ctx context.Context, obj ty
 		}
 
 		operation, found := opcontext.Get(ctx)
-		if found && operation.ResourceID != object.GetID() && operation.ID != object.GetID() {
+		if found && operation.ResourceID != object.GetID() && operation.ID != object.GetID() && object.GetType() != types.OperationType {
 			operation.TransitiveResources = append(operation.TransitiveResources, &types.RelatedType{
 				ID:            object.GetID(),
 				Type:          object.GetType(),

--- a/storage/interceptable_repository.go
+++ b/storage/interceptable_repository.go
@@ -273,7 +273,7 @@ func (ir *queryScopedInterceptableRepository) Update(ctx context.Context, obj ty
 		}
 
 		operation, found := opcontext.Get(ctx)
-		if found && operation.ResourceID != object.GetID() {
+		if found && operation.ResourceID != object.GetID() && operation.ID != object.GetID() {
 			operation.TransitiveResources = append(operation.TransitiveResources, &types.RelatedType{
 				ID:            object.GetID(),
 				Type:          object.GetType(),

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -3,10 +3,11 @@ server:
   shutdown_timeout: 4000ms
   port: 1234
 httpclient:
-  response_header_timeout: 40000ms
-  tls_handshake_timeout: 4000ms
-  idle_conn_timeout: 4000ms
-  dial_timeout: 4000ms
+  timeout: 1000ms
+  response_header_timeout: 1000ms
+  tls_handshake_timeout: 1000ms
+  idle_conn_timeout: 1000ms
+  dial_timeout: 1000ms
 websocket:
   ping_timeout: 4000ms
   write_timeout: 4000ms

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -81,6 +81,7 @@ type TestContext struct {
 	wg            *sync.WaitGroup
 	wsConnections []*websocket.Conn
 
+	Config      *config.Settings
 	SM          *SMExpect
 	SMWithOAuth *SMExpect
 	// Requests a token the the "multitenant" oauth client - then token issued by this client contains
@@ -341,7 +342,7 @@ func (tcb *TestContextBuilder) BuildWithListener(listener net.Listener, cleanup 
 	}
 	wg := &sync.WaitGroup{}
 
-	smServer, smRepository, smScheduler := newSMServer(environment, wg, tcb.smExtensions, listener)
+	smServer, smRepository, smScheduler, config := newSMServer(environment, wg, tcb.smExtensions, listener)
 	tcb.Servers[SMServer] = smServer
 
 	SM := httpexpect.New(ginkgo.GinkgoT(), smServer.URL())
@@ -359,6 +360,7 @@ func (tcb *TestContextBuilder) BuildWithListener(listener net.Listener, cleanup 
 
 	testContext := &TestContext{
 		wg:                   wg,
+		Config:               config,
 		SM:                   &SMExpect{Expect: SM},
 		SMWithOAuth:          &SMExpect{Expect: SMWithOAuth},
 		SMWithOAuthForTenant: &SMExpect{Expect: SMWithOAuthForTenant},
@@ -415,7 +417,7 @@ func NewSMListener() (net.Listener, error) {
 	return nil, fmt.Errorf("unable to create sm listener: %s", err)
 }
 
-func newSMServer(smEnv env.Environment, wg *sync.WaitGroup, fs []func(ctx context.Context, smb *sm.ServiceManagerBuilder, env env.Environment) error, listener net.Listener) (*testSMServer, storage.TransactionalRepository, *operations.Scheduler) {
+func newSMServer(smEnv env.Environment, wg *sync.WaitGroup, fs []func(ctx context.Context, smb *sm.ServiceManagerBuilder, env env.Environment) error, listener net.Listener) (*testSMServer, storage.TransactionalRepository, *operations.Scheduler, *config.Settings) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	cfg, err := config.New(smEnv)
@@ -455,7 +457,7 @@ func newSMServer(smEnv env.Environment, wg *sync.WaitGroup, fs []func(ctx contex
 	return &testSMServer{
 		cancel: cancel,
 		Server: testServer,
-	}, smb.Storage, scheduler
+	}, smb.Storage, scheduler, cfg
 }
 
 func (ctx *TestContext) RegisterBrokerWithCatalogAndLabels(catalog SBCatalog, brokerData Object) (string, Object, *BrokerServer) {

--- a/test/configuration_test/configuration_test.go
+++ b/test/configuration_test/configuration_test.go
@@ -69,11 +69,11 @@ var _ = Describe("Service Manager Config API", func() {
 					}
 				},
 				"httpclient": {
-					"dial_timeout": "4000ms",
-					"idle_conn_timeout": "4000ms",
-					"response_header_timeout": "40000ms",
+					"dial_timeout": "1000ms",
+					"idle_conn_timeout": "1000ms",
+					"response_header_timeout": "1000ms",
 					"skip_ssl_validation": false,
-					"tls_handshake_timeout": "4000ms"
+					"tls_handshake_timeout": "1000ms"
 				},
 				"log": {
 					"format": "text",

--- a/test/osb_test/osb_suite_test.go
+++ b/test/osb_test/osb_suite_test.go
@@ -22,12 +22,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Peripli/service-manager/test"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Peripli/service-manager/test"
 
 	"github.com/Peripli/service-manager/pkg/env"
 	"github.com/Peripli/service-manager/pkg/multitenancy"
@@ -105,7 +106,9 @@ type brokerPlatformCredentials struct {
 
 var _ = BeforeSuite(func() {
 	ctx = common.NewTestContextBuilderWithSecurity().WithEnvPreExtensions(func(set *pflag.FlagSet) {
+		Expect(set.Set("server.request_timeout", timeoutDuration.String())).ToNot(HaveOccurred())
 		Expect(set.Set("httpclient.response_header_timeout", timeoutDuration.String())).ToNot(HaveOccurred())
+		Expect(set.Set("httpclient.timeout", timeoutDuration.String())).ToNot(HaveOccurred())
 	}).WithSMExtensions(func(ctx context.Context, smb *sm.ServiceManagerBuilder, e env.Environment) error {
 		smb.EnableMultitenancy(TenantIdentifier, func(request *web.Request) (string, error) {
 			extractTenantFromToken := multitenancy.ExtractTenantFromTokenWrapperFunc("zid")


### PR DESCRIPTION
## Motivation

There are a few different aspects of these timeouts:

1. OSB calls via the /v1/osb API of Service Manager:
  - Calls for get catalog are done via CatalogFetcher which uses the default http client which was not configured.
  - Calls for all other requests are done via reverse proxy, which does not know when it should cancel the request, because the context is not cancelled on server.request_timeout. The only time it will time out is when the headers are not yet received. But if there is a "bad broker" which has returned headers, but is streaming the response very slowly, we will wait for the response forever. This can be fixed with something like [http.TimeoutHandler](https://golang.org/pkg/net/http/#TimeoutHandler). There is a branch with implementation: https://github.com/Peripli/service-manager/tree/handler_timeouts.
2. OSB calls via SM Write APIs
  - Calls are done via osb client which is initialized with http client that has configured timeout for the whole request, so they do not suffer the above problem

If you need to reproduce some of the scenarios let me know and I will attach the broker servers and scripts to reproduce.

## Pull Request status

* [x] Initial implementation
* [ ] Refactoring
* [x] Unit tests

