### PR TITLE
fix unstable tests executions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       name: "Unit Tests"
       script:
         - make precommit-unit-tests
-        - goveralls -coverprofile profile-unit-test.cov -service=travis-ci
+        - goveralls -coverprofile profile-unit.cov -service=travis-ci
         - kill %1
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,31 +18,31 @@ jobs:
       name: "Other Integration Tests"
       script:
         - make precommit-integration-tests-other
-        - goveralls -coverprofile profile.cov -service=travis-ci
+        - goveralls -coverprofile profile-int-other.cov -service=travis-ci
         - kill %1
     - stage: "Tests"
       name: "Broker Integration Tests"
       script:
         - make precommit-integration-tests-broker
-        - goveralls -coverprofile profile.cov -service=travis-ci
+        - goveralls -coverprofile profile-int-broker.cov -service=travis-ci
         - kill %1
     - stage: "Tests"
       name: "OSB and Plugin Integration Tests"
       script:
         - make precommit-integration-tests-osb-and-plugin
-        - goveralls -coverprofile profile.cov -service=travis-ci
+        - goveralls -coverprofile profile-int-osb-and-plugin.cov -service=travis-ci
         - kill %1
     - stage: "Tests"
       name: "Service Instance and Service Bindings Integration Tests"
       script:
         - make precommit-integration-tests-service-instance-and-binding
-        - goveralls -coverprofile profile.cov -service=travis-ci
+        - goveralls -coverprofile profile-int-service-instance-and-bindings.cov -service=travis-ci
         - kill %1
     - stage: "Tests"
       name: "Unit Tests"
       script:
         - make precommit-unit-tests
-        - goveralls -coverprofile profile.cov -service=travis-ci
+        - goveralls -coverprofile profile-unit-test.cov -service=travis-ci
         - kill %1
 
 env:

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,12 @@ PROJECT_PKG 		?= github.com/Peripli/service-manager
 PLATFORM 			?= linux
 ARCH     			?= amd64
 
-UNIT_TEST_PROFILE 	?= $(CURDIR)/profile-unit.cov
 INT_TEST_PROFILE 	?= $(CURDIR)/profile-int.cov
+UNIT_TEST_PROFILE 	?= $(CURDIR)/profile-unit.cov
+INT_BROKER_TEST_PROFILE ?= $(CURDIR)/profile-int-broker.cov
+INT_OSB_AND_PLUGIN_TEST_PROFILE ?= $(CURDIR)/profile-int-osb-and-plugin.cov
+INT_SERVICE_INSTANCE_AND_BINDINGS_TEST_PROFILE ?= $(CURDIR)/profile-int-service-instance-and-bindings.cov
+INT_OTHER_TEST_PROFILE ?= $(CURDIR)/profile-int-other.cov
 TEST_PROFILE 		?= $(CURDIR)/profile.cov
 COVERAGE 			?= $(CURDIR)/coverage.html
 
@@ -48,16 +52,16 @@ GO_INT_TEST 	= $(GO) test -p 1 -timeout 30m -race -coverpkg $(shell go list ./..
 				./test/... $(TEST_FLAGS) -coverprofile=$(INT_TEST_PROFILE)
 
 GO_INT_TEST_OTHER = $(GO) test -p 1 -timeout 30m -race -coverpkg $(shell go list ./... | egrep -v "fakes|test|cmd|parser" | paste -sd "," -) \
-				$(shell go list ./test/... | egrep -v "broker_test|osb_and_plugin_test|service_instance_and_binding_test") $(TEST_FLAGS) -coverprofile=$(INT_TEST_PROFILE)
+				$(shell go list ./test/... | egrep -v "broker_test|osb_and_plugin_test|service_instance_and_binding_test") $(TEST_FLAGS) -coverprofile=$(INT_OTHER_TEST_PROFILE)
 
 GO_INT_TEST_BROKER = $(GO) test -p 1 -timeout 30m -race -coverpkg $(shell go list ./... | egrep -v "fakes|test|cmd|parser" | paste -sd "," -) \
-				./test/broker_test/... $(TEST_FLAGS) -coverprofile=$(INT_TEST_PROFILE)
+				./test/broker_test/... $(TEST_FLAGS) -coverprofile=$(INT_BROKER_TEST_PROFILE)
 
 GO_INT_TEST_OSB_AND_PLUGIN = $(GO) test -p 1 -timeout 30m -race -coverpkg $(shell go list ./... | egrep -v "fakes|test|cmd|parser" | paste -sd "," -) \
-				./test/osb_and_plugin_test/... $(TEST_FLAGS) -coverprofile=$(INT_TEST_PROFILE)
+				./test/osb_and_plugin_test/... $(TEST_FLAGS) -coverprofile=$(INT_OSB_AND_PLUGIN_TEST_PROFILE)
 
 GO_INT_TEST_SERVICE_INSTANCE_AND_BINDING = $(GO) test -p 1 -timeout 30m -race -coverpkg $(shell go list ./... | egrep -v "fakes|test|cmd|parser" | paste -sd "," -) \
-				./test/service_instance_and_binding_test/... $(TEST_FLAGS) -coverprofile=$(INT_TEST_PROFILE)
+				./test/service_instance_and_binding_test/... $(TEST_FLAGS) -coverprofile=$(INT_SERVICE_INSTANCE_AND_BINDINGS_TEST_PROFILE)
 
 GO_UNIT_TEST 	= $(GO) test -p 1 -race -coverpkg $(shell go list ./... | egrep -v "fakes|test|cmd|parser" | paste -sd "," -) \
 				$(shell go list ./... | egrep -v "test") -coverprofile=$(UNIT_TEST_PROFILE)
@@ -187,47 +191,8 @@ test-report: test-int test-unit
 	@$(GO) get github.com/wadey/gocovmerge
 	@gocovmerge $(CURDIR)/*.cov > $(TEST_PROFILE)
 
-test-report-integration-other: test-int-other
-	@$(GO) get github.com/wadey/gocovmerge
-	@gocovmerge $(CURDIR)/*.cov > $(TEST_PROFILE)
-
-test-report-integration-broker: test-int-broker
-	@$(GO) get github.com/wadey/gocovmerge
-	@gocovmerge $(CURDIR)/*.cov > $(TEST_PROFILE)
-
-test-report-integration-osb-and-plugin: test-int-osb-and-plugin
-	@$(GO) get github.com/wadey/gocovmerge
-	@gocovmerge $(CURDIR)/*.cov > $(TEST_PROFILE)
-
-test-report-integration-service-instance-and-binding: test-int-service-instance-and-binding
-	@$(GO) get github.com/wadey/gocovmerge
-	@gocovmerge $(CURDIR)/*.cov > $(TEST_PROFILE)
-
-test-report-unit: test-unit
-	@$(GO) get github.com/wadey/gocovmerge
-	@gocovmerge $(CURDIR)/*.cov > $(TEST_PROFILE)
 
 coverage: test-report ## Produces an HTML report containing code coverage details
-	@go tool cover -html=$(TEST_PROFILE) -o $(COVERAGE)
-	@echo Generated coverage report in $(COVERAGE).
-
-coverage-unit-tests: test-report-unit ## Produces an HTML report containing code coverage details
-	@go tool cover -html=$(TEST_PROFILE) -o $(COVERAGE)
-	@echo Generated coverage report in $(COVERAGE).
-
-coverage-int-tests-broker: test-report-integration-broker ## Produces an HTML report containing code coverage details
-	@go tool cover -html=$(TEST_PROFILE) -o $(COVERAGE)
-	@echo Generated coverage report in $(COVERAGE).
-
-coverage-int-tests-osb-and-plugin: test-report-integration-osb-and-plugin ## Produces an HTML report containing code coverage details
-	@go tool cover -html=$(TEST_PROFILE) -o $(COVERAGE)
-	@echo Generated coverage report in $(COVERAGE).
-
-coverage-int-tests-service-instance-and-binding: test-report-integration-service-instance-and-binding ## Produces an HTML report containing code coverage details
-	@go tool cover -html=$(TEST_PROFILE) -o $(COVERAGE)
-	@echo Generated coverage report in $(COVERAGE).
-
-coverage-int-tests-other: test-report-integration-other ## Produces an HTML report containing code coverage details
 	@go tool cover -html=$(TEST_PROFILE) -o $(COVERAGE)
 	@echo Generated coverage report in $(COVERAGE).
 
@@ -254,11 +219,11 @@ clean-coverage: clean-test-report ## Cleans up coverage artifacts
 # Formatting, Linting, Static code checks
 #-----------------------------------------------------------------------------
 precommit: build coverage format-check lint-check ## Run this before commiting (builds, recreates fakes, runs tests, checks linting and formating). This also runs integration tests - check test-int target for details
-precommit-integration-tests-broker: build coverage-int-tests-broker ## Run this before commiting (builds, recreates fakes, runs tests, checks linting and formating). This also runs integration tests - check test-int target for details
-precommit-integration-tests-osb-and-plugin: build coverage-int-tests-osb-and-plugin ## Run this before commiting (builds, recreates fakes, runs tests, checks linting and formating). This also runs integration tests - check test-int target for details
-precommit-integration-tests-service-instance-and-binding: build coverage-int-tests-service-instance-and-binding ## Run this before commiting (builds, recreates fakes, runs tests, checks linting and formating). This also runs integration tests - check test-int target for details
-precommit-integration-tests-other: build coverage-int-tests-other ## Run this before commiting (builds, recreates fakes, runs tests, checks linting and formating). This also runs integration tests - check test-int target for details
-precommit-unit-tests: build coverage-unit-tests format-check lint-check ## Run this before commiting (builds, recreates fakes, runs tests, checks linting and formating). This also runs integration tests - check test-int target for details
+precommit-integration-tests-broker: build test-int-broker ## Run this before commiting (builds, recreates fakes, runs tests, checks linting and formating). This also runs integration tests - check test-int target for details
+precommit-integration-tests-osb-and-plugin: build test-int-osb-and-plugin ## Run this before commiting (builds, recreates fakes, runs tests, checks linting and formating). This also runs integration tests - check test-int target for details
+precommit-integration-tests-service-instance-and-binding: build test-int-service-instance-and-binding ## Run this before commiting (builds, recreates fakes, runs tests, checks linting and formating). This also runs integration tests - check test-int target for details
+precommit-integration-tests-other: build test-int-other ## Run this before commiting (builds, recreates fakes, runs tests, checks linting and formating). This also runs integration tests - check test-int target for details
+precommit-unit-tests: build test-unit format-check lint-check ## Run this before commiting (builds, recreates fakes, runs tests, checks linting and formating). This also runs integration tests - check test-int target for details
 
 format: ## Formats the source code files with gofmt
 	@echo The following files were reformated:


### PR DESCRIPTION
## Motivation

After merging https://github.com/Peripli/service-manager/pull/520 we experience unstable stages in Travis. It happens because all stages use the same profile.cov file (coverage file). One stage can delete another stage profile.cov file and cause it to fail with error "Error parsing coverage: open profile.cov: no such file or directory"

## Approach
To fix the issue, we simply use 5 different profile.cov files:
profile-unit.cov
profile-int-broker.cov
profile-int-osb-and-plugin.cov
profile-int-service-instance-and-bindings.cov
profile-int-other.cov
