### PR TITLE
[FIX] Do not require basic credentials, when using tls

### DIFF
--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -112,7 +112,7 @@ func (c *Controller) proxy(r *web.Request, logger *logrus.Entry, broker *types.S
 	}
 
 	modifiedRequest := r.Request.WithContext(ctx)
-	if broker.Credentials.Basic.Username != "" && broker.Credentials.Basic.Password != "" {
+	if broker.Credentials.Basic != nil {
 		modifiedRequest.SetBasicAuth(broker.Credentials.Basic.Username, broker.Credentials.Basic.Password)
 	}
 

--- a/storage/interceptors/smaap_service_instance_interceptor.go
+++ b/storage/interceptors/smaap_service_instance_interceptor.go
@@ -612,12 +612,15 @@ func preparePrerequisites(ctx context.Context, repository storage.Repository, os
 		EnableAlphaFeatures: true,
 		URL:                 broker.BrokerURL,
 		APIVersion:          osbc.LatestAPIVersion(),
-		AuthConfig: &osbc.AuthConfig{
+	}
+
+	if broker.Credentials.Basic != nil {
+		osbClientConfig.AuthConfig = &osbc.AuthConfig{
 			BasicAuthConfig: &osbc.BasicAuthConfig{
 				Username: broker.Credentials.Basic.Username,
 				Password: broker.Credentials.Basic.Password,
 			},
-		},
+		}
 	}
 
 	if tlsConfig != nil {

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -487,11 +487,11 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 					//actually the broker return invalid credentials, however the response is converted by the catalog fetch into badRequest
 					Context("when broker tls settings are valid but basic auth credentials are missing", func() {
-						It("returns StatusBadRequest", func() {
+						It("returns StatusCreated", func() {
 							ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerRequestWithTLS).
 								Expect().
-								Status(http.StatusBadRequest)
-							assertInvocationCount(brokerServerWithTLS.CatalogEndpointRequests, 0)
+								Status(http.StatusCreated)
+							assertInvocationCount(brokerServerWithTLS.CatalogEndpointRequests, 1)
 						})
 					})
 

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -649,10 +649,6 @@ func (ctx *TestContext) RegisterBrokerWithRandomCatalogAndTLS(expect *SMExpect) 
 		"broker_url":  brokerServerWithTLS.URL(),
 		"description": BrokerServerPrefixTLS + UUID2.String(),
 		"credentials": Object{
-			"basic": Object{
-				"username": brokerServerWithTLS.Username,
-				"password": brokerServerWithTLS.Password,
-			},
 			"tls": Object{
 				"client_certificate": tls_settings.ClientCertificate,
 				"client_key":         tls_settings.ClientKey,

--- a/test/osb_test/provision_test.go
+++ b/test/osb_test/provision_test.go
@@ -19,10 +19,11 @@ package osb_test
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"github.com/Peripli/service-manager/pkg/query"
 	"github.com/Peripli/service-manager/test"
 	"github.com/Peripli/service-manager/test/common"
-	"net/http"
 
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/pkg/web"

--- a/test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_test/service_instance_test.go
@@ -303,7 +303,6 @@ var _ = DescribeTestsFor(TestCase{
 									WithQuery("async", true).
 									WithJSON(postInstanceRequestTLS).
 									Expect().Status(http.StatusAccepted)
-
 							})
 
 							It("returns 201", func() {
@@ -3407,7 +3406,7 @@ func blueprint(ctx *TestContext, auth *SMExpect, async bool) Object {
 		panic(err)
 	}
 
-	instanceReqBody := make(Object, 0)
+	instanceReqBody := make(Object)
 	instanceReqBody["name"] = "test-service-instance-" + ID.String()
 	_, array := prepareBrokerWithCatalog(ctx, auth)
 	instanceReqBody["service_plan_id"] = array.First().Object().Value("id").String().Raw()


### PR DESCRIPTION
## Motivation

Do not require basic credentials if broker supports tls when doing provision requests.

## Pull Request status

* [x] Initial implementation
* [x] Unit tests
