### PR TITLE
Fixes in maintainer

### DIFF
--- a/operations/config.go
+++ b/operations/config.go
@@ -37,8 +37,9 @@ type Settings struct {
 	ActionTimeout                  time.Duration `mapstructure:"action_timeout" description:"timeout for async operations"`
 	ReconciliationOperationTimeout time.Duration `mapstructure:"reconciliation_operation_timeout" description:"the maximum allowed timeout for auto rescheduling of operation actions"`
 
-	CleanupInterval time.Duration `mapstructure:"cleanup_interval" description:"cleanup interval of old operations"`
-	Lifespan        time.Duration `mapstructure:"lifespan" description:"after that time is passed since its creation, the operation can be cleaned up by the maintainer"`
+	CleanupInterval         time.Duration `mapstructure:"cleanup_interval" description:"cleanup interval of old operations"`
+	MaintainerRetryInterval time.Duration `mapstructure:"mainatainer_retry_interval" description:"maintenance retry interval"`
+	Lifespan                time.Duration `mapstructure:"lifespan" description:"after that time is passed since its creation, the operation can be cleaned up by the maintainer"`
 
 	ReschedulingInterval time.Duration `mapstructure:"rescheduling_interval" description:"the interval between auto rescheduling of operation actions"`
 	PollingInterval      time.Duration `mapstructure:"polling_interval" description:"the interval between polls for async requests"`
@@ -53,16 +54,15 @@ type Settings struct {
 func DefaultSettings() *Settings {
 	return &Settings{
 		ActionTimeout:                  defaultActionTimeout,
+		ReconciliationOperationTimeout: defaultOperationLifespan,
 		CleanupInterval:                defaultCleanupInterval,
+		MaintainerRetryInterval:        5 * time.Minute,
 		Lifespan:                       defaultOperationLifespan,
+		ReschedulingInterval:           1 * time.Second,
+		PollingInterval:                1 * time.Second,
 		DefaultPoolSize:                20,
 		Pools:                          []PoolSettings{},
-		ReconciliationOperationTimeout: defaultOperationLifespan,
-
-		ReschedulingInterval: 1 * time.Second,
-		PollingInterval:      1 * time.Second,
-
-		SMSupportedPlatformType: types.SMPlatform,
+		SMSupportedPlatformType:        types.SMPlatform,
 	}
 }
 
@@ -82,6 +82,9 @@ func (s *Settings) Validate() error {
 	}
 	if s.PollingInterval <= minTimePeriod {
 		return fmt.Errorf("validate Settings: PollingInterval must be larger than %s", minTimePeriod)
+	}
+	if s.MaintainerRetryInterval <= minTimePeriod {
+		return fmt.Errorf("validate Settings: MaintainerRetryInterval must be larger than %s", minTimePeriod)
 	}
 	if s.DefaultPoolSize <= 0 {
 		return fmt.Errorf("validate Settings: DefaultPoolSize must be larger than 0")

--- a/operations/config.go
+++ b/operations/config.go
@@ -25,11 +25,6 @@ import (
 
 const (
 	minTimePeriod = time.Nanosecond
-
-	defaultActionTimeout     = 12 * time.Hour
-	defaultOperationLifespan = 7 * 24 * time.Hour
-
-	defaultCleanupInterval = 24 * time.Hour
 )
 
 // Settings type to be loaded from the environment
@@ -53,13 +48,13 @@ type Settings struct {
 // DefaultSettings returns default values for API settings
 func DefaultSettings() *Settings {
 	return &Settings{
-		ActionTimeout:                  defaultActionTimeout,
-		ReconciliationOperationTimeout: defaultOperationLifespan,
-		CleanupInterval:                defaultCleanupInterval,
+		ActionTimeout:                  15 * time.Minute,
+		ReconciliationOperationTimeout: 7 * 24 * time.Hour,
+		CleanupInterval:                1 * time.Hour,
 		MaintainerRetryInterval:        10 * time.Minute,
-		Lifespan:                       defaultOperationLifespan,
-		ReschedulingInterval:           1 * time.Second,
-		PollingInterval:                1 * time.Second,
+		Lifespan:                       7 * 24 * time.Hour,
+		ReschedulingInterval:           10 * time.Second,
+		PollingInterval:                4 * time.Second,
 		DefaultPoolSize:                20,
 		Pools:                          []PoolSettings{},
 		SMSupportedPlatformType:        types.SMPlatform,

--- a/operations/config.go
+++ b/operations/config.go
@@ -38,7 +38,7 @@ type Settings struct {
 	ReconciliationOperationTimeout time.Duration `mapstructure:"reconciliation_operation_timeout" description:"the maximum allowed timeout for auto rescheduling of operation actions"`
 
 	CleanupInterval         time.Duration `mapstructure:"cleanup_interval" description:"cleanup interval of old operations"`
-	MaintainerRetryInterval time.Duration `mapstructure:"mainatainer_retry_interval" description:"maintenance retry interval"`
+	MaintainerRetryInterval time.Duration `mapstructure:"maintainer_retry_interval" description:"maintenance retry interval"`
 	Lifespan                time.Duration `mapstructure:"lifespan" description:"after that time is passed since its creation, the operation can be cleaned up by the maintainer"`
 
 	ReschedulingInterval time.Duration `mapstructure:"rescheduling_interval" description:"the interval between auto rescheduling of operation actions"`
@@ -56,7 +56,7 @@ func DefaultSettings() *Settings {
 		ActionTimeout:                  defaultActionTimeout,
 		ReconciliationOperationTimeout: defaultOperationLifespan,
 		CleanupInterval:                defaultCleanupInterval,
-		MaintainerRetryInterval:        5 * time.Minute,
+		MaintainerRetryInterval:        10 * time.Minute,
 		Lifespan:                       defaultOperationLifespan,
 		ReschedulingInterval:           1 * time.Second,
 		PollingInterval:                1 * time.Second,

--- a/operations/maintainer.go
+++ b/operations/maintainer.go
@@ -360,6 +360,7 @@ func (om *Maintainer) markStuckOperationsFailed() {
 
 		if _, err := om.repository.Update(om.smCtx, operation, types.LabelChanges{}); err != nil {
 			logger.Warnf("Failed to update orphan operation with ID (%s) state to FAILED: %s", operation.ID, err)
+			continue
 		}
 
 		if operation.Type == types.CREATE || operation.Type == types.DELETE {

--- a/test/configuration_test/configuration_test.go
+++ b/test/configuration_test/configuration_test.go
@@ -85,13 +85,16 @@ var _ = Describe("Service Manager Config API", func() {
 					"label_key": "tenant"
 				},
 				"operations": {
-					"cleanup_interval": "24h0m0s",
+					"action_timeout": "15m0s",
+            		"cleanup_interval": "1h0m0s",
 					"default_pool_size": 20,
-					"action_timeout": "12h0m0s",
+					"lifespan": "168h0m0s",
+					"maintainer_retry_interval": "10m0s",
 					"polling_interval": "1ms",
 					"pools": "",
+					"reconciliation_operation_timeout": "168h0m0s",
 					"rescheduling_interval": "1ms",
-					"reconciliation_operation_timeout": "168h0m0s"
+					"sm_supported_platform_type": "service-manager"
 				  },
 				"server": {
 					"host": "",

--- a/test/operations_test/operations_test.go
+++ b/test/operations_test/operations_test.go
@@ -228,9 +228,10 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 			Context("Maintainer", func() {
 				const (
-					actionTimeout       = 1 * time.Second
-					cleanupInterval     = 2 * time.Second
-					operationExpiration = 2 * time.Second
+					maintainerRetry     = 1 * time.Second
+					actionTimeout       = 2 * time.Second
+					cleanupInterval     = 3 * time.Second
+					operationExpiration = 3 * time.Second
 				)
 
 				var ctxBuilder *TestContextBuilder
@@ -238,6 +239,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				postHookWithOperationsConfig := func() func(e env.Environment, servers map[string]FakeServer) {
 					return func(e env.Environment, servers map[string]FakeServer) {
 						e.Set("operations.action_timeout", actionTimeout)
+						e.Set("operations.maintainer_retry_interval", maintainerRetry)
 						e.Set("operations.cleanup_interval", cleanupInterval)
 						e.Set("operations.lifespan", operationExpiration)
 						e.Set("operations.reconciliation_operation_timeout", 9999*time.Hour)
@@ -253,10 +255,13 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				BeforeEach(func() {
 					postHook := postHookWithOperationsConfig()
 					ctxBuilder = NewTestContextBuilderWithSecurity().WithEnvPostExtensions(postHook)
-					ctx = ctxBuilder.Build()
 				})
 
 				When("Specified cleanup interval passes", func() {
+					BeforeEach(func() {
+						ctx = ctxBuilder.Build()
+					})
+
 					Context("operation platform is service Manager", func() {
 						It("Deletes operations older than that interval", func() {
 							ctx.SMWithOAuth.DELETE(web.ServiceBrokersURL+"/non-existent-broker-id").WithQuery("async", true).
@@ -370,6 +375,10 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				})
 
 				When("Specified action timeout passes", func() {
+					BeforeEach(func() {
+						ctx = ctxBuilder.Build()
+					})
+
 					It("Marks orphans as failed operations", func() {
 						operation := &types.Operation{
 							Base: types.Base{
@@ -402,10 +411,110 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						}, actionTimeout*6).Should(Equal(types.FAILED))
 					})
 				})
+
+				When("operation gets stuck in progress without being reschedulable", func() {
+					var operation *types.Operation
+
+					BeforeEach(func() {
+						ctxBuilder.WithSMExtensions(func(ctx context.Context, smb *sm.ServiceManagerBuilder, e env.Environment) error {
+							smb.WithDeleteAroundTxInterceptorProvider(types.ServiceBrokerType, DeleteBrokerDelayingInterceptorProvider{}).Register()
+							return nil
+						})
+
+						ctx = ctxBuilder.Build()
+
+						operation = &types.Operation{
+							Base: types.Base{
+								ID:        defaultOperationID,
+								CreatedAt: time.Now().Add(-5 * actionTimeout),
+								UpdatedAt: time.Now().Add(-5 * actionTimeout),
+								Labels:    make(map[string][]string),
+								Ready:     true,
+							},
+							State:         types.IN_PROGRESS,
+							ResourceID:    "test-resource-id",
+							ResourceType:  web.ServiceBrokersURL,
+							PlatformID:    types.SMPlatform,
+							CorrelationID: "test-correlation-id",
+							Reschedule:    false,
+						}
+					})
+
+					When("when operation is create", func() {
+						It("marks the operation as failed with scheduled deletion", func() {
+							operation.Type = types.CREATE
+
+							object, err := ctx.SMRepository.Create(context.Background(), operation)
+							Expect(err).To(BeNil())
+							Expect(object).To(Not(BeNil()))
+
+							VerifyOperationExists(ctx, "", OperationExpectations{
+								Category:          operation.Type,
+								State:             types.FAILED,
+								ResourceType:      operation.ResourceType,
+								Reschedulable:     false,
+								DeletionScheduled: true,
+							})
+						})
+					})
+
+					When("when operation is delete", func() {
+						It("marks the operation as failed with scheduled deletion", func() {
+							operation.Type = types.DELETE
+
+							object, err := ctx.SMRepository.Create(context.Background(), operation)
+							Expect(err).To(BeNil())
+							Expect(object).To(Not(BeNil()))
+
+							VerifyOperationExists(ctx, "", OperationExpectations{
+								Category:          operation.Type,
+								State:             types.FAILED,
+								ResourceType:      operation.ResourceType,
+								Reschedulable:     false,
+								DeletionScheduled: true,
+							})
+						})
+					})
+
+					When("when operation is update", func() {
+						It("marks the operation as failed without scheduled deletion", func() {
+							operation.Type = types.UPDATE
+
+							object, err := ctx.SMRepository.Create(context.Background(), operation)
+							Expect(err).To(BeNil())
+							Expect(object).To(Not(BeNil()))
+
+							VerifyOperationExists(ctx, "", OperationExpectations{
+								Category:          operation.Type,
+								State:             types.FAILED,
+								ResourceType:      operation.ResourceType,
+								Reschedulable:     false,
+								DeletionScheduled: false,
+							})
+						})
+					})
+				})
 			})
 		})
 	},
 })
+
+type DeleteBrokerDelayingInterceptorProvider struct{}
+
+func (DeleteBrokerDelayingInterceptorProvider) Name() string {
+	return "DeleteBrokerDelayingInterceptorProvider"
+}
+
+func (DeleteBrokerDelayingInterceptorProvider) Provide() storage.DeleteAroundTxInterceptor {
+	return DeleteBrokerDelayingInterceptor{}
+}
+
+type DeleteBrokerDelayingInterceptor struct{}
+
+func (DeleteBrokerDelayingInterceptor) AroundTxDelete(f storage.InterceptDeleteAroundTxFunc) storage.InterceptDeleteAroundTxFunc {
+	<-time.After(2 * time.Second)
+	return f
+}
 
 func blueprint(ctx *TestContext, _ *SMExpect, _ bool) Object {
 	cPaidPlan := GeneratePaidTestPlan()

--- a/test/service_binding_test/service_binding_test.go
+++ b/test/service_binding_test/service_binding_test.go
@@ -877,6 +877,7 @@ var _ = DescribeTestsFor(TestCase{
 										BeforeEach(func() {
 											newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
 												e.Set("server.shutdown_timeout", 1*time.Second)
+												e.Set("operations.maintainer_retry_interval", 1*time.Second)
 											}).BuildWithoutCleanup()
 
 											brokerServer.BindingHandlerFunc(http.MethodPut, http.MethodPut+"1", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))
@@ -1260,6 +1261,7 @@ var _ = DescribeTestsFor(TestCase{
 									BeforeEach(func() {
 										newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
 											e.Set("server.shutdown_timeout", 1*time.Second)
+											e.Set("operations.maintainer_retry_interval", 1*time.Second)
 										}).BuildWithoutCleanup()
 
 										brokerServer.BindingHandlerFunc(http.MethodDelete, http.MethodDelete+"3", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))
@@ -1834,6 +1836,7 @@ var _ = DescribeTestsFor(TestCase{
 										BeforeEach(func() {
 											newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
 												e.Set("server.shutdown_timeout", 1*time.Second)
+												e.Set("operations.maintainer_retry_interval", 1*time.Second)
 											}).BuildWithoutCleanup()
 
 											brokerServer.BindingHandlerFunc(http.MethodDelete, http.MethodDelete+"1", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))

--- a/test/service_binding_test/service_binding_test.go
+++ b/test/service_binding_test/service_binding_test.go
@@ -1071,6 +1071,7 @@ var _ = DescribeTestsFor(TestCase{
 									BeforeEach(func() {
 										newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
 											e.Set("server.shutdown_timeout", 1*time.Second)
+											e.Set("operations.maintainer_retry_interval", 1*time.Second)
 										}).BuildWithoutCleanup()
 
 										brokerServer.BindingHandlerFunc(http.MethodDelete, http.MethodDelete+"3", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))

--- a/test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_test/service_instance_test.go
@@ -981,6 +981,7 @@ var _ = DescribeTestsFor(TestCase{
 									BeforeEach(func() {
 										newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
 											e.Set("server.shutdown_timeout", 1*time.Second)
+											e.Set("operations.maintainer_retry_interval", 1*time.Second)
 										}).BuildWithoutCleanup()
 
 										brokerServer.ServiceInstanceHandlerFunc(http.MethodDelete, http.MethodDelete+"3", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))

--- a/test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_test/service_instance_test.go
@@ -785,6 +785,7 @@ var _ = DescribeTestsFor(TestCase{
 										BeforeEach(func() {
 											newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
 												e.Set("server.shutdown_timeout", 1*time.Second)
+												e.Set("operations.maintainer_retry_interval", 1*time.Second)
 											}).BuildWithoutCleanup()
 
 											brokerServer.ServiceInstanceLastOpHandlerFunc(http.MethodPut+"1", func(_ *http.Request) (int, map[string]interface{}) {
@@ -1194,6 +1195,7 @@ var _ = DescribeTestsFor(TestCase{
 									BeforeEach(func() {
 										newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
 											e.Set("server.shutdown_timeout", 1*time.Second)
+											e.Set("operations.maintainer_retry_interval", 1*time.Second)
 										}).BuildWithoutCleanup()
 
 										brokerServer.ServiceInstanceHandlerFunc(http.MethodDelete, http.MethodDelete+"3", ParameterizedHandler(http.StatusAccepted, Object{"async": true}))
@@ -2843,6 +2845,7 @@ var _ = DescribeTestsFor(TestCase{
 											BeforeEach(func() {
 												newSMCtx = t.ContextBuilder.WithEnvPostExtensions(func(e env.Environment, servers map[string]FakeServer) {
 													e.Set("server.shutdown_timeout", 1*time.Second)
+													e.Set("operations.maintainer_retry_interval", 1*time.Second)
 												}).BuildWithoutCleanup()
 
 												brokerServer.ServiceInstanceLastOpHandlerFunc(http.MethodDelete+"1", func(_ *http.Request) (int, map[string]interface{}) {


### PR DESCRIPTION
* fix logging and missing correlation ids when maintainer schedules an operation
* fix namings of maintainer functors
* fix maintainer setting deletion scheduled on stuck updates
* fix maintainer trying to do orphan mitigation after a stuck update operation has been marked as failed
* fix scheduler trying to create a new operation when invoked by maintainer even though one already exists (when maintainer reschedules an operation which is not the last operation for this resource because several hours have passed and newer operations have appeared after the one that is being rescheduled)