### PR TITLE
add validation to plan description (should not be empty)

### DIFF
--- a/pkg/types/service_plan.go
+++ b/pkg/types/service_plan.go
@@ -87,6 +87,9 @@ func (e *ServicePlan) Validate() error {
 	if e.ServiceOfferingID == "" {
 		return fmt.Errorf("service plan service offering id missing")
 	}
+	if e.Description == "" {
+		return fmt.Errorf("service plan description is missing")
+	}
 	var obj map[string]interface{}
 	if len(e.Schemas) != 0 {
 		if err := json.Unmarshal(e.Schemas, &obj); err != nil {

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -1429,8 +1429,6 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						})
 					})
 
-
-
 					verifyPATCHWhenCatalogFieldIsMissing := func(responseVerifier func(r *httpexpect.Response), shouldUpdateCatalog bool, fieldPath string) {
 						var expectedCatalog string
 
@@ -1871,10 +1869,9 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						Context("when a new service offering with new plans with empty description is added", func() {
 							var anotherServiceID string
 
-
 							BeforeEach(func() {
 
-								planStr:= GeneratePaidTestPlan()
+								planStr := GeneratePaidTestPlan()
 								planStr, err := sjson.Delete(planStr, "description")
 								Expect(err).ToNot(HaveOccurred())
 								anotherPlan := JSONToMap(planStr)


### PR DESCRIPTION
# Pull Request Template

## Prerequisites

https://jtrack.wdf.sap.corp/browse/NGPBUG-114921

## Motivation

SM accepted catalog with empty plan's description while CC doesn't.
They should be aligned. So this fix validated that a description exists

## Approach

_How does this change address the problem?_

## Pull Request status

* [x] Initial implementation
* [ ] Refactoring
* [ ] Unit tests
* [ ] Integration tests

Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.

## Third-party code

If you use third party code with your contribution such as, components, libraries, or snippets make sure to mention that.

Make sure that your contribution complies with our [Contribution guidelines][1].

## Work in Progress label

For as long as development of your Pull Request is still ongoing you MUST label it with a **wip** label as well as prefix the name of the PR with *[WIP]*.

For example: *[WIP] Service brokers API*

[1]: https://github.com/Peripli/service-manager/blob/master/CONTRIBUTING.md
