### PR TITLE
setting maximum number of open connections to the database

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -23,7 +23,7 @@ storage:
   encryption_key: ejHjRNHbS0NaqARSRvnweVV9zcmhQEa8
   skip_ssl_validation: false
   max_idle_connections: 5
-  max_open_connections: 30 
+  max_open_connections: 30
 api:
   token_issuer_url: http://localhost:8080/uaa
   client_id: cf

--- a/application.yml
+++ b/application.yml
@@ -23,6 +23,7 @@ storage:
   encryption_key: ejHjRNHbS0NaqARSRvnweVV9zcmhQEa8
   skip_ssl_validation: false
   max_idle_connections: 5
+  max_open_connections: 30
 api:
   token_issuer_url: http://localhost:8080/uaa
   client_id: cf

--- a/application.yml
+++ b/application.yml
@@ -23,7 +23,7 @@ storage:
   encryption_key: ejHjRNHbS0NaqARSRvnweVV9zcmhQEa8
   skip_ssl_validation: false
   max_idle_connections: 5
-  max_open_connections: 30
+  max_open_connections: 30 
 api:
   token_issuer_url: http://localhost:8080/uaa
   client_id: cf

--- a/deployment/k8s/charts/service-manager/values.yaml
+++ b/deployment/k8s/charts/service-manager/values.yaml
@@ -49,3 +49,4 @@ config:
     token_issuer_url: https://uaa.dev.cfdev.sh
   storage:
     max_idle_connections: 5
+    max_open_connections: 30

--- a/storage/interfaces.go
+++ b/storage/interfaces.go
@@ -63,6 +63,7 @@ type Settings struct {
 	EncryptionKey      string                `mapstructure:"encryption_key" description:"key to use for encrypting database entries"`
 	SkipSSLValidation  bool                  `mapstructure:"skip_ssl_validation" description:"whether to skip ssl verification when connecting to the storage"`
 	MaxIdleConnections int                   `mapstructure:"max_idle_connections" description:"sets the maximum number of connections in the idle connection pool"`
+	MaxOpenConnections int                   `mapstructure:"max_open_connections" description:"sets the maximum number of open connections to the database"`
 	Notification       *NotificationSettings `mapstructure:"notification"`
 	IntegrityProcessor security.IntegrityProcessor
 }
@@ -75,6 +76,7 @@ func DefaultSettings() *Settings {
 		EncryptionKey:      "",
 		SkipSSLValidation:  false,
 		MaxIdleConnections: 5,
+		MaxOpenConnections: 30,
 		Notification:       DefaultNotificationSettings(),
 		IntegrityProcessor: &security.HashingIntegrityProcessor{
 			HashingFunc: func(data []byte) []byte {

--- a/storage/postgres/storage.go
+++ b/storage/postgres/storage.go
@@ -90,6 +90,7 @@ func (ps *Storage) Open(settings *storage.Settings) error {
 		}
 		ps.layerOneEncryptionKey = []byte(settings.EncryptionKey)
 		ps.db.SetMaxIdleConns(settings.MaxIdleConnections)
+		ps.db.SetMaxOpenConns(settings.MaxOpenConnections)
 		ps.pgDB = ps.db
 		ps.queryBuilder = NewQueryBuilder(ps.pgDB)
 

--- a/test/configuration_test/configuration_test.go
+++ b/test/configuration_test/configuration_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Service Manager Config API", func() {
 				"storage": {
 					"encryption_key": "ejHjRNHbS0NaqARSRvnweVV9zcmhQEa8",
 					"max_idle_connections": 5,
-					"max_open_connections": 5,
+					"max_open_connections": 30,
 					"notification": {
 						"clean_interval": "24h",
 						"keep_for": "24h",

--- a/test/configuration_test/configuration_test.go
+++ b/test/configuration_test/configuration_test.go
@@ -107,6 +107,7 @@ var _ = Describe("Service Manager Config API", func() {
 				"storage": {
 					"encryption_key": "ejHjRNHbS0NaqARSRvnweVV9zcmhQEa8",
 					"max_idle_connections": 5,
+					"max_open_connections": 5,
 					"notification": {
 						"clean_interval": "24h",
 						"keep_for": "24h",


### PR DESCRIPTION
Go Postgres driver for database (github.com/lib/pq) does not have any default upper-bound on the connections pool size.
The default is 0 (unlimited). It is important to set MaxOpenConns
https://golang.org/pkg/database/sql/#DB.SetMaxOpenConns
Otherwise under certain circumstances it may lead to connections rate increasing exponentially, exhausting the connections, and as a result the driver can bring the database into a critical state.