### PR TITLE
omit empty 'plans' JSON field in service_offerings responses

### DIFF
--- a/pkg/types/service_offering.go
+++ b/pkg/types/service_offering.go
@@ -45,7 +45,7 @@ type ServiceOffering struct {
 	CatalogID   string `json:"catalog_id"`
 	CatalogName string `json:"catalog_name"`
 
-	Plans []*ServicePlan `json:"plans"`
+	Plans []*ServicePlan `json:"plans,omitempty"`
 }
 
 func (e *ServiceOffering) Equals(obj Object) bool {


### PR DESCRIPTION
null plans array is always returned for service_offerings, this might lead clients to assume there are no plans for the service.