### PR TITLE
add tenant label to offerings and plans

### DIFF
--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -201,10 +201,12 @@ func New(ctx context.Context, cancel context.CancelFunc, e env.Environment, cfg 
 	smb.
 		WithCreateInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerCreateCatalogInterceptorProvider{
 			CatalogFetcher: osb.CatalogFetcher(util.ClientRequest, cfg.API.OSBVersion),
+			TenantKey:      cfg.Multitenancy.LabelKey,
 		}).Register().
 		WithUpdateInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerUpdateCatalogInterceptorProvider{
 			CatalogFetcher: osb.CatalogFetcher(util.ClientRequest, cfg.API.OSBVersion),
 			CatalogLoader:  catalog.Load,
+			TenantKey:      cfg.Multitenancy.LabelKey,
 		}).Register().
 		WithDeleteInterceptorProvider(types.ServiceBrokerType, &interceptors.BrokerDeleteCatalogInterceptorProvider{
 			CatalogLoader: catalog.Load,

--- a/pkg/types/base.go
+++ b/pkg/types/base.go
@@ -61,14 +61,6 @@ func (b *Base) GetLabels() Labels {
 	return b.Labels
 }
 
-func (b *Base) ExtractTenantLabelValue(tenantLabelKey string) []string {
-	tenant, ok := b.Labels[tenantLabelKey]
-	if !ok {
-		return nil
-	}
-	return tenant
-}
-
 func (b *Base) GetPagingSequence() int64 {
 	return b.PagingSequence
 }

--- a/pkg/types/base.go
+++ b/pkg/types/base.go
@@ -61,6 +61,14 @@ func (b *Base) GetLabels() Labels {
 	return b.Labels
 }
 
+func (b *Base) ExtractTenantLabelValue(tenantLabelKey string) []string {
+	tenant, ok := b.Labels[tenantLabelKey]
+	if !ok {
+		return nil
+	}
+	return tenant
+}
+
 func (b *Base) GetPagingSequence() int64 {
 	return b.PagingSequence
 }

--- a/storage/interceptors/broker_create_catalog_interceptor.go
+++ b/storage/interceptors/broker_create_catalog_interceptor.go
@@ -109,7 +109,7 @@ func brokerCatalogAroundTx(ctx context.Context, broker *types.ServiceBroker, fet
 		service.CreatedAt = broker.UpdatedAt
 		service.UpdatedAt = broker.UpdatedAt
 		service.Ready = broker.GetReady()
-		service.Labels = addTenantToLabels(tenantKey, tenantValue, service.GetLabels())
+		service.Labels = addTenantToLabels(service.GetLabels(), tenantKey, tenantValue)
 		UUID, err := uuid.NewV4()
 		if err != nil {
 			return err
@@ -129,7 +129,7 @@ func brokerCatalogAroundTx(ctx context.Context, broker *types.ServiceBroker, fet
 			servicePlan.CreatedAt = broker.UpdatedAt
 			servicePlan.UpdatedAt = broker.UpdatedAt
 			servicePlan.Ready = broker.GetReady()
-			servicePlan.Labels = addTenantToLabels(tenantKey, tenantValue, servicePlan.GetLabels())
+			servicePlan.Labels = addTenantToLabels(servicePlan.GetLabels(), tenantKey, tenantValue)
 			UUID, err := uuid.NewV4()
 			if err != nil {
 				return err
@@ -149,7 +149,7 @@ func brokerCatalogAroundTx(ctx context.Context, broker *types.ServiceBroker, fet
 	return nil
 }
 
-func addTenantToLabels(tenantKey string, tenantValue []string, labels types.Labels) types.Labels {
+func addTenantToLabels(labels types.Labels, tenantKey string, tenantValue []string) types.Labels {
 	if tenantValue != nil {
 		if labels == nil {
 			labels = make(map[string][]string)

--- a/storage/interceptors/broker_create_catalog_interceptor.go
+++ b/storage/interceptors/broker_create_catalog_interceptor.go
@@ -100,7 +100,7 @@ func brokerCatalogAroundTx(ctx context.Context, broker *types.ServiceBroker, fet
 		return err
 	}
 
-	tenantValue, _ := broker.GetLabels()[tenantKey]
+	tenantValue := broker.GetLabels()[tenantKey]
 
 	for _, service := range catalogResponse.Services {
 		service.CatalogID = service.ID

--- a/storage/interceptors/broker_create_catalog_interceptor.go
+++ b/storage/interceptors/broker_create_catalog_interceptor.go
@@ -109,7 +109,7 @@ func brokerCatalogAroundTx(ctx context.Context, broker *types.ServiceBroker, fet
 		service.CreatedAt = broker.UpdatedAt
 		service.UpdatedAt = broker.UpdatedAt
 		service.Ready = broker.GetReady()
-		service.Labels = addTenantToLabels(service.GetLabels(), tenantKey, tenantValue)
+		service.Labels = setLabelValue(service.GetLabels(), tenantKey, tenantValue)
 		UUID, err := uuid.NewV4()
 		if err != nil {
 			return err
@@ -129,7 +129,7 @@ func brokerCatalogAroundTx(ctx context.Context, broker *types.ServiceBroker, fet
 			servicePlan.CreatedAt = broker.UpdatedAt
 			servicePlan.UpdatedAt = broker.UpdatedAt
 			servicePlan.Ready = broker.GetReady()
-			servicePlan.Labels = addTenantToLabels(servicePlan.GetLabels(), tenantKey, tenantValue)
+			servicePlan.Labels = setLabelValue(servicePlan.GetLabels(), tenantKey, tenantValue)
 			UUID, err := uuid.NewV4()
 			if err != nil {
 				return err
@@ -149,12 +149,12 @@ func brokerCatalogAroundTx(ctx context.Context, broker *types.ServiceBroker, fet
 	return nil
 }
 
-func addTenantToLabels(labels types.Labels, tenantKey string, tenantValue []string) types.Labels {
-	if tenantValue != nil {
+func setLabelValue(labels types.Labels, key string, value []string) types.Labels {
+	if value != nil {
 		if labels == nil {
 			labels = make(map[string][]string)
 		}
-		labels[tenantKey] = tenantValue
+		labels[key] = value
 	}
 	return labels
 }

--- a/storage/interceptors/broker_create_catalog_interceptor.go
+++ b/storage/interceptors/broker_create_catalog_interceptor.go
@@ -100,8 +100,8 @@ func brokerCatalogAroundTx(ctx context.Context, broker *types.ServiceBroker, fet
 		return err
 	}
 
+	tenantValue := broker.ExtractTenantLabelValue(tenantKey)
 	for _, service := range catalogResponse.Services {
-		var tenantValue []string
 		var labels types.Labels
 
 		service.CatalogID = service.ID
@@ -111,7 +111,7 @@ func brokerCatalogAroundTx(ctx context.Context, broker *types.ServiceBroker, fet
 		service.UpdatedAt = broker.UpdatedAt
 		service.Ready = broker.GetReady()
 
-		if tenantValue = broker.ExtractTenantLabelValue(tenantKey); tenantValue != nil {
+		if tenantValue != nil {
 			if labels = service.GetLabels(); labels == nil {
 				labels = make(map[string][]string)
 			}

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -936,7 +936,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				})
 			})
 
-			FDescribe("PATCH", func() {
+			Describe("PATCH", func() {
 				var brokerID, brokerIDWithTLS, tenantScopedBrokerID string
 
 				assertRepositoryReturnsExpectedCatalogAfterPatching := func(brokerID, expectedCatalog string) {


### PR DESCRIPTION
Tenant label is required for offerings and plans in addition to the current setup in which broker labels only has it. 
