### PR TITLE
do not notify platforms that were never active

### DIFF
--- a/storage/service_plans/resolver.go
+++ b/storage/service_plans/resolver.go
@@ -34,7 +34,7 @@ func ResolveSupportedPlatformsForTenant(ctx context.Context, plans []*types.Serv
 		return nil, err
 	}
 
-	platformsForTenant := make(map[string]*types.Platform, 0)
+	platformsForTenant := make(map[string]*types.Platform)
 	for _, platform := range platforms {
 		if isGlobal(platform) || isTenantScoped(platform) {
 			platformsForTenant[platform.ID] = platform

--- a/storage/service_plans/resolver.go
+++ b/storage/service_plans/resolver.go
@@ -20,7 +20,7 @@ func ResolveSupportedPlatformIDsForPlans(ctx context.Context, plans []*types.Ser
 	return platformIDs, nil
 }
 
-func ResolveSupportedPlatformIDsForTenant(ctx context.Context, plans []*types.ServicePlan, repository storage.Repository, tenantKey string, tenantValue string) ([]string, error) {
+func ResolveSupportedPlatformsForTenant(ctx context.Context, plans []*types.ServicePlan, repository storage.Repository, tenantKey string, tenantValue string) (map[string]*types.Platform, error) {
 	isGlobal := func(platform *types.Platform) bool {
 		return platform.Labels == nil || len(platform.Labels[tenantKey]) == 0
 	}
@@ -34,13 +34,13 @@ func ResolveSupportedPlatformIDsForTenant(ctx context.Context, plans []*types.Se
 		return nil, err
 	}
 
-	platformIDs := make([]string, 0)
+	platformsForTenant := make(map[string]*types.Platform, 0)
 	for _, platform := range platforms {
 		if isGlobal(platform) || isTenantScoped(platform) {
-			platformIDs = append(platformIDs, platform.ID)
+			platformsForTenant[platform.ID] = platform
 		}
 	}
-	return platformIDs, nil
+	return platformsForTenant, nil
 }
 
 func ResolveSupportedPlatformsForPlans(ctx context.Context, plans []*types.ServicePlan, repository storage.Repository) (map[string]*types.Platform, error) {

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -757,7 +757,11 @@ func (ctx *TestContext) RegisterBroker() *BrokerUtils {
 }
 
 func (ctx *TestContext) RegisterPlatform() *types.Platform {
-	return ctx.RegisterPlatformWithType("test-type")
+	return ctx.RegisterPlatformAndActivate(true)
+}
+
+func (ctx *TestContext) RegisterPlatformAndActivate(activate bool) *types.Platform {
+	return ctx.RegisterPlatformWithTypeAndActivate("test-type", activate)
 }
 
 func (ctx *TestContext) RegisterTenantPlatform() *types.Platform {
@@ -765,6 +769,10 @@ func (ctx *TestContext) RegisterTenantPlatform() *types.Platform {
 }
 
 func (ctx *TestContext) RegisterPlatformWithType(platformType string) *types.Platform {
+	return ctx.RegisterPlatformWithTypeAndActivate(platformType, true)
+}
+
+func (ctx *TestContext) RegisterPlatformWithTypeAndActivate(platformType string, activate bool) *types.Platform {
 	UUID, err := uuid.NewV4()
 	if err != nil {
 		panic(err)
@@ -775,9 +783,16 @@ func (ctx *TestContext) RegisterPlatformWithType(platformType string) *types.Pla
 		"description": "testDescrption",
 	}
 	platform := RegisterPlatformInSM(platformJSON, ctx.SMWithOAuth, map[string]string{})
-	platform.Active = true
-	platformObj, err := ctx.SMRepository.Update(context.Background(), platform, nil)
-	return platformObj.(*types.Platform)
+	if activate {
+		platform.Active = true
+		platformObj, err := ctx.SMRepository.Update(context.Background(), platform, nil)
+		if err != nil {
+			panic(err)
+		}
+		platform = platformObj.(*types.Platform)
+	}
+
+	return platform
 }
 
 func (ctx *TestContext) NewTenantExpect(clientID, tenantIdentifier string, scopes ...string) *SMExpect {

--- a/test/common/test_context.go
+++ b/test/common/test_context.go
@@ -526,7 +526,7 @@ func (tcb *TestContextBuilder) BuildWithListener(listener net.Listener, cleanup 
 	}
 
 	if !tcb.shouldSkipBasicAuthClient {
-		platform, err := tcb.prepareTestPlatform(testContext.SMWithOAuth)
+		platform, err := tcb.prepareTestPlatform(testContext.SMWithOAuth, smRepository)
 		if err != nil {
 			panic(err)
 		}
@@ -541,14 +541,17 @@ func (tcb *TestContextBuilder) BuildWithListener(listener net.Listener, cleanup 
 	return testContext
 }
 
-func (tcb *TestContextBuilder) prepareTestPlatform(smClient *SMExpect) (*types.Platform, error) {
+func (tcb *TestContextBuilder) prepareTestPlatform(smClient *SMExpect, repository storage.TransactionalRepository) (*types.Platform, error) {
 	if tcb.basicAuthPlatformName == "" {
 		tcb.basicAuthPlatformName = "basic-auth-default-test-platform"
 		resp := smClient.GET(web.PlatformsURL + "/" + tcb.basicAuthPlatformName).Expect()
 		if resp.Raw().StatusCode == http.StatusNotFound {
 			platformJSON := MakePlatform(tcb.basicAuthPlatformName, tcb.basicAuthPlatformName, "platform-type", "test-platform")
 			platform := RegisterPlatformInSM(platformJSON, smClient, map[string]string{})
-			return platform, nil
+			platform.Active = true
+			platformObj, err := repository.Update(context.Background(), platform, nil)
+
+			return platformObj.(*types.Platform), err
 		}
 
 		if resp.Raw().StatusCode != http.StatusOK {
@@ -771,7 +774,10 @@ func (ctx *TestContext) RegisterPlatformWithType(platformType string) *types.Pla
 		"type":        platformType,
 		"description": "testDescrption",
 	}
-	return RegisterPlatformInSM(platformJSON, ctx.SMWithOAuth, map[string]string{})
+	platform := RegisterPlatformInSM(platformJSON, ctx.SMWithOAuth, map[string]string{})
+	platform.Active = true
+	platformObj, err := ctx.SMRepository.Update(context.Background(), platform, nil)
+	return platformObj.(*types.Platform)
 }
 
 func (ctx *TestContext) NewTenantExpect(clientID, tenantIdentifier string, scopes ...string) *SMExpect {

--- a/test/interceptors_test/interceptors_test.go
+++ b/test/interceptors_test/interceptors_test.go
@@ -225,7 +225,7 @@ var _ = Describe("Interceptors", func() {
 	Describe("Calling other intereceptors", func() {
 		Context("when interceptor fails", func() {
 			It("should cancel the transaction", func() {
-				platform1 := ctx.RegisterPlatform()
+				platform1 := ctx.RegisterPlatformAndActivate(false)
 
 				createModificationInterceptors[types.PlatformType].OnTxCreateStub = func(f storage.InterceptCreateOnTxFunc) storage.InterceptCreateOnTxFunc {
 					return func(ctx context.Context, txStorage storage.Repository, newObject types.Object) (types.Object, error) {
@@ -259,8 +259,8 @@ var _ = Describe("Interceptors", func() {
 
 		Context("when creating platform", func() {
 			It("should call all interceptors", func() {
-				platform1 := ctx.RegisterPlatform()
-				platform2 := ctx.RegisterPlatform()
+				platform1 := ctx.RegisterPlatformAndActivate(false)
+				platform2 := ctx.RegisterPlatformAndActivate(false)
 
 				createModificationInterceptors[types.PlatformType].OnTxCreateStub = func(f storage.InterceptCreateOnTxFunc) storage.InterceptCreateOnTxFunc {
 					return func(ctx context.Context, txStorage storage.Repository, newObject types.Object) (types.Object, error) {
@@ -307,7 +307,7 @@ var _ = Describe("Interceptors", func() {
 				}
 
 				txDeleteCallCount := deleteModificationInterceptors[types.PlatformType].OnTxDeleteCallCount()
-				ctx.RegisterPlatform()
+				ctx.RegisterPlatformAndActivate(false)
 				Expect(deleteModificationInterceptors[types.PlatformType].OnTxDeleteCallCount()).To(Equal(txDeleteCallCount + 1))
 
 				deleteModificationInterceptors[types.PlatformType].OnTxDeleteStub = func(f storage.InterceptDeleteOnTxFunc) storage.InterceptDeleteOnTxFunc {
@@ -372,7 +372,7 @@ var _ = Describe("Interceptors", func() {
 
 		Context("Platform", func() {
 			It("Should call interceptors in right order", func() {
-				platform := ctx.RegisterPlatform() // Post /v1/platforms
+				platform := ctx.RegisterPlatformAndActivate(false) // Post /v1/platforms
 				checkCreateStack(types.PlatformType)
 
 				ctx.SMWithOAuth.PATCH(web.PlatformsURL + "/" + platform.ID).WithJSON(common.Object{}).Expect().Status(http.StatusOK)


### PR DESCRIPTION
Notifications are created for platforms that were registered but never connected. Those platforms will anyways do a full resync upon their first connection, so there is no point in storing those notifications.
This change skips those platforms during the broker notification flows, so no unneeded notification are created in this flow.