### PR TITLE
Configure page size when listing resources

### DIFF
--- a/pkg/util/list.go
+++ b/pkg/util/list.go
@@ -21,6 +21,9 @@ type ListIterator struct {
 	done bool
 }
 
+// DefaultPageSize means to use the server default page size when fetching multiple resources
+const DefaultPageSize = -1
+
 type listResponse struct {
 	Token    string      `json:"token"`
 	NumItems int64       `json:"num_items"`
@@ -86,7 +89,7 @@ func ListAll(ctx context.Context, doRequest DoRequestFunc, url string, items int
 	options := ListOptions{
 		DoRequest: doRequest,
 		URL:       url,
-		PageSize:  -1, // server default page size
+		PageSize:  DefaultPageSize,
 		Items:     items,
 	}
 	return ListAllWithOptions(ctx, options)

--- a/pkg/util/list_test.go
+++ b/pkg/util/list_test.go
@@ -174,7 +174,7 @@ var _ = Describe("List Utils", func() {
 			})
 		})
 
-		When("There the server returns error status", func() {
+		When("the server returns error status", func() {
 			It("Returns an error", func() {
 				reaction.Status = 500
 				var items []string
@@ -228,4 +228,44 @@ var _ = Describe("List Utils", func() {
 		})
 	})
 
+	Describe("ListAllWithOptions", func() {
+		It("sets the page size", func() {
+			expectations.Params["max_items"] = "2"
+			sequence := []common.HTTPCouple{
+				{
+					Expectations: &expectations,
+					Reaction: &common.HTTPReaction{
+						Status: http.StatusOK,
+						Body: `{
+							"num_items": 3,
+							"token": "page2",
+							"items":["aaa","bbb"]
+						}`,
+					},
+				},
+				{
+					Expectations: &expectations,
+					Reaction: &common.HTTPReaction{
+						Status: http.StatusOK,
+						Body: `{
+							"num_items": 3,
+							"items":["ccc"]
+						}`,
+					},
+				},
+			}
+
+			var items []string
+			options := util.ListOptions{
+				DoRequest: common.DoHTTPSequence(sequence),
+				URL:       url,
+				PageSize:  2,
+				Items:     &items,
+			}
+			err := util.ListAllWithOptions(ctx, options)
+
+			Expect(err).To(BeNil())
+			Expect(items).To(Equal([]string{"aaa", "bbb", "ccc"}))
+		})
+	})
 })


### PR DESCRIPTION
When fetching resources using the default page size sometimes leads to timeout.
Sometimes we need to configure smaller page size.


