### PR TITLE
Authz - Support multiple trusted client ID suffixes

### DIFF
--- a/pkg/sm/security_builder.go
+++ b/pkg/sm/security_builder.go
@@ -175,8 +175,13 @@ func (sb *SecurityBuilder) WithScopes(scopes ...string) *SecurityBuilder {
 
 // WithClientIDSuffix applies authorization mechanism, which checks the JWT client id for the specified suffix
 func (sb *SecurityBuilder) WithClientIDSuffix(suffix string) *SecurityBuilder {
+	return sb.WithClientIDSuffixes([]string{suffix})
+}
+
+// WithClientIDSuffix applies authorization mechanism, which checks the JWT client id for one of the specified suffixes
+func (sb *SecurityBuilder) WithClientIDSuffixes(suffixes []string) *SecurityBuilder {
 	sb.authorization = true
-	sb.authorizers = append(sb.authorizers, authz.NewClientIDSuffixAuthorizer(suffix, web.GlobalAccess))
+	sb.authorizers = append(sb.authorizers, authz.NewClientIDSuffixesAuthorizer(suffixes, web.GlobalAccess))
 	return sb
 }
 

--- a/test/security_test/security_test.go
+++ b/test/security_test/security_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Service Manager Security Tests", func() {
 							WithScopes("read_health").Required()
 
 						smb.Security().Path(web.ServiceBrokersURL).Method(http.MethodGet).
-							WithClientIDSuffix("trustedsuffix").Required()
+							WithClientIDSuffixes([]string{"trustedsuffix", "anothertrustedsfx"}).Required()
 						return nil
 					})
 				})
@@ -178,6 +178,18 @@ var _ = Describe("Service Manager Security Tests", func() {
 					BeforeEach(func() {
 						contextBuilder.WithDefaultTokenClaims(map[string]interface{}{
 							"cid": "some_trustedsuffix",
+						})
+					})
+					It("should allow access", func() {
+						ctx.SMWithOAuth.GET(web.ServiceBrokersURL).Expect().
+							Status(http.StatusOK)
+					})
+				})
+
+				Context("with another trusted client id suffix", func() {
+					BeforeEach(func() {
+						contextBuilder.WithDefaultTokenClaims(map[string]interface{}{
+							"cid": "some_anothertrustedsfx",
 						})
 					})
 					It("should allow access", func() {


### PR DESCRIPTION
# Pull Request Template

## Motivation

In some cases it is required to support multiple trusted client ID suffixes in the authz layer.

## Approach

Enhance the ClientIDSuffixAuthorizer and the security builder to support an array of allowed suffixes 

## Pull Request status

* [x] Initial implementation
* [x] Unit tests