### PR TITLE
filter brokers by visibilities in agent calls

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -150,6 +150,7 @@ func New(ctx context.Context, e env.Environment, options *Options) (*web.API, er
 			&filters.PatchOnlyLabelsFilter{},
 			filters.NewPlansFilterByVisibility(options.Repository),
 			filters.NewServicesFilterByVisibility(options.Repository),
+			filters.NewBrokersFilterByVisibility(options.Repository),
 			&filters.CheckBrokerCredentialsFilter{},
 			filters.NewServiceInstanceTransferFilter(options.Repository, options.APISettings.EnableInstanceTransfer),
 		},

--- a/api/filters/brokers_filter_by_visibility.go
+++ b/api/filters/brokers_filter_by_visibility.go
@@ -1,0 +1,91 @@
+package filters
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/types"
+
+	"github.com/Peripli/service-manager/storage"
+
+	"github.com/Peripli/service-manager/pkg/web"
+)
+
+const BrokersVisibilityFilterName = "BrokersFilterByVisibility"
+
+func NewBrokersFilterByVisibility(repository storage.Repository) *BrokersFilterByVisibility {
+	return &BrokersFilterByVisibility{
+		visibilityFilteringMiddleware: &visibilityFilteringMiddleware{
+			ListResourcesCriteria: brokersCriteriaFunc(repository),
+			IsResourceVisible:     isBrokerVisible(repository),
+		},
+	}
+}
+
+type BrokersFilterByVisibility struct {
+	*visibilityFilteringMiddleware
+}
+
+func isBrokerVisible(repository storage.Repository) func(ctx context.Context, brokerID, platformID string) (bool, error) {
+	return func(ctx context.Context, brokerID, platformID string) (bool, error) {
+		servicesList, err := repository.List(ctx, types.ServiceOfferingType, query.ByField(query.EqualsOperator, "broker_id", brokerID))
+		if err != nil {
+			return false, err
+		}
+		serviceIDs := make([]string, 0, servicesList.Len())
+		for i := 0; i < servicesList.Len(); i++ {
+			serviceIDs = append(serviceIDs, servicesList.ItemAt(i).GetID())
+		}
+
+		plansList, err := repository.List(ctx, types.ServicePlanType, query.ByField(query.InOperator, "service_offering_id", serviceIDs...))
+		if err != nil {
+			return false, err
+		}
+		planIds := make([]string, 0, plansList.Len())
+		for i := 0; i < plansList.Len(); i++ {
+			planIds = append(planIds, plansList.ItemAt(i).GetID())
+		}
+
+		visibilities, err := repository.List(ctx, types.VisibilityType, query.ByField(query.InOperator, "service_plan_id", planIds...),
+			query.ByField(query.EqualsOrNilOperator, "platform_id", platformID))
+		return visibilities.Len() > 0, err
+	}
+}
+
+func brokersCriteriaFunc(repository storage.Repository) func(ctx context.Context, platformID string) (*query.Criterion, error) {
+	return func(ctx context.Context, platformID string) (*query.Criterion, error) {
+		planQuery, err := plansCriteria(ctx, repository, platformID)
+		if err != nil {
+			return nil, err
+		}
+		if planQuery == nil {
+			return nil, nil
+		}
+
+		servicesQuery, err := servicesCriteria(ctx, repository, planQuery)
+		if err != nil {
+			return nil, err
+		}
+		if servicesQuery == nil {
+			return nil, nil
+		}
+
+		return brokersCriteria(ctx, repository, servicesQuery)
+	}
+}
+
+func (vf *BrokersFilterByVisibility) FilterMatchers() []web.FilterMatcher {
+	return []web.FilterMatcher{
+		{
+			Matchers: []web.Matcher{
+				web.Path(web.ServiceBrokersURL + "/*"),
+				web.Methods(http.MethodGet),
+			},
+		},
+	}
+}
+
+func (vf *BrokersFilterByVisibility) Name() string {
+	return BrokersVisibilityFilterName
+}

--- a/api/filters/helpers.go
+++ b/api/filters/helpers.go
@@ -8,6 +8,23 @@ import (
 	"github.com/Peripli/service-manager/storage"
 )
 
+func brokersCriteria(ctx context.Context, repository storage.Repository, servicesQuery *query.Criterion) (*query.Criterion, error) {
+	objectList, err := repository.List(ctx, types.ServiceOfferingType, *servicesQuery)
+	if err != nil {
+		return nil, err
+	}
+	services := objectList.(*types.ServiceOfferings)
+	if services.Len() < 1 {
+		return nil, nil
+	}
+	brokerIDs := make([]string, 0, services.Len())
+	for _, p := range services.ServiceOfferings {
+		brokerIDs = append(brokerIDs, p.BrokerID)
+	}
+	c := query.ByField(query.InOperator, "id", brokerIDs...)
+	return &c, nil
+}
+
 func servicesCriteria(ctx context.Context, repository storage.Repository, planQuery *query.Criterion) (*query.Criterion, error) {
 	objectList, err := repository.List(ctx, types.ServicePlanType, *planQuery)
 	if err != nil {

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -220,6 +221,93 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				RemoveAllBrokers(ctx.SMRepository)
 
 				repository = ctx.SMRepository
+			})
+
+			Describe("GET", func() {
+				var (
+					k8sPlatform   *types.Platform
+					k8sAgent      *common.SMExpect
+					brokerID      string
+					planCatalogID string
+				)
+
+				assertBrokerForPlatformByID := func(agent *common.SMExpect, brokerID interface{}, status int) {
+					k8sAgent.GET(fmt.Sprintf("%s/%s", web.ServiceBrokersURL, brokerID.(string))).
+						Expect().
+						Status(status)
+				}
+
+				assertBrokersForPlatformWithQuery := func(agent *common.SMExpect, query map[string]interface{}, brokers ...interface{}) {
+					q := url.Values{}
+					for k, v := range query {
+						q.Set(k, fmt.Sprint(v))
+					}
+					queryString := q.Encode()
+					result := agent.ListWithQuery(web.ServiceBrokersURL, queryString).Path("$[*].id").Array()
+					result.Length().Equal(len(brokers))
+					if len(brokers) > 0 {
+						result.ContainsOnly(brokers...)
+					}
+				}
+
+				assertBrokersForPlatform := func(agent *common.SMExpect, brokers ...interface{}) {
+					assertBrokersForPlatformWithQuery(agent, nil, brokers...)
+				}
+
+				BeforeEach(func() {
+					k8sPlatformJSON := common.MakePlatform("k8s-platform", "k8s-platform", "kubernetes", "test-platform-k8s")
+					k8sPlatform = common.RegisterPlatformInSM(k8sPlatformJSON, ctx.SMWithOAuth, map[string]string{})
+					k8sAgent = &common.SMExpect{Expect: ctx.SM.Builder(func(req *httpexpect.Request) {
+						username, password := k8sPlatform.Credentials.Basic.Username, k8sPlatform.Credentials.Basic.Password
+						req.WithBasicAuth(username, password)
+					})}
+
+					plan := common.GeneratePaidTestPlan()
+					planCatalogID = gjson.Get(plan, "id").String()
+					service := common.GenerateTestServiceWithPlans(plan)
+					catalog := common.NewEmptySBCatalog()
+					catalog.AddService(service)
+					brokerID = ctx.RegisterBrokerWithCatalog(catalog).Broker.ID
+				})
+
+				AfterEach(func() {
+					ctx.CleanupAdditionalResources()
+				})
+
+				Context("with no visibilities for any of the broker's plans", func() {
+					It("should return not found", func() {
+						assertBrokersForPlatform(k8sAgent, nil...)
+						assertBrokerForPlatformByID(k8sAgent, brokerID, http.StatusNotFound)
+					})
+
+					It("should not list broker with field query broker id", func() {
+						assertBrokersForPlatformWithQuery(k8sAgent,
+							map[string]interface{}{
+								"fieldQuery": fmt.Sprintf("broker_id eq '%s'", brokerID),
+							}, nil...)
+					})
+				})
+
+				Context("with public visibility for broker's plan", func() {
+					BeforeEach(func() {
+						ctx.TestContextData.SetAuthContext(ctx.SMWithOAuth).AddPlanVisibilityForPlatform(planCatalogID, "", "")
+					})
+					It("should return one broker", func() {
+						assertBrokersForPlatform(k8sAgent, brokerID)
+						assertBrokerForPlatformByID(k8sAgent, brokerID, http.StatusOK)
+					})
+				})
+
+				Context("with visibility for platform and one of the broker's plans", func() {
+					BeforeEach(func() {
+						ctx.TestContextData.SetAuthContext(ctx.SMWithOAuth).AddPlanVisibilityForPlatform(planCatalogID, k8sPlatform.ID, "")
+					})
+
+					It("should return the broker", func() {
+						assertBrokersForPlatform(k8sAgent, brokerID)
+						assertBrokerForPlatformByID(k8sAgent, brokerID, http.StatusOK)
+					})
+				})
 			})
 
 			Describe("POST", func() {

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -164,18 +164,21 @@ func (ctx *BrokerUtils) AddPlanVisibilityForPlatform(planCatalogID string, platf
 		First().Object().Value("id").String().Raw()
 
 	visibilityID := RegisterVisibilityForPlanAndPlatform(ctx.authContext, smPlanID, platformID)
-	patchLabelsBody := make(map[string]interface{})
-	patchLabels := []types.LabelChange{{
-		Operation: types.AddLabelOperation,
-		Key:       "organization_guid",
-		Values:    []string{orgID},
-	}}
-	patchLabelsBody["labels"] = patchLabels
+	if orgID != "" {
+		patchLabelsBody := make(map[string]interface{})
+		patchLabels := []types.LabelChange{{
+			Operation: types.AddLabelOperation,
+			Key:       "organization_guid",
+			Values:    []string{orgID},
+		}}
+		patchLabelsBody["labels"] = patchLabels
 
-	ctx.authContext.PATCH(web.VisibilitiesURL + "/" + visibilityID).
-		WithJSON(patchLabelsBody).
-		Expect().
-		Status(http.StatusOK)
+		ctx.authContext.PATCH(web.VisibilitiesURL + "/" + visibilityID).
+			WithJSON(patchLabelsBody).
+			Expect().
+			Status(http.StatusOK)
+	}
+
 	return ctx
 }
 

--- a/test/security_test/security_test.go
+++ b/test/security_test/security_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Service Manager Security Tests", func() {
 				bearerAuthRequestExpectedStatus: http.StatusUnauthorized,
 			}),
 			Entry("should return 200 for path without authentication", testCase{
-				path:                            web.ServiceBrokersURL,
+				path:                            web.PlatformsURL,
 				method:                          http.MethodGet,
 				noAuthRequestExpectedStatus:     http.StatusOK,
 				basicAuthRequestExpectedStatus:  http.StatusOK,
@@ -102,7 +102,7 @@ var _ = Describe("Service Manager Security Tests", func() {
 					bearerAuthRequestExpectedStatus: http.StatusUnauthorized,
 				}),
 				Entry("should return 200 for path without authentication", testCase{
-					path:                            web.ServiceBrokersURL,
+					path:                            web.PlatformsURL,
 					method:                          http.MethodGet,
 					noAuthRequestExpectedStatus:     http.StatusOK,
 					basicAuthRequestExpectedStatus:  http.StatusOK,
@@ -127,7 +127,7 @@ var _ = Describe("Service Manager Security Tests", func() {
 					bearerAuthRequestExpectedStatus: http.StatusOK,
 				}),
 				Entry("should return 200 for path without authentication", testCase{
-					path:                            web.ServiceBrokersURL,
+					path:                            web.PlatformsURL,
 					method:                          http.MethodGet,
 					noAuthRequestExpectedStatus:     http.StatusOK,
 					basicAuthRequestExpectedStatus:  http.StatusOK,
@@ -139,14 +139,14 @@ var _ = Describe("Service Manager Security Tests", func() {
 
 			Context("with authorization", func() {
 				BeforeEach(func() {
-					attachRequiredBearer(contextBuilder, []string{web.ServiceBrokersURL}, []string{http.MethodGet})
+					attachRequiredBearer(contextBuilder, []string{web.PlatformsURL}, []string{http.MethodGet})
 
 					contextBuilder.WithSMExtensions(func(_ context.Context, smb *sm.ServiceManagerBuilder, e env.Environment) error {
 						smb.Security().
 							Path(web.MonitorHealthURL).Method(http.MethodGet).
 							WithScopes("read_health").Required()
 
-						smb.Security().Path(web.ServiceBrokersURL).Method(http.MethodGet).
+						smb.Security().Path(web.PlatformsURL).Method(http.MethodGet).
 							WithClientIDSuffixes([]string{"trustedsuffix", "anothertrustedsfx"}).Required()
 						return nil
 					})
@@ -168,7 +168,7 @@ var _ = Describe("Service Manager Security Tests", func() {
 					})
 
 					It("should NOT allow access", func() {
-						ctx.SMWithOAuth.GET(web.ServiceBrokersURL).Expect().
+						ctx.SMWithOAuth.GET(web.PlatformsURL).Expect().
 							Status(http.StatusForbidden).
 							JSON().Path("$.description").String().Contains("client id \"not_trusted_id\" from user token does not have the required suffix")
 					})
@@ -181,7 +181,7 @@ var _ = Describe("Service Manager Security Tests", func() {
 						})
 					})
 					It("should allow access", func() {
-						ctx.SMWithOAuth.GET(web.ServiceBrokersURL).Expect().
+						ctx.SMWithOAuth.GET(web.PlatformsURL).Expect().
 							Status(http.StatusOK)
 					})
 				})
@@ -193,7 +193,7 @@ var _ = Describe("Service Manager Security Tests", func() {
 						})
 					})
 					It("should allow access", func() {
-						ctx.SMWithOAuth.GET(web.ServiceBrokersURL).Expect().
+						ctx.SMWithOAuth.GET(web.PlatformsURL).Expect().
 							Status(http.StatusOK)
 					})
 				})
@@ -318,7 +318,7 @@ var _ = Describe("Service Manager Security Tests", func() {
 					bearerAuthRequestExpectedStatus: http.StatusOK,
 				}),
 				Entry("should return 200 for path without authentication", testCase{
-					path:                            web.ServiceBrokersURL,
+					path:                            web.PlatformsURL,
 					method:                          http.MethodGet,
 					noAuthRequestExpectedStatus:     http.StatusOK,
 					basicAuthRequestExpectedStatus:  http.StatusOK,
@@ -348,7 +348,7 @@ var _ = Describe("Service Manager Security Tests", func() {
 				bearerAuthRequestExpectedStatus: http.StatusOK,
 			}),
 			Entry("should return for path without authentication", testCase{
-				path:                            web.ServiceBrokersURL,
+				path:                            web.PlatformsURL,
 				method:                          http.MethodGet,
 				noAuthRequestExpectedStatus:     http.StatusOK,
 				basicAuthRequestExpectedStatus:  http.StatusOK,
@@ -372,7 +372,7 @@ var _ = Describe("Service Manager Security Tests", func() {
 					bearerAuthRequestExpectedStatus: http.StatusOK,
 				}),
 				Entry("should return 200 for path without authentication", testCase{
-					path:                            web.ServiceBrokersURL,
+					path:                            web.PlatformsURL,
 					method:                          http.MethodGet,
 					noAuthRequestExpectedStatus:     http.StatusOK,
 					basicAuthRequestExpectedStatus:  http.StatusOK,
@@ -424,11 +424,11 @@ var _ = Describe("Service Manager Security Tests", func() {
 
 				Context("when requesting required subpath", func() {
 					It("should return 401 for no auth", func() {
-						ctx.SM.GET(web.ServiceBrokersURL).Expect().Status(http.StatusUnauthorized)
+						ctx.SM.GET(web.PlatformsURL).Expect().Status(http.StatusUnauthorized)
 					})
 
 					It("should return 200 for basic", func() {
-						ctx.SMWithBasic.GET(web.ServiceBrokersURL).Expect().Status(http.StatusOK)
+						ctx.SMWithBasic.GET(web.PlatformsURL).Expect().Status(http.StatusOK)
 					})
 				})
 
@@ -462,20 +462,20 @@ var _ = Describe("Service Manager Security Tests", func() {
 
 			Context("with authenticator for GET and POST", func() {
 				BeforeEach(func() {
-					attachRequiredBasic(contextBuilder, []string{web.ServiceBrokersURL}, []string{http.MethodPost}, authenticators.BasicPlatformAuthenticator)
-					attachOptionalBasic(contextBuilder, []string{web.ServiceBrokersURL}, []string{http.MethodGet}, authenticators.BasicPlatformAuthenticator)
+					attachRequiredBasic(contextBuilder, []string{web.ServiceInstancesURL}, []string{http.MethodPost}, authenticators.BasicPlatformAuthenticator)
+					attachOptionalBasic(contextBuilder, []string{web.ServiceInstancesURL}, []string{http.MethodGet}, authenticators.BasicPlatformAuthenticator)
 				})
 
 				It("should return 401 for POST with no auth", func() {
-					ctx.SM.POST(web.ServiceBrokersURL).WithJSON("").Expect().Status(http.StatusUnauthorized)
+					ctx.SM.POST(web.ServiceInstancesURL).WithJSON("").Expect().Status(http.StatusUnauthorized)
 				})
 
 				It("should NOT return 401 for POST with auth", func() {
-					Expect(ctx.SM.POST(web.ServiceBrokersURL).Expect().Raw().StatusCode).NotTo(Equal(http.StatusUnauthorized))
+					Expect(ctx.SM.POST(web.ServiceInstancesURL).Expect().Raw().StatusCode).NotTo(Equal(http.StatusUnauthorized))
 				})
 
 				It("should return 200 for GET", func() {
-					ctx.SM.GET(web.ServiceBrokersURL).Expect().Status(http.StatusOK)
+					ctx.SM.GET(web.ServiceInstancesURL).Expect().Status(http.StatusOK)
 				})
 			})
 


### PR DESCRIPTION
Brokers are not filtered when using platform basic credentials, this exposes tenant-owned brokers to other tenants. This change filters them based on visibilities of the broker plans, as it is done for service offerings. 