### PR TITLE
pass newObj configured services & plans to interceptors after broker update catalog

### DIFF
--- a/storage/interceptors/broker_update_catalog_interceptor.go
+++ b/storage/interceptors/broker_update_catalog_interceptor.go
@@ -94,7 +94,6 @@ func (c *brokerUpdateCatalogInterceptor) OnTxUpdate(f storage.InterceptUpdateOnT
 			return nil, err
 		}
 		log.C(ctx).Debugf("Found %d services and %d plans in catalog for broker with id %s", len(catalogServices), len(catalogPlansMap), brokerID)
-
 		log.C(ctx).Debugf("Resyncing service offerings for broker with id %s...", brokerID)
 		offeringsToBeCreated := make([]*types.ServiceOffering, 0)
 		for _, catalogService := range catalogServices {

--- a/storage/interceptors/broker_update_catalog_interceptor.go
+++ b/storage/interceptors/broker_update_catalog_interceptor.go
@@ -78,18 +78,18 @@ func (c *brokerUpdateCatalogInterceptor) OnTxUpdate(f storage.InterceptUpdateOnT
 
 		oldBroker.Services = existingServiceOfferingsWithServicePlans.ServiceOfferings
 
-		updatedObject, err := f(ctx, txStorage, oldObj, newObj, labelChanges...)
+		_, err = f(ctx, txStorage, oldObj, newObj, labelChanges...)
 		if err != nil {
 			return nil, err
 		}
 
-		updatedBroker := updatedObject.(*types.ServiceBroker)
-		brokerID := updatedBroker.GetID()
+		newBrokerObj := newObj.(*types.ServiceBroker)
+		brokerID := newObj.GetID()
 
 		existingServicesOfferingsMap, existingServicePlansPerOfferingMap := convertExistingServiceOfferringsToMaps(existingServiceOfferingsWithServicePlans.ServiceOfferings)
 		log.C(ctx).Debugf("Found %d services currently known for broker", len(existingServicesOfferingsMap))
 
-		catalogServices, catalogPlansMap, err := getBrokerCatalogServicesAndPlans(updatedBroker.Services)
+		catalogServices, catalogPlansMap, err := getBrokerCatalogServicesAndPlans(newBrokerObj.Services)
 		if err != nil {
 			return nil, err
 		}
@@ -222,10 +222,10 @@ func (c *brokerUpdateCatalogInterceptor) OnTxUpdate(f storage.InterceptUpdateOnT
 			}
 		}
 
-		updatedBroker.Services = catalogServices
+		newBrokerObj.Services = catalogServices
 
 		log.C(ctx).Debugf("Successfully resynced service plans for broker with id %s", brokerID)
-		return updatedBroker, nil
+		return newBrokerObj, nil
 	}
 }
 


### PR DESCRIPTION
# Pull Request Template

## Motivation

Allow interceptors configured after the broker_update_catalog_interceptor to obtain the original reference to services and plans 

## Approach
Use newObj instead of the updated_broker object

## Pull Request status

* [x ] Refactoring