### PR TITLE
Check for instance visibility without returning the label list to sm

### DIFF
--- a/api/filters/check_instance_visibility_filter.go
+++ b/api/filters/check_instance_visibility_filter.go
@@ -51,7 +51,6 @@ func (*serviceInstanceVisibilityFilter) Name() string {
 	return ServiceInstanceVisibilityFilterName
 }
 
-//@todo improve label selection
 func (f *serviceInstanceVisibilityFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
 	ctx := req.Context()
 

--- a/api/filters/check_instance_visibility_filter.go
+++ b/api/filters/check_instance_visibility_filter.go
@@ -70,7 +70,7 @@ func (f *serviceInstanceVisibilityFilter) Run(req *web.Request, next web.Handler
 		return next.Handle(req)
 	}
 
-	list, err := f.repository.QueryForList(ctx, types.VisibilityType, storage.QueryForLabelLessVisibilitiesByPlatformAndPlan, map[string]interface{}{
+	list, err := f.repository.QueryForList(ctx, types.VisibilityType, storage.QueryForVisibilityWithPlatformAndPlan, map[string]interface{}{
 		"platform_id":     visibilityMetadata.PlatformID,
 		"service_plan_id": planID,
 		"key":             visibilityMetadata.LabelKey,
@@ -81,7 +81,7 @@ func (f *serviceInstanceVisibilityFilter) Run(req *web.Request, next web.Handler
 		return nil, util.HandleStorageError(err, types.VisibilityType.String())
 	}
 
-	if list != nil && list.Len() > 0 {
+	if list.Len() > 0 {
 		return next.Handle(req)
 	}
 

--- a/api/filters/check_instance_visibility_filter.go
+++ b/api/filters/check_instance_visibility_filter.go
@@ -17,7 +17,6 @@
 package filters
 
 import (
-	"github.com/Peripli/service-manager/pkg/query"
 	"net/http"
 
 	"github.com/Peripli/service-manager/pkg/log"
@@ -72,32 +71,18 @@ func (f *serviceInstanceVisibilityFilter) Run(req *web.Request, next web.Handler
 		return next.Handle(req)
 	}
 
-	criteria := []query.Criterion{
-		query.ByField(query.EqualsOperator, platformIDProperty, visibilityMetadata.PlatformID),
-		query.ByField(query.EqualsOperator, planIDProperty, planID),
-		query.ByLabel(query.EqualsOperator, visibilityMetadata.LabelKey, visibilityMetadata.LabelValue),
-	}
-
-	list, err := f.repository.ListNoLabels(ctx, types.VisibilityType, criteria...)
-
-	if err != nil {
-		return nil, util.HandleStorageError(err, types.VisibilityType.String())
-	}
-
-	if list != nil && list.Len() > 0 {
-		return next.Handle(req)
-	}
-
-	list, err = f.repository.QueryForList(ctx, types.VisibilityType, storage.QueryForLabelLessVisibilitiesByPlatformAndPlan, map[string]interface{}{
+	list, err := f.repository.QueryForList(ctx, types.VisibilityType, storage.QueryForLabelLessVisibilitiesByPlatformAndPlan, map[string]interface{}{
 		"platform_id":     visibilityMetadata.PlatformID,
 		"service_plan_id": planID,
+		"key":             visibilityMetadata.LabelKey,
+		"val":             visibilityMetadata.LabelValue,
 	})
 
 	if err != nil {
 		return nil, util.HandleStorageError(err, types.VisibilityType.String())
 	}
 
-	if list.Len() != 0 && list.ItemAt(0).GetLabels() == nil {
+	if list != nil && list.Len() > 0 {
 		return next.Handle(req)
 	}
 

--- a/api/osb/check_instance_visibility_plugin.go
+++ b/api/osb/check_instance_visibility_plugin.go
@@ -88,7 +88,8 @@ func (p *checkVisibilityPlugin) checkVisibility(req *web.Request, next web.Handl
 		return nil, err
 	}
 
-	if platform.Type == types.CFPlatformType {
+	switch platform.Type {
+	case "cloudfoundry":
 		if len(osbContext) == 0 {
 			log.C(ctx).Errorf("Could not find context in the osb request.")
 			return nil, &util.HTTPError{

--- a/api/osb/check_instance_visibility_plugin.go
+++ b/api/osb/check_instance_visibility_plugin.go
@@ -107,12 +107,13 @@ func (p *checkVisibilityPlugin) checkVisibility(req *web.Request, next web.Handl
 			}
 		}
 
-		visibilityList, err := p.repository.QueryForList(ctx, types.VisibilityType, storage.QueryForVisibility, map[string]interface{}{
-			"platform_id":     platform.ID,
-			"service_plan_id": planID,
-			"key":             "organization_guid",
-			"val":             payloadOrgGUID,
-		})
+		criteria := []query.Criterion{
+			query.ByField(query.EqualsOperator, "platform_id", platform.ID),
+			query.ByField(query.EqualsOperator, "service_plan_id", planID),
+			query.ByLabel(query.EqualsOperator, "organization_guid", payloadOrgGUID),
+		}
+
+		visibilityList, err := p.repository.List(ctx, types.VisibilityType, criteria...)
 
 		if err != nil {
 			return nil, err
@@ -123,7 +124,7 @@ func (p *checkVisibilityPlugin) checkVisibility(req *web.Request, next web.Handl
 		}
 	}
 
-	visibilityList, err := p.repository.QueryForList(ctx, types.VisibilityType, storage.QueryForLabelLessVisibilitiesForPlatformAndPlan, map[string]interface{}{
+	visibilityList, err := p.repository.QueryForList(ctx, types.VisibilityType, storage.QueryForLabelLessVisibilitiesByPlatformAndPlan, map[string]interface{}{
 		"platform_id":     platform.ID,
 		"service_plan_id": planID,
 	})

--- a/api/osb/check_instance_visibility_plugin.go
+++ b/api/osb/check_instance_visibility_plugin.go
@@ -113,7 +113,7 @@ func (p *checkVisibilityPlugin) checkVisibility(req *web.Request, next web.Handl
 		tenantKey = "organization_guid"
 	}
 
-	list, err := p.repository.QueryForList(ctx, types.VisibilityType, storage.QueryForLabelLessVisibilitiesByPlatformAndPlan, map[string]interface{}{
+	list, err := p.repository.QueryForList(ctx, types.VisibilityType, storage.QueryForVisibilityWithPlatformAndPlan, map[string]interface{}{
 		"platform_id":     platform.ID,
 		"service_plan_id": planID,
 		"key":             tenantKey,

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -55,8 +55,8 @@ var namedQueries = map[NamedQuery]string{
 	WHERE resource_id IN (:id_list)`,
 	QueryForLabelLessVisibilities: `
 	SELECT v.* FROM visibilities v
-	WHERE (v.platform_id in (:platform_ids) OR v.platform_id IS NULL) AND
-	NOT EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id LIMIT 1)`,
+	LEFT OUTER JOIN visibility_labels vl on v.id = vl.visibility_id
+	WHERE (vl.id IS NULL and v.platform_id in (:platform_ids)) OR v.platform_id IS NULL`,
 	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
 	SELECT visibilities.*
 	FROM visibilities

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -55,9 +55,8 @@ var namedQueries = map[NamedQuery]string{
 	WHERE resource_id IN (:id_list)`,
 	QueryForLabelLessVisibilities: `
 	SELECT v.* FROM visibilities v
-	LEFT OUTER JOIN visibility_labels vl on v.id = vl.visibility_id
-	WHERE (vl.id IS NULL and v.platform_id in (:platform_ids)) OR v.platform_id IS NULL`,
-
+	WHERE (v.platform_id in (:platform_ids) OR v.platform_id IS NULL) AND
+	NOT EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id LIMIT 1)`,
 	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
 	SELECT visibilities.*,
 	visibility_labels.id         "visibility_labels.id",

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -59,16 +59,14 @@ var namedQueries = map[NamedQuery]string{
 	NOT EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id LIMIT 1)`,
 	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
 	SELECT visibilities.*,
-	visibility_labels.id         "visibility_labels.id",
-	visibility_labels.key        "visibility_labels.key",
-	visibility_labels.val        "visibility_labels.val",
-	visibility_labels.created_at "visibility_labels.created_at",
-	visibility_labels.updated_at "visibility_labels.updated_at",
-	visibility_labels.visibility_id "visibility_labels.visibility_id"
 	FROM visibilities
-		 LEFT JOIN visibility_labels
+	LEFT JOIN visibility_labels
 	ON visibilities.id = visibility_labels.visibility_id
-	WHERE service_plan_id = :service_plan_id and platform_id IS NULL OR service_plan_id = :service_plan_id and platform_id=:platform_id LIMIT 1`,
+	WHERE service_plan_id = :service_plan_id and (
+	platform_id IS NULL
+	OR ( platform_id=:platform_id AND NOT EXISTS (SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = visibilities.id))
+	OR ( platform_id = :platform_id and exists (SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = visibilities.id and vl.key=:key and vl.val =:value ))
+    )`,
 }
 
 func GetNamedQuery(query NamedQuery) string {

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -67,7 +67,7 @@ var namedQueries = map[NamedQuery]string{
 	visibility_labels.updated_at "visibility_labels.updated_at",
 	visibility_labels.visibility_id "visibility_labels.visibility_id"
 	FROM visibilities
-		INNER JOIN visibility_labels
+		 LEFT JOIN visibility_labels
 	ON visibilities.id = visibility_labels.visibility_id
 	WHERE service_plan_id = :service_plan_id and platform_id IS NULL OR service_plan_id = :service_plan_id and platform_id=:platform_id LIMIT 1`,
 }

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -58,14 +58,14 @@ var namedQueries = map[NamedQuery]string{
 	WHERE (v.platform_id in (:platform_ids) OR v.platform_id IS NULL) AND
 	NOT EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id LIMIT 1)`,
 	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
-	SELECT visibilities.*,
+	SELECT visibilities.*
 	FROM visibilities
 	LEFT JOIN visibility_labels
 	ON visibilities.id = visibility_labels.visibility_id
 	WHERE service_plan_id = :service_plan_id and (
 	platform_id IS NULL
 	OR ( platform_id=:platform_id AND NOT EXISTS (SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = visibilities.id))
-	OR ( platform_id = :platform_id and exists (SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = visibilities.id and vl.key=:key and vl.val =:value ))
+	OR ( platform_id = :platform_id and exists (SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = visibilities.id and vl.key=:key and vl.val =:val ))
     )`,
 }
 

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -65,10 +65,11 @@ var namedQueries = map[NamedQuery]string{
 	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
 	SELECT v.*
 	FROM visibilities v
-	WHERE v.service_plan_id = :service_plan_id
-	AND ((v.platform_id IS NULL OR v.platform_id = :platform_id)
+	WHERE v.service_plan_id = :service_plan_id 
+    AND  ((( v.platform_id IS NULL )) 
+	OR  (( v.platform_id = :platform_id )
 	AND ((:key = '' IS TRUE) OR NOT EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id)))
-	OR EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id AND vl.key = :key and vl.val = :val)`,
+	OR EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id AND vl.key = :key and vl.val = :val))`,
 }
 
 func GetNamedQuery(query NamedQuery) string {

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -7,8 +7,7 @@ const (
 	QueryByExistingLabel
 	QueryForLastOperationsPerResource
 	QueryForLabelLessVisibilities
-	QueryForVisibility
-	QueryForLabelLessVisibilitiesForPlatformAndPlan
+	QueryForLabelLessVisibilitiesByPlatformAndPlan
 )
 
 var namedQueries = map[NamedQuery]string{
@@ -58,22 +57,18 @@ var namedQueries = map[NamedQuery]string{
 	SELECT v.* FROM visibilities v
 	LEFT OUTER JOIN visibility_labels vl on v.id = vl.visibility_id
 	WHERE (vl.id IS NULL and v.platform_id in (:platform_ids)) OR v.platform_id IS NULL`,
-	QueryForVisibility: `
-	SELECT v.* FROM visibilities v
-	INNER JOIN visibility_labels vl on v.id = vl.visibility_id
-	WHERE key=:key and val = :val and platform_id = :platform_id and service_plan_id = :service_plan_id`,
 
-	QueryForLabelLessVisibilitiesForPlatformAndPlan: `
-	SELECT {{.ENTITY_TABLE}}.*,
-	{{.LABELS_TABLE}}.id         "{{.LABELS_TABLE}}.id",
-	{{.LABELS_TABLE}}.key        "{{.LABELS_TABLE}}.key",
-	{{.LABELS_TABLE}}.val        "{{.LABELS_TABLE}}.val",
-	{{.LABELS_TABLE}}.created_at "{{.LABELS_TABLE}}.created_at",
-	{{.LABELS_TABLE}}.updated_at "{{.LABELS_TABLE}}.updated_at",
-	{{.LABELS_TABLE}}.{{.REF_COLUMN}} "{{.LABELS_TABLE}}.{{.REF_COLUMN}}"
-	FROM {{.ENTITY_TABLE}}
-		{{.JOIN}} {{.LABELS_TABLE}}
-	ON {{.ENTITY_TABLE}}.{{.PRIMARY_KEY}} = {{.LABELS_TABLE}}.{{.REF_COLUMN}}
+	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
+	SELECT visibilities.*,
+	visibility_labels.id         "visibility_labels.id",
+	visibility_labels.key        "visibility_labels.key",
+	visibility_labels.val        "visibility_labels.val",
+	visibility_labels.created_at "visibility_labels.created_at",
+	visibility_labels.updated_at "visibility_labels.updated_at",
+	visibility_labels.visibility_id "visibility_labels.visibility_id"
+	FROM visibilities
+		INNER JOIN visibility_labels
+	ON visibilities.id = visibility_labels.visibility_id
 	WHERE service_plan_id = :service_plan_id and platform_id IS NULL OR service_plan_id = :service_plan_id and platform_id=:platform_id LIMIT 1`,
 }
 

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -63,12 +63,12 @@ var namedQueries = map[NamedQuery]string{
 	LEFT OUTER JOIN visibility_labels vl on v.id = vl.visibility_id
 	WHERE (vl.id IS NULL and v.service_plan_id in (:service_plan_ids))`,
 	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
-	SELECT v.* FROM visibilities v
+	SELECT v.*
+	FROM visibilities v
 	WHERE v.service_plan_id = :service_plan_id
-	AND (
-	v.platform_id IS NULL
-	OR (v.platform_id = :platform_id ) and :key = '' IS TRUE
-	OR EXISTS ( SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id AND vl.key = :key and vl.val = :val ))`,
+	AND ((v.platform_id IS NULL OR v.platform_id = :platform_id)
+	AND ((:key = '' IS TRUE) OR NOT EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id)))
+	OR EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id AND vl.key = :key and vl.val = :val)`,
 }
 
 func GetNamedQuery(query NamedQuery) string {

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -7,8 +7,8 @@ const (
 	QueryByExistingLabel
 	QueryForLastOperationsPerResource
 	QueryForLabelLessVisibilities
-	QueryForLabelLessVisibilitiesByPlatformAndPlan
 	QueryForLabelLessPlanVisibilities
+	QueryForLabelLessVisibilitiesByPlatformAndPlan
 )
 
 var namedQueries = map[NamedQuery]string{
@@ -58,6 +58,20 @@ var namedQueries = map[NamedQuery]string{
 	SELECT v.* FROM visibilities v
 	LEFT OUTER JOIN visibility_labels vl on v.id = vl.visibility_id
 	WHERE (vl.id IS NULL and v.platform_id in (:platform_ids)) OR v.platform_id IS NULL`,
+	QueryForLabelLessPlanVisibilities: `
+	SELECT v.* FROM visibilities v
+	LEFT OUTER JOIN visibility_labels vl on v.id = vl.visibility_id
+	WHERE (vl.id IS NULL and v.service_plan_id in (:service_plan_ids))`,
+	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
+	SELECT visibilities.*
+	FROM visibilities
+	LEFT JOIN visibility_labels
+	ON visibilities.id = visibility_labels.visibility_id
+	WHERE service_plan_id = :service_plan_id and (
+	platform_id IS NULL
+	OR ( platform_id=:platform_id AND NOT EXISTS (SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = visibilities.id))
+	OR ( platform_id = :platform_id and exists (SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = visibilities.id and vl.key=:key and vl.val =:val ))
+    )`,
 }
 
 func GetNamedQuery(query NamedQuery) string {

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -8,7 +8,7 @@ const (
 	QueryForLastOperationsPerResource
 	QueryForLabelLessVisibilities
 	QueryForLabelLessPlanVisibilities
-	QueryForLabelLessVisibilitiesByPlatformAndPlan
+	QueryForVisibilityWithPlatformAndPlan
 )
 
 var namedQueries = map[NamedQuery]string{
@@ -62,7 +62,7 @@ var namedQueries = map[NamedQuery]string{
 	SELECT v.* FROM visibilities v
 	LEFT OUTER JOIN visibility_labels vl on v.id = vl.visibility_id
 	WHERE (vl.id IS NULL and v.service_plan_id in (:service_plan_ids))`,
-	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
+	QueryForVisibilityWithPlatformAndPlan: `
 	SELECT v.*
 	FROM visibilities v
 	WHERE v.service_plan_id = :service_plan_id

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -65,9 +65,10 @@ var namedQueries = map[NamedQuery]string{
 	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
 	SELECT v.* FROM visibilities v
 	WHERE v.service_plan_id = :service_plan_id
-	AND (v.platform_id IS NULL
-	OR (v.platform_id = :platform_id AND ( NOT EXISTS ( SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id )
-	OR EXISTS ( SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id AND vl.key = :key and vl.val = :val ))))`,
+	AND (
+	v.platform_id IS NULL
+	OR (v.platform_id = :platform_id ) and :key = '' IS TRUE
+	OR EXISTS ( SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id AND vl.key = :key and vl.val = :val ))`,
 }
 
 func GetNamedQuery(query NamedQuery) string {

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -65,11 +65,10 @@ var namedQueries = map[NamedQuery]string{
 	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
 	SELECT v.*
 	FROM visibilities v
-	WHERE v.service_plan_id = :service_plan_id 
-    AND  ((( v.platform_id IS NULL )) 
-	OR  (( v.platform_id = :platform_id )
-	AND ((:key = '' IS TRUE) OR NOT EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id)))
-	OR EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id AND vl.key = :key and vl.val = :val))`,
+	WHERE v.service_plan_id = :service_plan_id
+	AND (v.platform_id IS NULL
+		OR (v.platform_id = :platform_id AND (:key = '' IS TRUE OR NOT EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id)))
+		OR EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id AND vl.key = :key AND vl.val = :val))`,
 }
 
 func GetNamedQuery(query NamedQuery) string {

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -63,15 +63,11 @@ var namedQueries = map[NamedQuery]string{
 	LEFT OUTER JOIN visibility_labels vl on v.id = vl.visibility_id
 	WHERE (vl.id IS NULL and v.service_plan_id in (:service_plan_ids))`,
 	QueryForLabelLessVisibilitiesByPlatformAndPlan: `
-	SELECT visibilities.*
-	FROM visibilities
-	LEFT JOIN visibility_labels
-	ON visibilities.id = visibility_labels.visibility_id
-	WHERE service_plan_id = :service_plan_id and (
-	platform_id IS NULL
-	OR ( platform_id=:platform_id AND NOT EXISTS (SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = visibilities.id))
-	OR ( platform_id = :platform_id and exists (SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = visibilities.id and vl.key=:key and vl.val =:val ))
-    )`,
+	SELECT v.* FROM visibilities v
+	WHERE v.service_plan_id = :service_plan_id
+	AND (v.platform_id IS NULL
+	OR (v.platform_id = :platform_id AND ( NOT EXISTS ( SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id )
+	OR EXISTS ( SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id AND vl.key = :key and vl.val = :val ))))`,
 }
 
 func GetNamedQuery(query NamedQuery) string {

--- a/storage/postgres/query_builder_test.go
+++ b/storage/postgres/query_builder_test.go
@@ -1012,8 +1012,8 @@ WHERE visibilities.id = t.id RETURNING *;`)))
 				qb.NewQuery(entity).Query(ctx, storage.QueryForLabelLessVisibilities, params)
 				Expect(executedQuery).Should(Equal(`
 	SELECT v.* FROM visibilities v
-	LEFT OUTER JOIN visibility_labels vl on v.id = vl.visibility_id
-	WHERE (vl.id IS NULL and v.platform_id in (?, ?)) OR v.platform_id IS NULL`))
+	WHERE (v.platform_id in (?, ?) OR v.platform_id IS NULL) AND
+	NOT EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id LIMIT 1)`))
 			})
 		})
 

--- a/storage/postgres/query_builder_test.go
+++ b/storage/postgres/query_builder_test.go
@@ -1012,8 +1012,8 @@ WHERE visibilities.id = t.id RETURNING *;`)))
 				qb.NewQuery(entity).Query(ctx, storage.QueryForLabelLessVisibilities, params)
 				Expect(executedQuery).Should(Equal(`
 	SELECT v.* FROM visibilities v
-	WHERE (v.platform_id in (?, ?) OR v.platform_id IS NULL) AND
-	NOT EXISTS(SELECT vl.id FROM visibility_labels vl WHERE vl.visibility_id = v.id LIMIT 1)`))
+	LEFT OUTER JOIN visibility_labels vl on v.id = vl.visibility_id
+	WHERE (vl.id IS NULL and v.platform_id in (?, ?)) OR v.platform_id IS NULL`))
 			})
 		})
 


### PR DESCRIPTION
## Motivation

Improve the check_instance_visiblity plugin and filter by checking for instance visibility without returning a full label list that matches a plan & platform visibility to sm.

## Approach

Refracture the code to perform the visibility check on the DB layer (by using 2 named queries)

## Pull Request status

* [x ] Refactoring