### PR TITLE
fix unique username for technical platforms

### DIFF
--- a/pkg/types/platform.go
+++ b/pkg/types/platform.go
@@ -90,11 +90,17 @@ func (e *Platform) Sanitize(ctx context.Context) {
 }
 
 func (e *Platform) Encrypt(ctx context.Context, encryptionFunc func(context.Context, []byte) ([]byte, error)) error {
-	return e.transform(ctx, encryptionFunc)
+	if !e.Technical {
+		return e.transform(ctx, encryptionFunc)
+	}
+	return nil
 }
 
 func (e *Platform) Decrypt(ctx context.Context, decryptionFunc func(context.Context, []byte) ([]byte, error)) error {
-	return e.transform(ctx, decryptionFunc)
+	if !e.Technical {
+		return e.transform(ctx, decryptionFunc)
+	}
+	return nil
 }
 
 func (e *Platform) transform(ctx context.Context, transformationFunc func(context.Context, []byte) ([]byte, error)) error {
@@ -125,13 +131,16 @@ func (e *Platform) transform(ctx context.Context, transformationFunc func(contex
 }
 
 func (e *Platform) IntegralData() []byte {
-	oldCredentials := ""
-	if e.OldCredentials != nil && e.OldCredentials.Basic != nil {
-		oldCredentials = fmt.Sprintf(":%s:%s", e.OldCredentials.Basic.Username, e.OldCredentials.Basic.Password)
-	}
 	integrity := ""
-	if e.Credentials != nil {
-		integrity = fmt.Sprintf("%s:%s%s", e.Credentials.Basic.Username, e.Credentials.Basic.Password, oldCredentials)
+	if !e.Technical {
+		oldCredentials := ""
+		if e.OldCredentials != nil && e.OldCredentials.Basic != nil {
+			oldCredentials = fmt.Sprintf(":%s:%s", e.OldCredentials.Basic.Username, e.OldCredentials.Basic.Password)
+		}
+
+		if e.Credentials != nil {
+			integrity = fmt.Sprintf("%s:%s%s", e.Credentials.Basic.Username, e.Credentials.Basic.Password, oldCredentials)
+		}
 	}
 	return []byte(integrity)
 }

--- a/storage/interceptors/secured_generate_credentials_interceptor.go
+++ b/storage/interceptors/secured_generate_credentials_interceptor.go
@@ -64,6 +64,9 @@ func (c *generatePlatformCredentialsInterceptor) AroundTxCreate(h storage.Interc
 		}
 
 		if platform.Technical {
+			platform.Credentials = &types.Credentials{
+				Basic: &types.Basic{Username: platform.ID},
+			}
 			return h(ctx, obj)
 		}
 

--- a/test/platform_test/platform_test.go
+++ b/test/platform_test/platform_test.go
@@ -244,7 +244,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								"id":          "1234",
 							}).Expect().Status(http.StatusCreated).JSON().Object()
 						result.Value("id").String().Equal("1234")
-						result.NotContainsKey("credentials")
+						result.Value("technical").Boolean().Equal(true)
 					})
 				})
 			})

--- a/test/storage_test/storage_test.go
+++ b/test/storage_test/storage_test.go
@@ -328,18 +328,18 @@ var _ = Describe("Test", func() {
 
 	Context("when storing technical platform", func() {
 		It("should be created without credentials", func() {
-			ctx.SMRepository.Create(context.Background(), &types.Platform{
+			_, err := ctx.SMRepository.Create(context.Background(), &types.Platform{
 				Base: types.Base{
 					ID: "id_1234",
 				},
 				Name:      "platform",
 				Technical: true,
 			})
-
+			Expect(err).To(Not(HaveOccurred()))
 			obj, err := ctx.SMRepository.Get(context.Background(), types.PlatformType, query.ByField(query.EqualsOperator, "id", "id_1234"))
 			Expect(err).NotTo(HaveOccurred())
 			platform := obj.(*types.Platform)
-			Expect(platform.Credentials).To(BeNil())
+			Expect(platform.Credentials.Basic.Username).To(Equal(platform.ID))
 			Expect(platform.OldCredentials).To(BeNil())
 		})
 	})


### PR DESCRIPTION
fix unique username for technical platforms
technical platform have empty username which causing unique constraint violation on second technical platform creation.
The fix is to add platform id in username column