### PR TITLE
when there is no binding name use binding Id

### DIFF
--- a/api/osb/osb_store_plugin.go
+++ b/api/osb/osb_store_plugin.go
@@ -798,7 +798,7 @@ func (sp *storePlugin) storeBinding(ctx context.Context, storage storage.Reposit
 	bindingName := gjson.GetBytes(req.RawContext, "binding_name").String()
 	if len(bindingName) == 0 {
 		log.C(ctx).Debugf("Binding name missing. Defaulting to id %s", req.BindingID)
-		bindingName = req.InstanceID
+		bindingName = req.BindingID
 	}
 	binding := &types.ServiceBinding{
 		Base: types.Base{


### PR DESCRIPTION
When creating a binding on instance in k8s, the binding name is not enhanced on the context which is sent to SM.
SM verifies that a binding name exists, and if not it uses the binding Id as the binding name.
The current code the instance Id was used instead of the binding Id.  