### PR TITLE
add tls to CheckBrokerCredentialsFilter

### DIFF
--- a/api/filters/checkBrokerCredentials.go
+++ b/api/filters/checkBrokerCredentials.go
@@ -31,7 +31,7 @@ func (*CheckBrokerCredentialsFilter) Run(req *web.Request, next web.Handler) (*w
 	if brokerUrl.Exists() && credentialsMissing(basicFields, tlsFields) {
 		return nil, &util.HTTPError{
 			ErrorType:   "BadRequest",
-			Description: "Updating an URL of a broker requires its credentials",
+			Description: "Updating a URL of a broker requires its credentials",
 			StatusCode:  http.StatusBadRequest,
 		}
 	}


### PR DESCRIPTION
## Motivation

When updating broker_url we want to validate credentials were passed. Currently the filter validates only basic, adding tls as well.