### PR TITLE
add index on notifications revision

### DIFF
--- a/storage/postgres/keystore_test.go
+++ b/storage/postgres/keystore_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Secured Storage", func() {
 		mock.ExpectQuery(`SELECT CURRENT_DATABASE()`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("mock"))
 		mock.ExpectQuery(`SELECT COUNT(1)*`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("1"))
 		mock.ExpectExec("SELECT pg_advisory_lock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20200914413800,false"))
+		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20201005251500,false"))
 		mock.ExpectExec("SELECT pg_advisory_unlock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 		options := storage.DefaultSettings()
 		options.EncryptionKey = string(envEncryptionKey)

--- a/storage/postgres/locker_test.go
+++ b/storage/postgres/locker_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Storage Locker", func() {
 		mock.ExpectQuery(`SELECT CURRENT_DATABASE()`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("mock"))
 		mock.ExpectQuery(`SELECT COUNT(1)*`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("1"))
 		mock.ExpectExec("SELECT pg_advisory_lock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20200914413800,false"))
+		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20201005251500,false"))
 		mock.ExpectExec("SELECT pg_advisory_unlock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		options := storage.DefaultSettings()

--- a/storage/postgres/migrations/20201005251500_notifications_revision_index.down.sql
+++ b/storage/postgres/migrations/20201005251500_notifications_revision_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS notifications_revision_index;

--- a/storage/postgres/migrations/20201005251500_notifications_revision_index.up.sql
+++ b/storage/postgres/migrations/20201005251500_notifications_revision_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS notifications_revision_index ON notifications (revision);


### PR DESCRIPTION
When notifications table grow large the queries for notification by revision issued by agents take too long, this index should improve the DB lookup times in this flow.
