### PR TITLE
Fix cross tenant notifications

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -1,5 +1,5 @@
 server:
-  request_timeout: 4000ms
+  request_timeout: 40000ms
   shutdown_timeout: 4000ms
   port: 8085
   # max_body_bytes: 4000

--- a/application.yml
+++ b/application.yml
@@ -1,5 +1,5 @@
 server:
-  request_timeout: 40000ms
+  request_timeout: 600s
   shutdown_timeout: 4000ms
   port: 8085
   # max_body_bytes: 4000

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -213,9 +213,9 @@ func New(ctx context.Context, cancel context.CancelFunc, e env.Environment, cfg 
 		WithCreateOnTxInterceptorProvider(types.VisibilityType, &interceptors.VisibilityCreateNotificationsInterceptorProvider{}).Register().
 		WithUpdateOnTxInterceptorProvider(types.VisibilityType, &interceptors.VisibilityUpdateNotificationsInterceptorProvider{}).Register().
 		WithDeleteOnTxInterceptorProvider(types.VisibilityType, &interceptors.VisibilityDeleteNotificationsInterceptorProvider{}).Register().
-		WithCreateOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsCreateInterceptorProvider{cfg.Multitenancy.LabelKey}).Before(interceptors.BrokerCreateCatalogInterceptorName).Register().
-		WithUpdateOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsUpdateInterceptorProvider{cfg.Multitenancy.LabelKey}).Before(interceptors.BrokerUpdateCatalogInterceptorName).Register().
-		WithDeleteOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsDeleteInterceptorProvider{cfg.Multitenancy.LabelKey}).After(interceptors.BrokerDeleteCatalogInterceptorName).Register()
+		WithCreateOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsCreateInterceptorProvider{TenantKey: cfg.Multitenancy.LabelKey}).Before(interceptors.BrokerCreateCatalogInterceptorName).Register().
+		WithUpdateOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsUpdateInterceptorProvider{TenantKey: cfg.Multitenancy.LabelKey}).Before(interceptors.BrokerUpdateCatalogInterceptorName).Register().
+		WithDeleteOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsDeleteInterceptorProvider{TenantKey: cfg.Multitenancy.LabelKey}).After(interceptors.BrokerDeleteCatalogInterceptorName).Register()
 
 	baseSMAAPInterceptorProvider := &interceptors.BaseSMAAPInterceptorProvider{
 		OSBClientCreateFunc: osbClientProvider,

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -213,7 +213,7 @@ func New(ctx context.Context, cancel context.CancelFunc, e env.Environment, cfg 
 		WithCreateOnTxInterceptorProvider(types.VisibilityType, &interceptors.VisibilityCreateNotificationsInterceptorProvider{}).Register().
 		WithUpdateOnTxInterceptorProvider(types.VisibilityType, &interceptors.VisibilityUpdateNotificationsInterceptorProvider{}).Register().
 		WithDeleteOnTxInterceptorProvider(types.VisibilityType, &interceptors.VisibilityDeleteNotificationsInterceptorProvider{}).Register().
-		WithCreateOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsCreateInterceptorProvider{}).Before(interceptors.BrokerCreateCatalogInterceptorName).Register().
+		WithCreateOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsCreateInterceptorProvider{cfg.Multitenancy.LabelKey}).Before(interceptors.BrokerCreateCatalogInterceptorName).Register().
 		WithUpdateOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsUpdateInterceptorProvider{}).Before(interceptors.BrokerUpdateCatalogInterceptorName).Register().
 		WithDeleteOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsDeleteInterceptorProvider{}).After(interceptors.BrokerDeleteCatalogInterceptorName).Register()
 

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -214,8 +214,8 @@ func New(ctx context.Context, cancel context.CancelFunc, e env.Environment, cfg 
 		WithUpdateOnTxInterceptorProvider(types.VisibilityType, &interceptors.VisibilityUpdateNotificationsInterceptorProvider{}).Register().
 		WithDeleteOnTxInterceptorProvider(types.VisibilityType, &interceptors.VisibilityDeleteNotificationsInterceptorProvider{}).Register().
 		WithCreateOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsCreateInterceptorProvider{cfg.Multitenancy.LabelKey}).Before(interceptors.BrokerCreateCatalogInterceptorName).Register().
-		WithUpdateOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsUpdateInterceptorProvider{}).Before(interceptors.BrokerUpdateCatalogInterceptorName).Register().
-		WithDeleteOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsDeleteInterceptorProvider{}).After(interceptors.BrokerDeleteCatalogInterceptorName).Register()
+		WithUpdateOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsUpdateInterceptorProvider{cfg.Multitenancy.LabelKey}).Before(interceptors.BrokerUpdateCatalogInterceptorName).Register().
+		WithDeleteOnTxInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerNotificationsDeleteInterceptorProvider{cfg.Multitenancy.LabelKey}).After(interceptors.BrokerDeleteCatalogInterceptorName).Register()
 
 	baseSMAAPInterceptorProvider := &interceptors.BaseSMAAPInterceptorProvider{
 		OSBClientCreateFunc: osbClientProvider,

--- a/test/notification_test/notification_test.go
+++ b/test/notification_test/notification_test.go
@@ -104,6 +104,7 @@ var _ = Describe("Notifications Suite", func() {
 			}
 			return smAuth
 		}
+
 		return notificationTypeEntry{
 			ResourceType:         types.ServiceBrokerType,
 			ResourceTenantScoped: tenantScoped,
@@ -178,6 +179,7 @@ var _ = Describe("Notifications Suite", func() {
 				if object["labels"] != nil {
 					brokerTenantLabel, found := object["labels"].(common.Object)[tenantLabelKey]
 					if found {
+						// tenant scoped broker
 						brokerTenantID = brokerTenantLabel.(common.Array)[0].(string)
 					}
 				}
@@ -238,9 +240,11 @@ var _ = Describe("Notifications Suite", func() {
 				}
 
 				// broker notifications
-				for _, notification := range notificationsAfterOp.Notifications {
-					if notification.Resource == types.ServiceBrokerType {
-						if tenantScoped {
+				if tenantScoped {
+					// broker notifications
+					for _, notification := range notificationsAfterOp.Notifications {
+						if notification.Resource == types.ServiceBrokerType {
+
 							platformID := notification.PlatformID
 							Expect(platformID).ToNot(BeEmpty())
 
@@ -258,7 +262,8 @@ var _ = Describe("Notifications Suite", func() {
 		brokersNotificationEntry(true),
 		brokersNotificationEntry(false),
 		{
-			ResourceType: types.VisibilityType,
+			ResourceType:         types.VisibilityType,
+			ResourceTenantScoped: false,
 			ResourceCreateFunc: func() common.Object {
 				visReqBody := make(common.Object)
 				cPaidPlan := common.GeneratePaidTestPlan()


### PR DESCRIPTION
Broker notifications (CREATE/UPDATE/DELETE) are sent to all agents according to supportedPlatforms only. In case multi-tenancy is enabled, this leads to notifications about tenant-scoped brokers being sent to different tenant's platform. This is a breach to the tenant isolation. 
This change filters out platforms owned by other tenants in case of operations on a tenant-scoped broker. 