### PR TITLE
Allow Broker Platform Credential Rotation during full resync in K8S platforms

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -85,12 +85,12 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
+  digest = "1:80057945464ffb5b0da1f026beb8df0e8dbd098eaf771a349291bed2cd29a83e"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
-  version = "v1.4.7"
+  revision = "45d7d09e39ef4ac08d493309fa031790c15bfe8a"
+  version = "v1.4.9"
 
 [[projects]]
   digest = "1:2d2a4b9fce4d0a808476e6388fc8ab4d43f1fe5da52fb3e9a088486cc745ed89"
@@ -167,8 +167,8 @@
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   pruneopts = "UT"
-  revision = "5d5b4c10bd43f85e63bd9e4a3fa9b1ea2ef88af2"
-  version = "v1.3.4"
+  revision = "84668698ea25b64748563aa20726db66a6b8d299"
+  version = "v1.3.5"
 
 [[projects]]
   digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
@@ -195,12 +195,12 @@
   version = "v1.6.1"
 
 [[projects]]
-  digest = "1:e62657cca9badaa308d86e7716083e4c5933bb78e30a17743fc67f50be26f6f4"
+  digest = "1:6d29f02f0f01c627c2be40fb7347669a9ff2aa215cb97747294c1d13ffa74bdd"
   name = "github.com/gorilla/websocket"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c3e18be99d19e6b3e8f1559eea2c161a665c4b6b"
-  version = "v1.4.1"
+  revision = "b65e62901fc1c0d968042419e74789f6af455eb9"
+  version = "v1.4.2"
 
 [[projects]]
   digest = "1:c0d19ab64b32ce9fe5cf4ddceba78d5bc9807f0016db6b1183599da3dcc24d10"
@@ -245,7 +245,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9d697efc0ad1d6ee43708e8fc822861a66107d03f95d2b398ef488305500140a"
+  digest = "1:5f7995e31baca7f9f00534818e69b5a0aadae6fcf3689e9fdcce9d487db45022"
   name = "github.com/jmoiron/sqlx"
   packages = [
     ".",
@@ -253,7 +253,7 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "2ba0fc60eb4a54030f3a6d73ff0a047349c7eeca"
+  revision = "ee514944af4b0d1b90212831674e03df1b850998"
 
 [[projects]]
   digest = "1:e5e0d775194850f7f06c78f51015ec7c85a59a62613d1ad9847b5ba0f2a021c8"
@@ -264,8 +264,8 @@
     "zlib",
   ]
   pruneopts = "UT"
-  revision = "d4b3bb13d45b000ac3a915d4f32069a9284540bb"
-  version = "v1.10.2"
+  revision = "788b7f06fee85b7e1d2aa4a3a86f8dbbbcc771ae"
+  version = "v1.10.3"
 
 [[projects]]
   digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
@@ -285,7 +285,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e8501d7fa801be523f103178ced935b37778925c7338f0f94e50c14a4d450f4a"
+  digest = "1:00a8bb2a5d9b736e4f8c5f3f3bc0b73aeb0ef1b91e63f72f322750370a3b3757"
   name = "github.com/lib/pq"
   packages = [
     ".",
@@ -293,7 +293,7 @@
     "scram",
   ]
   pruneopts = "UT"
-  revision = "9eb3fc897d6fd97dd4aad3d0404b54e2f7cc56be"
+  revision = "356e267cd3f45ee1303b7d8765e3583cb949950e"
 
 [[projects]]
   digest = "1:5a0ef768465592efca0412f7e838cdc0826712f8447e70e6ccc52eb441e9ab13"
@@ -304,12 +304,12 @@
   version = "v1.8.1"
 
 [[projects]]
-  digest = "1:53bc4cd4914cd7cd52139990d5170d6dc99067ae31c56530621b18b35fc30318"
+  digest = "1:6ea2d98ba8ae7c06a918970661b744be5d1a385c40917b9c317e9a4f2c36ac6f"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3536a929edddb9a5b34bd6861dc4a9647cb459fe"
-  version = "v1.1.2"
+  revision = "694aaefbc689be1915c2ef39e880409057931a94"
+  version = "v1.2.2"
 
 [[projects]]
   digest = "1:7aefb397a53fc437c90f0fdb3e1419c751c5a3a165ced52325d5d797edf1aca6"
@@ -378,12 +378,12 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:6eea828983c70075ca297bb915ffbcfd3e34c5a50affd94428a65df955c0ff9c"
+  digest = "1:1d835d5c3153aceef96c2d58866edde1aa70e25339831cff07b1e47456410e5c"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
   pruneopts = "UT"
-  revision = "903d9455db9ff1d7ac1ab199062eca7266dd11a3"
-  version = "v1.6.0"
+  revision = "8e8d2a6aad23fcaa64716c5fa6975ec3abbf8281"
+  version = "v1.7.0"
 
 [[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
@@ -499,12 +499,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:b70c951ba6fdeecfbd50dabe95aa5e1b973866ae9abbece46ad60348112214f2"
+  digest = "1:d6144d834c1d542969d499093cb6df7e0dbaebfb510bdda5648fd35ea4aee7c3"
   name = "github.com/tidwall/sjson"
   packages = ["."]
   pruneopts = "UT"
-  revision = "25fb082a20e29e83fb7b7ef5f5919166aad1f084"
-  version = "v1.0.4"
+  revision = "11cb24d8421de3e1bb5c5efb066a03037150568d"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:c468422f334a6b46a19448ad59aaffdfc0a36b08fdcc1c749a0b29b6453d7e59"
@@ -588,7 +588,7 @@
     "pbkdf2",
   ]
   pruneopts = "UT"
-  revision = "78000ba7a073cafc0278790f6bce552a0f25850e"
+  revision = "baeed622b8d86045ff442b324772b0ad306a2b3f"
 
 [[projects]]
   branch = "master"
@@ -604,7 +604,7 @@
     "publicsuffix",
   ]
   pruneopts = "UT"
-  revision = "244492dfa37ae2ce87222fd06250a03160745faa"
+  revision = "d3edc9973b7eb1fb302b0ff2c62357091cea9a30"
 
 [[projects]]
   branch = "master"
@@ -619,11 +619,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8d59aa6f03198132e0ca3bf998677f9698e1e27fc67976c85d85086ac3496530"
+  digest = "1:842f1500cf319662226ee2f897aa1bf5e9228bb851af8a9aaef5c425fe90f14e"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "5c8b2ff67527cb88b770f693cebf3799036d8bc0"
+  revision = "c3d80250170dec19bf61949c81233cede5ddaf61"
 
 [[projects]]
   digest = "1:28deae5fe892797ff37a317b5bcda96d11d1c90dadd89f1337651df3bc4c586e"
@@ -679,13 +679,13 @@
   version = "v1.6.5"
 
 [[projects]]
-  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
+  digest = "1:80057945464ffb5b0da1f026beb8df0e8dbd098eaf771a349291bed2cd29a83e"
   name = "gopkg.in/fsnotify.v1"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  revision = "45d7d09e39ef4ac08d493309fa031790c15bfe8a"
   source = "https://github.com/fsnotify/fsnotify.git"
-  version = "v1.4.7"
+  version = "v1.4.9"
 
 [[projects]]
   digest = "1:3c4aaca5a82adc021322f239e0cf3f46852bb0b18ae050d0feab2e9e4c527462"

--- a/api/credentials_controller.go
+++ b/api/credentials_controller.go
@@ -111,7 +111,7 @@ func (c *credentialsController) setCredentials(r *web.Request) (*web.Response, e
 		return nil, util.HandleStorageError(err, types.BrokerPlatformCredentialType.String())
 	}
 
-	if body.NotificationID == "" && platform.Type != types.K8sPlatformType { // K8S clusters are very volatile in terms of life cycle
+	if body.NotificationID == "" && platform.Type != types.K8sPlatformType { // K8S clusters are less restrictive in terms of broker management, we need to allow credential rotation even if it's triggered by full resync
 		log.C(ctx).Error("Notification id not provided and broker platform credentials already exists...")
 		return nil, &util.HTTPError{
 			ErrorType:   "CredentialsError",

--- a/api/credentials_controller.go
+++ b/api/credentials_controller.go
@@ -111,7 +111,7 @@ func (c *credentialsController) setCredentials(r *web.Request) (*web.Response, e
 		return nil, util.HandleStorageError(err, types.BrokerPlatformCredentialType.String())
 	}
 
-	if body.NotificationID == "" {
+	if body.NotificationID == "" && platform.Type != types.K8sPlatformType { // K8S clusters are very volatile in terms of life cycle
 		log.C(ctx).Error("Notification id not provided and broker platform credentials already exists...")
 		return nil, &util.HTTPError{
 			ErrorType:   "CredentialsError",

--- a/test/osb_test/catalog_test.go
+++ b/test/osb_test/catalog_test.go
@@ -444,6 +444,11 @@ var _ = Describe("Catalog", func() {
 					By("rotation of K8S credentials broker platform credentials should work")
 					k8sOSBClient.GET(osbURL + "/v2/catalog").
 						Expect().Status(http.StatusOK).JSON().Object().ContainsKey("services")
+
+					By("old K8S credentials broker platform credentials should not work")
+					k8sOSBClient.SetBasicCredentials(ctx, username, password)
+					k8sOSBClient.GET(osbURL + "/v2/catalog").
+						Expect().Status(http.StatusUnauthorized)
 				})
 			})
 		})

--- a/test/osb_test/catalog_test.go
+++ b/test/osb_test/catalog_test.go
@@ -438,7 +438,7 @@ var _ = Describe("Catalog", func() {
 					k8sOSBClient.GET(osbURL + "/v2/catalog").
 						Expect().Status(http.StatusOK).JSON().Object().ContainsKey("services")
 
-					newUsername, newPassword = test.RegisterBrokerPlatformCredentialsExpect(k8sPlatformClient, prefixedBrokerID, http.StatusOK)
+					newUsername, newPassword = test.RegisterBrokerPlatformCredentials(k8sPlatformClient, prefixedBrokerID)
 					k8sOSBClient.SetBasicCredentials(ctx, newUsername, newPassword)
 
 					By("rotation of K8S credentials broker platform credentials should work")

--- a/test/osb_test/catalog_test.go
+++ b/test/osb_test/catalog_test.go
@@ -413,7 +413,7 @@ var _ = Describe("Catalog", func() {
 			})
 
 			Context("when broker platform credentials change out of notification processing context when already exist", func() {
-				FIt("should return 409 for non-kubernetes platforms", func() {
+				It("should return 409 for non-kubernetes platforms", func() {
 					By("CF platform attempts credential rotation")
 					newUsername, newPassword := test.RegisterBrokerPlatformCredentialsExpect(SMWithBasicPlatform, prefixedBrokerID, http.StatusConflict)
 					ctx.SMWithBasic.SetBasicCredentials(ctx, newUsername, newPassword)

--- a/test/osb_test/catalog_test.go
+++ b/test/osb_test/catalog_test.go
@@ -413,11 +413,37 @@ var _ = Describe("Catalog", func() {
 			})
 
 			Context("when broker platform credentials change out of notification processing context when already exist", func() {
-				It("should return 409", func() {
+				FIt("should return 409 for non-kubernetes platforms", func() {
+					By("CF platform attempts credential rotation")
 					newUsername, newPassword := test.RegisterBrokerPlatformCredentialsExpect(SMWithBasicPlatform, prefixedBrokerID, http.StatusConflict)
 					ctx.SMWithBasic.SetBasicCredentials(ctx, newUsername, newPassword)
 
 					assertCredentialsNotChanged(oldSMWithBasic, ctx.SMWithBasic)
+
+					By("K8S platform attempts credential rotation")
+					k8sPlatformJSON := common.MakePlatform("k8s-platform", "k8s-platform", "kubernetes", "test-platform-k8s")
+					k8sPlatform := common.RegisterPlatformInSM(k8sPlatformJSON, ctx.SMWithOAuth, map[string]string{})
+
+					k8sPlatformClient := &common.SMExpect{Expect: ctx.SM.Builder(func(req *httpexpect.Request) {
+						username, password := k8sPlatform.Credentials.Basic.Username, k8sPlatform.Credentials.Basic.Password
+						req.WithBasicAuth(username, password).WithClient(ctx.HttpClient)
+					})}
+
+					username, password := test.RegisterBrokerPlatformCredentials(k8sPlatformClient, prefixedBrokerID)
+					k8sOSBClient := &common.SMExpect{Expect: ctx.SM.Builder(func(req *httpexpect.Request) {
+						req.WithBasicAuth(username, password).WithClient(ctx.HttpClient)
+					})}
+
+					By("initial K8S credentials should work")
+					k8sOSBClient.GET(osbURL + "/v2/catalog").
+						Expect().Status(http.StatusOK).JSON().Object().ContainsKey("services")
+
+					newUsername, newPassword = test.RegisterBrokerPlatformCredentialsExpect(k8sPlatformClient, prefixedBrokerID, http.StatusOK)
+					k8sOSBClient.SetBasicCredentials(ctx, newUsername, newPassword)
+
+					By("rotation of K8S credentials broker platform credentials should work")
+					k8sOSBClient.GET(osbURL + "/v2/catalog").
+						Expect().Status(http.StatusOK).JSON().Object().ContainsKey("services")
 				})
 			})
 		})


### PR DESCRIPTION
# Allow Broker Platform Credential Rotation during full resync in K8S platforms

## Motivation

Unlike CF installations, K8S clusters are very volatile environments and it's easier to delete broker resources there. In case a broker is deleted in K8S directly (or CF for that matter), the broker record and its broker platform credentials will still exist in SM. And whenever the K8S agent retriggers full resync it would fail to register the broker back in the platform as it would try to essentially rotate the broker platform credentials - something we do not allow. We only allow full resync to initially set broker platform credentials, but now we will allow this rotation for K8S platforms,

## Approach

Make broker platform credentials controller less restrictive.

## Pull Request status

* [x] Initial implementation
* [x] Integration tests
