### PR TITLE
Prefer X-CorrelationID header over X-Correlation-ID

### DIFF
--- a/pkg/log/request.go
+++ b/pkg/log/request.go
@@ -23,7 +23,8 @@ import (
 )
 
 // CorrelationIDHeaders are the headers whose values will be taken as a correlation id for incoming requests
-var CorrelationIDHeaders = []string{"X-Correlation-ID", "X-CorrelationID", "X-ForRequest-ID", "X-Request-ID", "X-Vcap-Request-Id", "X-Broker-API-Request-Identity"}
+// The first one will be set on outgoing requests
+var CorrelationIDHeaders = []string{"X-CorrelationID", "X-Correlation-ID", "X-ForRequest-ID", "X-Request-ID", "X-Vcap-Request-Id", "X-Broker-API-Request-Identity"}
 
 // CorrelationIDForRequest returns checks the http headers for any of the supported correlation id headers.
 // The first that matches is taken as the correlation id. If none exists a new one is generated.


### PR DESCRIPTION
`X-CorrelationID` (with a single dash) is the correct header to set on outbound requests