### PR TITLE
SAP CP re-branding to SAP BTP

### DIFF
--- a/docs/usage/example-usage.md
+++ b/docs/usage/example-usage.md
@@ -16,7 +16,7 @@ The following page contains some example scenarios in which the Service Manager 
 
 1. An application running in Kubernetes can consume services provided by the different evironments offered by the Multicloud (e.g. from multiple CF installations as well as K8S clusters). How this works can be seen [HERE](https://youtu.be/AYULBewzEwI).
 
-2. The same is valid for scenarios across cloud providers - the application may very well consume service-x from Azure, service-y from GCP and service-z from SAP CP. The only requirement is that the services offered by these cloud providers are exposed via service brokers.
+2. The same is valid for scenarios across cloud providers - the application may very well consume service-x from Azure, service-y from GCP and service-z from SAP BTP. The only requirement is that the services offered by these cloud providers are exposed via service brokers.
 
 ## Service Instance Sharing Examples
 


### PR DESCRIPTION
As pert of SAP re-branding of the SAP Cloud Platform to SAP BTP, we need to update the documentation 