### PR TITLE
Insert labels in batches to avoid pq param limit

### DIFF
--- a/storage/postgres/storage.go
+++ b/storage/postgres/storage.go
@@ -228,8 +228,10 @@ func (ps *Storage) createLabels(ctx context.Context, labels []PostgresLabel) err
 			return checkIntegrityViolation(ctx, err)
 		}
 		rowsAffected, err := result.RowsAffected()
-		if err == nil {
-			log.C(ctx).Debugf("%d rows affected", rowsAffected)
+		if err != nil {
+			log.C(ctx).Debugf("Could not get number of affected rows: %v", err)
+		} else {
+			log.C(ctx).Debugf("%d rows inserted", rowsAffected)
 		}
 		labels = labels[rows:]
 	}

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -13,7 +13,7 @@ websocket:
   ping_timeout: 4000ms
   write_timeout: 4000ms
 log:
-  level: debug
+  level: info
   format: text
 storage:
   uri: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -13,7 +13,7 @@ websocket:
   ping_timeout: 4000ms
   write_timeout: 4000ms
 log:
-  level: info
+  level: debug
   format: text
 storage:
   uri: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable

--- a/test/common/application.yml
+++ b/test/common/application.yml
@@ -1,5 +1,5 @@
 server:
-  request_timeout: 10000ms
+  request_timeout: 30s
   shutdown_timeout: 4000ms
   port: 1234
 httpclient:

--- a/test/configuration_test/configuration_test.go
+++ b/test/configuration_test/configuration_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Service Manager Config API", func() {
 					"max_body_bytes": 1048576,
 					"max_header_bytes": 1024,
 					"port": 1234,
-					"request_timeout": "10000ms",
+					"request_timeout": "30s",
 					"shutdown_timeout": "4000ms"
 				},
 				"storage": {

--- a/test/visibility_test/visibility_test.go
+++ b/test/visibility_test/visibility_test.go
@@ -250,7 +250,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						})
 					})
 
-					FContext("When many labels are provided", func() {
+					Context("When many labels are provided", func() {
 						It("should return 201", func() {
 							// see https://github.com/lib/pq/blob/master/conn.go#L1282
 							const labelCount = 20000 // 20000 * 6 > 65535 - max postgres parameter number
@@ -261,9 +261,10 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							postVisibilityRequestWithLabels["labels"] = common.Object{
 								"org_id": orgs,
 							}
-							ctx.SMWithOAuth.POST(web.VisibilitiesURL).
-								WithJSON(postVisibilityRequestWithLabels).
-								Expect().Status(http.StatusCreated).
+							r := ctx.SMWithOAuth.POST(web.VisibilitiesURL).
+								WithJSON(postVisibilityRequestWithLabels).Expect()
+							common.Print("Response: %s", r.Body().Raw())
+							r.Status(http.StatusCreated).
 								JSON().Object().Path("$.labels.org_id").Array().ContainsOnly(orgs...)
 						})
 					})

--- a/test/visibility_test/visibility_test.go
+++ b/test/visibility_test/visibility_test.go
@@ -261,10 +261,9 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							postVisibilityRequestWithLabels["labels"] = common.Object{
 								"org_id": orgs,
 							}
-							r := ctx.SMWithOAuth.POST(web.VisibilitiesURL).
-								WithJSON(postVisibilityRequestWithLabels).Expect()
-							common.Print("Response: %s", r.Body().Raw())
-							r.Status(http.StatusCreated).
+							ctx.SMWithOAuth.POST(web.VisibilitiesURL).
+								WithJSON(postVisibilityRequestWithLabels).
+								Expect().Status(http.StatusCreated).
 								JSON().Object().Path("$.labels.org_id").Array().ContainsOnly(orgs...)
 						})
 					})

--- a/test/visibility_test/visibility_test.go
+++ b/test/visibility_test/visibility_test.go
@@ -250,7 +250,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						})
 					})
 
-					Context("When many labels are provided", func() {
+					FContext("When many labels are provided", func() {
 						It("should return 201", func() {
 							// see https://github.com/lib/pq/blob/master/conn.go#L1282
 							const labelCount = 20000 // 20000 * 6 > 65535 - max postgres parameter number

--- a/test/visibility_test/visibility_test.go
+++ b/test/visibility_test/visibility_test.go
@@ -250,6 +250,24 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						})
 					})
 
+					Context("When many labels are provided", func() {
+						It("should return 201", func() {
+							// see https://github.com/lib/pq/blob/master/conn.go#L1282
+							const labelCount = 20000 // 20000 * 6 > 65535 - max postgres parameter number
+							orgs := make(common.Array, labelCount)
+							for i := range orgs {
+								orgs[i] = fmt.Sprintf("org-id-%d", i)
+							}
+							postVisibilityRequestWithLabels["labels"] = common.Object{
+								"org_id": orgs,
+							}
+							ctx.SMWithOAuth.POST(web.VisibilitiesURL).
+								WithJSON(postVisibilityRequestWithLabels).
+								Expect().Status(http.StatusCreated).
+								JSON().Object().Path("$.labels.org_id").Array().ContainsOnly(orgs...)
+						})
+					})
+
 					Context("When creating labeled visibility for which a public one exists", func() {
 						It("Should return 409", func() {
 							ctx.SMWithOAuth.POST(web.VisibilitiesURL).


### PR DESCRIPTION
pq has a limit of 65535 parameters, see https://github.com/lib/pq/blob/master/conn.go#L1282
now we insert labels in batches to avoid this limit