### PR TITLE
Adjust http client test timeouts

### DIFF
--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -687,7 +687,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				})
 
 				Context("when broker is responding slow", func() {
-					FIt("should timeout", func() {
+					It("should timeout", func() {
 						brokerServer.CatalogHandler = func(rw http.ResponseWriter, req *http.Request) {
 							rw.WriteHeader(http.StatusOK)
 							if fl, ok := rw.(http.Flusher); ok {

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -19,12 +19,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Peripli/service-manager/test/tls_settings"
 	"net/http"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Peripli/service-manager/test/tls_settings"
 
 	"github.com/Peripli/service-manager/pkg/httpclient"
 	"github.com/Peripli/service-manager/pkg/web"
@@ -686,11 +687,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				})
 
 				Context("when broker is responding slow", func() {
-					It("should timeout", func() {
+					FIt("should timeout", func() {
 						brokerServer.CatalogHandler = func(rw http.ResponseWriter, req *http.Request) {
 							rw.WriteHeader(http.StatusOK)
 							if fl, ok := rw.(http.Flusher); ok {
-								for i := 0; i < 30; i++ {
+								for i := 0; i < 50; i++ {
 									fmt.Fprintf(rw, "Chunk %d", i)
 									fl.Flush()
 									time.Sleep(time.Millisecond * 100)

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -3,12 +3,12 @@ server:
   shutdown_timeout: 4000ms
   port: 1234
 httpclient:
-  timeout: 1000ms
-  response_header_timeout: 1000ms
-  tls_handshake_timeout: 1000ms
-  idle_conn_timeout: 1000ms
+  timeout: 4000ms
+  response_header_timeout: 4000ms
+  tls_handshake_timeout: 4000ms
+  idle_conn_timeout: 4000ms
   skip_ssl_validation: true
-  dial_timeout: 1000ms
+  dial_timeout: 4000ms
 websocket:
   ping_timeout: 4000ms
   write_timeout: 4000ms

--- a/test/configuration_test/configuration_test.go
+++ b/test/configuration_test/configuration_test.go
@@ -69,11 +69,12 @@ var _ = Describe("Service Manager Config API", func() {
 					}
 				},
 				"httpclient": {
-					"dial_timeout": "1000ms",
-					"idle_conn_timeout": "1000ms",
-					"response_header_timeout": "1000ms",
+					"timeout": "4000ms",
+					"dial_timeout": "4000ms",
+					"idle_conn_timeout": "4000ms",
+					"response_header_timeout": "4000ms",
 					"skip_ssl_validation": true,
-					"tls_handshake_timeout": "1000ms"
+					"tls_handshake_timeout": "4000ms"
 				},
 				"log": {
 					"format": "text",


### PR DESCRIPTION
## Motivation

Tests are failing sporadically on Travis for the operations maintainer. So increase the timeouts that they should not fail because of timeouts