### PR TITLE
Excluded platform names

### DIFF
--- a/pkg/types/service_plan.go
+++ b/pkg/types/service_plan.go
@@ -106,5 +106,17 @@ func (e *ServicePlan) Validate() error {
 		return fmt.Errorf("only one of supportedPlatforms and supportedPlatformNames can be defined in plan metadata")
 	}
 
+	return e.validateSupportedPlatformsMetadata()
+}
+
+func (e *ServicePlan) validateSupportedPlatformsMetadata() error {
+
+	if (len(e.SupportedPlatformNames()) != 0 && (len(e.SupportedPlatformTypes()) != 0 || len(e.ExcludedPlatformNames()) != 0)) ||
+		(len(e.SupportedPlatformTypes()) != 0 && (len(e.SupportedPlatformNames()) != 0 || len(e.ExcludedPlatformNames()) != 0)) ||
+		(len(e.ExcludedPlatformNames()) != 0 && (len(e.SupportedPlatformTypes()) != 0 || len(e.SupportedPlatformNames()) != 0)) {
+
+		return fmt.Errorf("only one of supportedPlatforms, supportedPlatformNames and excludedPlatformNames can be defined in plan metadata")
+	}
+
 	return nil
 }

--- a/pkg/types/service_plan.go
+++ b/pkg/types/service_plan.go
@@ -19,8 +19,10 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Peripli/service-manager/pkg/util"
+	"math"
 	"reflect"
+
+	"github.com/Peripli/service-manager/pkg/util"
 )
 
 //go:generate smgen api ServicePlan
@@ -110,11 +112,11 @@ func (e *ServicePlan) Validate() error {
 }
 
 func (e *ServicePlan) validateSupportedPlatformsMetadata() error {
+	hasSupportedPlatformNames := math.Min(float64(len(e.SupportedPlatformNames())), 1)
+	hasSupportedPlatformTypes := math.Min(float64(len(e.SupportedPlatformTypes())), 1)
+	hasExcludedPlatformNames := math.Min(float64(len(e.ExcludedPlatformNames())), 1)
 
-	if (len(e.SupportedPlatformNames()) != 0 && (len(e.SupportedPlatformTypes()) != 0 || len(e.ExcludedPlatformNames()) != 0)) ||
-		(len(e.SupportedPlatformTypes()) != 0 && (len(e.SupportedPlatformNames()) != 0 || len(e.ExcludedPlatformNames()) != 0)) ||
-		(len(e.ExcludedPlatformNames()) != 0 && (len(e.SupportedPlatformTypes()) != 0 || len(e.SupportedPlatformNames()) != 0)) {
-
+	if hasExcludedPlatformNames+hasSupportedPlatformNames+hasSupportedPlatformTypes > 1 {
 		return fmt.Errorf("only one of supportedPlatforms, supportedPlatformNames and excludedPlatformNames can be defined in plan metadata")
 	}
 

--- a/pkg/types/service_plan_utils.go
+++ b/pkg/types/service_plan_utils.go
@@ -34,30 +34,38 @@ func (e *ServicePlan) SupportsPlatformType(platformType string) bool {
 
 // SupportsPlatformInstance determines whether a specific platform instance is among the ones that a plan supports
 func (e *ServicePlan) SupportsPlatformInstance(platform Platform) bool {
-	platformNames := e.SupportedPlatformNames()
+	if excludedPlatformNames := e.ExcludedPlatformNames(); len(excludedPlatformNames) > 0 {
+		return !slice.StringsAnyEquals(excludedPlatformNames, platform.Name)
+	}
 
-	if len(platformNames) == 0 {
-		return e.SupportsPlatformType(platform.Type)
-	} else {
+	if platformNames := e.SupportedPlatformNames(); len(platformNames) > 0 {
 		return slice.StringsAnyEquals(platformNames, platform.Name)
+	} else {
+		return e.SupportsPlatformType(platform.Type)
 	}
 }
 
 // SupportsAllPlatforms determines whether the plan supports all platforms
 func (e *ServicePlan) SupportsAllPlatforms() bool {
-	return len(e.SupportedPlatformNames()) == 0 && len(e.SupportedPlatformTypes()) == 0
+	return len(e.SupportedPlatformNames()) == 0 && len(e.SupportedPlatformTypes()) == 0 && len(e.ExcludedPlatformNames()) == 0
 }
 
 // SupportedPlatformTypes returns the supportedPlatforms provided in a plan's metadata (if a value is provided at all).
-// If there are no supported platforms, nil is returned denoting that the plan is available to platforms of all types.
+// If there are no supported platforms, empty array is returned denoting that the plan is available to platforms of all types.
 func (e *ServicePlan) SupportedPlatformTypes() []string {
 	return e.metadataPropertyAsStringArray("supportedPlatforms")
 }
 
 // SupportedPlatformNames returns the supportedPlatformNames provided in a plan's metadata (if a value is provided at all).
-// If there are no supported platforms names, nil is returned
+// If there are no supported platforms names, empty array is returned
 func (e *ServicePlan) SupportedPlatformNames() []string {
 	return e.metadataPropertyAsStringArray("supportedPlatformNames")
+}
+
+// ExcludedPlatformNames returns the excludedPlatformNames provided in a plan's metadata (if a value is provided at all).
+// If there are no excluded platforms names, empty array is returned
+func (e *ServicePlan) ExcludedPlatformNames() []string {
+	return e.metadataPropertyAsStringArray("excludedPlatformNames")
 }
 
 func (e *ServicePlan) metadataPropertyAsStringArray(propertyKey string) []string {

--- a/storage/service_plans/resolver.go
+++ b/storage/service_plans/resolver.go
@@ -2,97 +2,42 @@ package service_plans
 
 import (
 	"context"
-	"fmt"
 	"github.com/Peripli/service-manager/pkg/query"
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/storage"
 )
 
 func ResolveSupportedPlatformIDsForPlans(ctx context.Context, plans []*types.ServicePlan, repository storage.Repository) ([]string, error) {
-	platformTypes := make(map[string]bool)
-	platformNames := make(map[string]bool)
-	allPlatformsSupported := false
+	platformIDsSet := make(map[string]bool)
+
 	for _, plan := range plans {
-		if plan.SupportsAllPlatforms() {
-			// all platforms are supported by one of the plan, no need for further processing
-			allPlatformsSupported = true
-			break
-		}
-
-		planSupportedPlatformNames := plan.SupportedPlatformNames()
-		if len(planSupportedPlatformNames) == 0 {
-			// no explicit supported platform names defined - collect the supported platform types
-			supportedPlatformTypes := plan.SupportedPlatformTypes()
-			for _, t := range supportedPlatformTypes {
-				platformTypes[t] = true
-			}
-		} else {
-			// explicit platform names are defined for the plan
-			for _, name := range planSupportedPlatformNames {
-				platformNames[name] = true
-			}
-		}
-	}
-
-	platformIDs := make(map[string]bool)
-	var criteria []query.Criterion
-
-	if !allPlatformsSupported {
-		if len(platformNames) != 0 {
-			// fetch IDs of platform instances with the requested names
-			supportedPlatformNames := make([]string, 0)
-			for name := range platformNames {
-				supportedPlatformNames = append(supportedPlatformNames, name)
-			}
-			err := addIDsOfSupportedPlatformNames(ctx, repository, supportedPlatformNames, platformIDs)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if len(platformTypes) != 0 {
-			//add a criteria for the supported types
-			supportedPlatformTypes := make([]string, 0)
-			for platformType := range platformTypes {
-				if platformType == types.GetSMSupportedPlatformType() {
-					platformType = types.SMPlatform
-				}
-				supportedPlatformTypes = append(supportedPlatformTypes, platformType)
-			}
-
-			criteria = []query.Criterion{query.ByField(query.InOperator, "type", supportedPlatformTypes...)}
-		}
-	}
-
-	if allPlatformsSupported || criteria != nil {
-		// fetch IDs of platform instances of the supported types from DB
-		objList, err := repository.List(ctx, types.PlatformType, criteria...)
-		if err != nil {
+		if err := addSupportedPlatformIDsForPlan(ctx, plan, repository, platformIDsSet); err != nil {
 			return nil, err
 		}
-
-		for i := 0; i < objList.Len(); i++ {
-			platformIDs[objList.ItemAt(i).GetID()] = true
-		}
 	}
 
-	supportedPlatformIDs := make([]string, 0)
-	for id := range platformIDs {
-		supportedPlatformIDs = append(supportedPlatformIDs, id)
+	platformIDs := make([]string, 0)
+	for id := range platformIDsSet {
+		platformIDs = append(platformIDs, id)
 	}
-
-	return supportedPlatformIDs, nil
+	return platformIDs, nil
 }
 
-func addIDsOfSupportedPlatformNames(ctx context.Context, repository storage.Repository, supportedPlatformNames []string, platformIDs map[string]bool) error {
-	var criteria []query.Criterion
-	if len(supportedPlatformNames) != 0 {
-		criteria = []query.Criterion{query.ByField(query.InOperator, "name", supportedPlatformNames...)}
-	} else {
-		return fmt.Errorf("supportedPlatformNames must be a non empty array")
+func addSupportedPlatformIDsForPlan(ctx context.Context, plan *types.ServicePlan, repository storage.Repository, platformIDs map[string]bool) error {
+	criterions := make([]query.Criterion, 0)
+	if excludedPlatformNames := plan.ExcludedPlatformNames(); len(excludedPlatformNames) > 0 {
+		// plan explicitly defined excluded platforms, all other platforms are supported
+		criterions = append(criterions, query.ByField(query.NotInOperator, "name", excludedPlatformNames...))
+	} else if planSupportedPlatformNames := plan.SupportedPlatformNames(); len(planSupportedPlatformNames) > 0 {
+		// plan explicitly defined supported platform names
+		criterions = append(criterions, query.ByField(query.InOperator, "name", planSupportedPlatformNames...))
+	} else if planSupportedPlatformTypes := plan.SupportedPlatformTypes(); len(planSupportedPlatformTypes) > 0 {
+		// plan explicitly defined supported platform types
+		criterions = append(criterions, query.ByField(query.InOperator, "type", planSupportedPlatformTypes...))
 	}
 
-	objList, err := repository.List(ctx, types.PlatformType, criteria...)
+	// fetch IDs of platform instances of the supported types from DB
+	objList, err := repository.List(ctx, types.PlatformType, criterions...)
 	if err != nil {
 		return err
 	}
@@ -100,5 +45,6 @@ func addIDsOfSupportedPlatformNames(ctx context.Context, repository storage.Repo
 	for i := 0; i < objList.Len(); i++ {
 		platformIDs[objList.ItemAt(i).GetID()] = true
 	}
+
 	return nil
 }

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -595,6 +595,20 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								r.Status(http.StatusBadRequest).JSON().Object().Keys().NotContains("services", "credentials")
 							}, "services.0.plans.0.metadata", common.Object{"supportedPlatforms": []string{"a"}, "supportedPlatformNames": []string{"a"}})
 						})
+
+						Context("that has both supportedPlatforms and excludedPlatformNames", func() {
+
+							verifyPOSTWhenCatalogFieldHasValue(func(r *httpexpect.Response) {
+								r.Status(http.StatusBadRequest).JSON().Object().Keys().NotContains("services", "credentials")
+							}, "services.0.plans.0.metadata", common.Object{"supportedPlatforms": []string{"a"}, "excludedPlatformNames": []string{"a"}})
+						})
+
+						Context("that has both supportedPlatformNames and excludedPlatformNames", func() {
+
+							verifyPOSTWhenCatalogFieldHasValue(func(r *httpexpect.Response) {
+								r.Status(http.StatusBadRequest).JSON().Object().Keys().NotContains("services", "credentials")
+							}, "services.0.plans.0.metadata", common.Object{"supportedPlatformNames": []string{"a"}, "excludedPlatformNames": []string{"a"}})
+						})
 					})
 				})
 


### PR DESCRIPTION
## Motivation

In some cases a service plan must not be visible on a specific platform, e.g. to avoid name conflicts with locally-registered brokers on that platform. 

## Approach

This change introduces a new property that can be added in a plan's catalog metadata: `excludedPlatformNames`. If set on a plan, this plan will not be visible on platforms with names specified in the property value.  
## Pull Request status

* [x] Initial implementation
* [x] Integration tests

