### PR TITLE
Add flag to transfer API/disable delete across platforms

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -742,6 +742,7 @@
     "github.com/jmoiron/sqlx/types",
     "github.com/kubernetes-sigs/go-open-service-broker-client/v2",
     "github.com/lib/pq",
+    "github.com/mitchellh/mapstructure",
     "github.com/onrik/logrus/filename",
     "github.com/onsi/ginkgo",
     "github.com/onsi/ginkgo/extensions/table",

--- a/api/api.go
+++ b/api/api.go
@@ -49,25 +49,27 @@ const osbVersion = "2.13"
 
 // Settings type to be loaded from the environment
 type Settings struct {
-	TokenIssuerURL  string   `mapstructure:"token_issuer_url" description:"url of the token issuer which to use for validating tokens"`
-	ClientID        string   `mapstructure:"client_id" description:"id of the client from which the token must be issued"`
-	TokenBasicAuth  bool     `mapstructure:"token_basic_auth" description:"specifies if client credentials to the authorization server should be sent in the header as basic auth (true) or in the body (false)"`
-	ProtectedLabels []string `mapstructure:"protected_labels" description:"defines labels which cannot be modified/added by REST API requests"`
-	OSBVersion      string   `mapstructure:"-"`
-	MaxPageSize     int      `mapstructure:"max_page_size" description:"maximum number of items that could be returned in a single page"`
-	DefaultPageSize int      `mapstructure:"default_page_size" description:"default number of items returned in a single page if not specified in request"`
+	TokenIssuerURL         string   `mapstructure:"token_issuer_url" description:"url of the token issuer which to use for validating tokens"`
+	ClientID               string   `mapstructure:"client_id" description:"id of the client from which the token must be issued"`
+	TokenBasicAuth         bool     `mapstructure:"token_basic_auth" description:"specifies if client credentials to the authorization server should be sent in the header as basic auth (true) or in the body (false)"`
+	ProtectedLabels        []string `mapstructure:"protected_labels" description:"defines labels which cannot be modified/added by REST API requests"`
+	OSBVersion             string   `mapstructure:"-"`
+	MaxPageSize            int      `mapstructure:"max_page_size" description:"maximum number of items that could be returned in a single page"`
+	DefaultPageSize        int      `mapstructure:"default_page_size" description:"default number of items returned in a single page if not specified in request"`
+	EnableInstanceTransfer bool     `mapstructure:"enable_instance_transfer" description:"whether service instance transfer is enabled or not"`
 }
 
 // DefaultSettings returns default values for API settings
 func DefaultSettings() *Settings {
 	return &Settings{
-		TokenIssuerURL:  "",
-		ClientID:        "",
-		TokenBasicAuth:  true, // RFC 6749 section 2.3.1
-		OSBVersion:      osbVersion,
-		MaxPageSize:     200,
-		DefaultPageSize: 50,
-		ProtectedLabels: []string{},
+		TokenIssuerURL:         "",
+		ClientID:               "",
+		TokenBasicAuth:         true, // RFC 6749 section 2.3.1
+		ProtectedLabels:        []string{},
+		OSBVersion:             osbVersion,
+		MaxPageSize:            200,
+		DefaultPageSize:        50,
+		EnableInstanceTransfer: false,
 	}
 }
 
@@ -148,7 +150,7 @@ func New(ctx context.Context, e env.Environment, options *Options) (*web.API, er
 			filters.NewPlansFilterByVisibility(options.Repository),
 			filters.NewServicesFilterByVisibility(options.Repository),
 			&filters.CheckBrokerCredentialsFilter{},
-			filters.NewServiceInstanceTransferFilter(options.Repository),
+			filters.NewServiceInstanceTransferFilter(options.Repository, options.APISettings.EnableInstanceTransfer),
 		},
 		Registry: health.NewDefaultRegistry(),
 	}, nil

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -18,8 +18,9 @@ package api_test
 
 import (
 	"context"
-	"github.com/Peripli/service-manager/operations"
 	"testing"
+
+	"github.com/Peripli/service-manager/operations"
 
 	"github.com/Peripli/service-manager/pkg/env/envfakes"
 

--- a/api/filters/check_instance_transfer_filter.go
+++ b/api/filters/check_instance_transfer_filter.go
@@ -33,12 +33,14 @@ import (
 const ServiceInstanceTransferFilterName = "ServiceInstanceTransferFilter"
 
 type serviceInstanceTransferFilter struct {
-	repository storage.Repository
+	repository             storage.Repository
+	enableInstanceTransfer bool
 }
 
-func NewServiceInstanceTransferFilter(repository storage.Repository) *serviceInstanceTransferFilter {
+func NewServiceInstanceTransferFilter(repository storage.Repository, enableInstanceTransfer bool) *serviceInstanceTransferFilter {
 	return &serviceInstanceTransferFilter{
-		repository: repository,
+		repository:             repository,
+		enableInstanceTransfer: enableInstanceTransfer,
 	}
 }
 
@@ -52,6 +54,14 @@ func (f *serviceInstanceTransferFilter) Run(req *web.Request, next web.Handler) 
 	platformID := gjson.GetBytes(req.Body, "platform_id").String()
 	if platformID == "" {
 		return next.Handle(req)
+	}
+
+	if !f.enableInstanceTransfer {
+		return nil, &util.HTTPError{
+			ErrorType:   "TransferDisabled",
+			Description: "Instance transfer is disabled in this service-manager installation",
+			StatusCode:  http.StatusBadRequest,
+		}
 	}
 
 	instanceID := req.PathParams[web.PathParamResourceID]

--- a/storage/interceptors/smaap_service_instance_interceptor.go
+++ b/storage/interceptors/smaap_service_instance_interceptor.go
@@ -338,6 +338,10 @@ func (i *ServiceInstanceInterceptor) AroundTxDelete(f storage.InterceptDeleteAro
 
 		if instances.Len() != 0 {
 			instance := instances.ItemAt(0).(*types.ServiceInstance)
+			//TODO remove when deletion of instances from all platforms is enabled
+			if instance.PlatformID != types.SMPlatform {
+				return f(ctx, deletionCriteria...)
+			}
 			operation, found := opcontext.Get(ctx)
 			if !found {
 				return fmt.Errorf("operation missing from context")

--- a/test/osb_test/poll_instance_last_operation_test.go
+++ b/test/osb_test/poll_instance_last_operation_test.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/Peripli/service-manager/pkg/web"
-
 	"github.com/Peripli/service-manager/pkg/query"
 	"github.com/Peripli/service-manager/pkg/types"
 	. "github.com/onsi/ginkgo"
@@ -128,8 +126,9 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 					brokerServer.ServiceInstanceHandler = parameterizedHandler(http.StatusOK, `{}`)
 
 					By(fmt.Sprintf("Deleting instance with id %s", SID))
-					ctx.SMWithOAuthForTenant.DELETE(web.ServiceInstancesURL+"/"+SID).WithQuery("async", false).
-						Expect().Status(http.StatusOK)
+					byID := query.ByField(query.EqualsOperator, "id", SID)
+					err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
+					Expect(err).ToNot(HaveOccurred())
 
 					ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
 						Expect().Status(http.StatusNotFound)
@@ -360,8 +359,9 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 					brokerServer.ServiceInstanceHandler = parameterizedHandler(http.StatusOK, `{}`)
 
 					By(fmt.Sprintf("Deleting instance with id %s", SID))
-					ctx.SMWithOAuthForTenant.DELETE(web.ServiceInstancesURL+"/"+SID).WithQuery("async", false).
-						Expect().Status(http.StatusOK)
+					byID := query.ByField(query.EqualsOperator, "id", SID)
+					err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
+					Expect(err).ToNot(HaveOccurred())
 
 					ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
 						Expect().Status(http.StatusNotFound)
@@ -504,8 +504,9 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 					brokerServer.ServiceInstanceHandler = parameterizedHandler(http.StatusOK, `{}`)
 
 					By(fmt.Sprintf("Deleting instance with id %s", SID))
-					ctx.SMWithOAuthForTenant.DELETE(web.ServiceInstancesURL+"/"+SID).WithQuery("async", false).
-						Expect().Status(http.StatusOK)
+					byID := query.ByField(query.EqualsOperator, "id", SID)
+					err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
+					Expect(err).ToNot(HaveOccurred())
 
 					ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
 						Expect().Status(http.StatusNotFound)
@@ -583,8 +584,9 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 					brokerServer.ServiceInstanceHandler = parameterizedHandler(http.StatusOK, `{}`)
 
 					By(fmt.Sprintf("Deleting instance with id %s", SID))
-					ctx.SMWithOAuthForTenant.DELETE(web.ServiceInstancesURL+"/"+SID).WithQuery("async", false).
-						Expect().Status(http.StatusOK)
+					byID := query.ByField(query.EqualsOperator, "id", SID)
+					err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
+					Expect(err).ToNot(HaveOccurred())
 
 					ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
 						Expect().Status(http.StatusNotFound)
@@ -677,8 +679,9 @@ var _ = Describe("Get Service Instance Last Operation", func() {
 					brokerServer.ServiceInstanceHandler = parameterizedHandler(http.StatusOK, `{}`)
 
 					By(fmt.Sprintf("Deleting instance with id %s", SID))
-					ctx.SMWithOAuthForTenant.DELETE(web.ServiceInstancesURL+"/"+SID).WithQuery("async", false).
-						Expect().Status(http.StatusOK)
+					byID := query.ByField(query.EqualsOperator, "id", SID)
+					err := ctx.SMRepository.Delete(context.TODO(), types.ServiceInstanceType, byID)
+					Expect(err).ToNot(HaveOccurred())
 
 					ctx.SMWithOAuth.GET("/v1/service_instances/"+SID).WithHeader(brokerAPIVersionHeaderKey, brokerAPIVersionHeaderValue).
 						Expect().Status(http.StatusNotFound)

--- a/test/security_test/security_test.go
+++ b/test/security_test/security_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Service Manager Security Tests", func() {
 	)
 
 	BeforeEach(func() {
-		contextBuilder = common.NewTestContextBuilder()
+		contextBuilder = common.NewTestContextBuilder().WithBasicAuthPlatformName("security-tests-platform")
 	})
 
 	JustBeforeEach(func() {

--- a/test/storage_test/storage_test.go
+++ b/test/storage_test/storage_test.go
@@ -97,11 +97,12 @@ var _ = Describe("Test", func() {
 			byID = query.ByField(query.EqualsOperator, "id", platform.GetID())
 			obj, err = ctx.SMRepository.Get(context.Background(), types.PlatformType, byID)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(obj.GetLabels()).To(Equal(types.Labels{
+
+			compareLabels(obj.GetLabels(), types.Labels{
 				label1Key: []string{label1Value1},
 				label2Key: []string{label2Value1},
 				label3Key: []string{label3Value1, label3Value2},
-			}))
+			})
 
 			By("Does not fail if label already exists")
 			err = ctx.SMRepository.UpdateLabels(context.Background(), types.PlatformType, platform.GetID(), types.LabelChanges{
@@ -116,11 +117,11 @@ var _ = Describe("Test", func() {
 			byID = query.ByField(query.EqualsOperator, "id", platform.GetID())
 			obj, err = ctx.SMRepository.Get(context.Background(), types.PlatformType, byID)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(obj.GetLabels()).To(Equal(types.Labels{
+			compareLabels(obj.GetLabels(), types.Labels{
 				label1Key: []string{label1Value1},
 				label2Key: []string{label2Value1},
 				label3Key: []string{label3Value1, label3Value2},
-			}))
+			})
 
 			By("Successfully adds new values to existing labels")
 			err = ctx.SMRepository.UpdateLabels(context.Background(), types.PlatformType, platform.GetID(), types.LabelChanges{
@@ -139,11 +140,11 @@ var _ = Describe("Test", func() {
 			byID = query.ByField(query.EqualsOperator, "id", platform.GetID())
 			obj, err = ctx.SMRepository.Get(context.Background(), types.PlatformType, byID)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(obj.GetLabels()).To(Equal(types.Labels{
+			compareLabels(obj.GetLabels(), types.Labels{
 				label1Key: []string{label1Value1, label1Value2},
 				label2Key: []string{label2Value1, label2Value2},
 				label3Key: []string{label3Value1, label3Value2},
-			}))
+			})
 
 			By("Does not fail if label value already exists")
 			err = ctx.SMRepository.UpdateLabels(context.Background(), types.PlatformType, platform.GetID(), types.LabelChanges{
@@ -162,11 +163,11 @@ var _ = Describe("Test", func() {
 			byID = query.ByField(query.EqualsOperator, "id", platform.GetID())
 			obj, err = ctx.SMRepository.Get(context.Background(), types.PlatformType, byID)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(obj.GetLabels()).To(Equal(types.Labels{
+			compareLabels(obj.GetLabels(), types.Labels{
 				label1Key: []string{label1Value1, label1Value2},
 				label2Key: []string{label2Value1, label2Value2},
 				label3Key: []string{label3Value1, label3Value2},
-			}))
+			})
 
 			By("Successfully removes existing values from existing labels")
 			err = ctx.SMRepository.UpdateLabels(context.Background(), types.PlatformType, platform.GetID(), types.LabelChanges{
@@ -186,11 +187,11 @@ var _ = Describe("Test", func() {
 			byID = query.ByField(query.EqualsOperator, "id", platform.GetID())
 			obj, err = ctx.SMRepository.Get(context.Background(), types.PlatformType, byID)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(obj.GetLabels()).To(Equal(types.Labels{
+			compareLabels(obj.GetLabels(), types.Labels{
 				label1Key: []string{label1Value1},
 				label2Key: []string{label2Value1},
 				label3Key: []string{label3Value1, label3Value2},
-			}))
+			})
 
 			By("Does not fail if label value does not exist")
 			err = ctx.SMRepository.UpdateLabels(context.Background(), types.PlatformType, platform.GetID(), types.LabelChanges{
@@ -210,11 +211,11 @@ var _ = Describe("Test", func() {
 			byID = query.ByField(query.EqualsOperator, "id", platform.GetID())
 			obj, err = ctx.SMRepository.Get(context.Background(), types.PlatformType, byID)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(obj.GetLabels()).To(Equal(types.Labels{
+			compareLabels(obj.GetLabels(), types.Labels{
 				label1Key: []string{label1Value1},
 				label2Key: []string{label2Value1},
 				label3Key: []string{label3Value1, label3Value2},
-			}))
+			})
 
 			By("Successfully removes existing labels")
 			err = ctx.SMRepository.UpdateLabels(context.Background(), types.PlatformType, platform.GetID(), types.LabelChanges{
@@ -252,9 +253,9 @@ var _ = Describe("Test", func() {
 			byID = query.ByField(query.EqualsOperator, "id", platform.GetID())
 			obj, err = ctx.SMRepository.Get(context.Background(), types.PlatformType, byID)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(obj.GetLabels()).To(Equal(types.Labels{
+			compareLabels(obj.GetLabels(), types.Labels{
 				label3Key: []string{label3Value1, label3Value2},
-			}))
+			})
 		})
 	})
 
@@ -291,3 +292,10 @@ var _ = Describe("Test", func() {
 		})
 	})
 })
+
+func compareLabels(actual, expected types.Labels) {
+	Expect(actual).To(HaveLen(len(expected)))
+	for labelKey, labelValues := range actual {
+		Expect(labelValues).To(ConsistOf(expected[labelKey]))
+	}
+}


### PR DESCRIPTION
The functionality if deleting instances across platforms requires storing bindings in SMDB as a prerequisite