### PR TITLE
Add .pipeline to .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 vendor/
 debug
 .vscode/
+.pipeline/
 .gitignore
 .gometalinter.json
 .travis.yml


### PR DESCRIPTION
## Motivation

The .pipeline folder keep information needed only for CI/CD automation. Not related to project functionality or structure. Such files need to be ignored and not stored in repository. 

## Approach

Adding folder to .gitignore 

## Pull Request status

* [x] implementation