### PR TITLE
Attach last operation to the resource on PATCH and POST

### DIFF
--- a/api/base_controller.go
+++ b/api/base_controller.go
@@ -518,8 +518,9 @@ func attachLastOperation(ctx context.Context, objectID string, object types.Obje
 		log.C(ctx).Debugf("No last operation found for entity with id %s of type %s", objectID, object.GetType().String())
 		return nil
 	}
-	lastOperation := list.ItemAt(0)
-	object.SetLastOperation(lastOperation.(*types.Operation))
+	lastOperation := list.ItemAt(0).(*types.Operation)
+	lastOperation.TransitiveResources = nil
+	object.SetLastOperation(lastOperation)
 	return nil
 }
 

--- a/api/base_controller.go
+++ b/api/base_controller.go
@@ -213,6 +213,10 @@ func (c *BaseController) CreateObject(r *web.Request) (*web.Response, error) {
 		return nil, util.HandleStorageError(err, c.objectType.String())
 	}
 
+	if err := attachLastOperation(ctx, createdObj.GetID(), createdObj, c.repository); err != nil {
+		return nil, err
+	}
+
 	return util.NewJSONResponse(http.StatusCreated, createdObj)
 }
 
@@ -315,7 +319,7 @@ func (c *BaseController) GetSingleObject(r *web.Request) (*web.Response, error) 
 
 	cleanObject(object)
 
-	if err := attachLastOperation(ctx, objectID, object, r, c.repository); err != nil {
+	if err := attachLastOperation(ctx, objectID, object, c.repository); err != nil {
 		return nil, err
 	}
 
@@ -490,6 +494,9 @@ func (c *BaseController) PatchObject(r *web.Request) (*web.Response, error) {
 	}
 
 	cleanObject(object)
+	if err := attachLastOperation(ctx, object.GetID(), object, c.repository); err != nil {
+		return nil, err
+	}
 	return util.NewJSONResponse(http.StatusOK, object)
 }
 
@@ -499,7 +506,7 @@ func cleanObject(object types.Object) {
 	}
 }
 
-func attachLastOperation(ctx context.Context, objectID string, object types.Object, r *web.Request, repository storage.Repository) error {
+func attachLastOperation(ctx context.Context, objectID string, object types.Object, repository storage.Repository) error {
 	orderBy := query.OrderResultBy("paging_sequence", query.DescOrder)
 	byObjectID := query.ByField(query.EqualsOperator, "resource_id", objectID)
 	// Limit cannot be applied, otherwise the query is corrupted and does not return valid result

--- a/test/notification_test/notification_test.go
+++ b/test/notification_test/notification_test.go
@@ -93,6 +93,7 @@ var _ = Describe("Notifications Suite", func() {
 			ResourceCreateFunc: func() common.Object {
 				obj := ctx.RegisterBroker().Broker.JSON
 				delete(obj, "credentials")
+				delete(obj, "last_operation")
 				return obj
 			},
 			ResourceUpdateFunc: func(obj common.Object, update common.Object) common.Object {
@@ -101,6 +102,7 @@ var _ = Describe("Notifications Suite", func() {
 					Expect().
 					Status(http.StatusOK).JSON().Object().Raw()
 
+				delete(patchedObj, "last_operation")
 				return patchedObj
 			},
 			ResourceUpdates: []func() common.Object{
@@ -232,12 +234,14 @@ var _ = Describe("Notifications Suite", func() {
 				visibility := ctx.SMWithOAuth.POST(web.VisibilitiesURL).WithJSON(visReqBody).Expect().
 					Status(http.StatusCreated).JSON().Object().Raw()
 
+				delete(visibility, "last_operation")
 				return visibility
 			},
 			ResourceUpdateFunc: func(obj common.Object, update common.Object) common.Object {
 				updatedObj := ctx.SMWithOAuth.PATCH(web.VisibilitiesURL + "/" + obj["id"].(string)).WithJSON(update).Expect().
 					Status(http.StatusOK).JSON().Object().Raw()
 
+				delete(updatedObj, "last_operation")
 				return updatedObj
 			},
 			ResourceUpdates: []func() common.Object{


### PR DESCRIPTION
## Motivation

Attach last operation to the resource returned by PATCH and POST request for better and consistent experience with the CLI and API