### PR TITLE
support platform suspension

### DIFF
--- a/api/filters/check_platform_suspended_filter.go
+++ b/api/filters/check_platform_suspended_filter.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 The Service Manager Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import (
+	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/Peripli/service-manager/pkg/util"
+	"net/http"
+
+	"github.com/Peripli/service-manager/pkg/web"
+)
+
+const CheckPlatformSuspendedFilterName = "CheckPlatformSuspendedFilter"
+
+// ServiceBindingStripFilter checks post request body for unmodifiable properties
+type CheckPlatformSuspendedFilter struct {
+}
+
+func (*CheckPlatformSuspendedFilter) Name() string {
+	return CheckPlatformSuspendedFilterName
+}
+
+func (f *CheckPlatformSuspendedFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
+	user, ok := web.UserFromContext(req.Context())
+	if !ok {
+		return next.Handle(req)
+	}
+	platform := &types.Platform{}
+	err := user.Data(platform)
+	if err != nil {
+		return nil, err
+	}
+	if platform.Suspended {
+		return nil, &util.HTTPError{
+			ErrorType:   "BadRequest",
+			Description: "platform suspended",
+			StatusCode:  http.StatusBadRequest,
+		}
+	}
+	return next.Handle(req)
+}
+
+func (*CheckPlatformSuspendedFilter) FilterMatchers() []web.FilterMatcher {
+	return []web.FilterMatcher{
+		{
+			Matchers: []web.Matcher{
+				web.Path(web.OSBURL + "/**"),
+				web.Methods(http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete),
+			},
+		},
+	}
+}

--- a/pkg/sm/sm.go
+++ b/pkg/sm/sm.go
@@ -155,8 +155,7 @@ func New(ctx context.Context, cancel context.CancelFunc, e env.Environment, cfg 
 	securityBuilder, securityFilters := NewSecurityBuilder()
 	API.RegisterFiltersAfter(filters.LoggingFilterName, securityFilters...)
 	API.RegisterFilters(&filters.RegeneratePlatformCredentialsFilter{}, &filters.TechnicalPlatformFilter{Storage: interceptableRepository})
-
-	API.RegisterFiltersAfter(secFilters.AuthorizationFilterName, &filters.ForceDeleteValidationFilter{})
+	API.RegisterFiltersAfter(secFilters.AuthorizationFilterName, &filters.CheckPlatformSuspendedFilter{}, &filters.ForceDeleteValidationFilter{})
 
 	storageHealthIndicator, err := storage.NewSQLHealthIndicator(storage.PingFunc(smStorage.PingContext))
 	if err != nil {

--- a/pkg/types/platform.go
+++ b/pkg/types/platform.go
@@ -56,6 +56,7 @@ type Platform struct {
 	OldCredentials    *Credentials `json:"old_credentials,omitempty"`
 	Version           string       `json:"-"`
 	Active            bool         `json:"-"`
+	Suspended         bool         `json:"suspended,omitempty"`
 	LastActive        time.Time    `json:"-"`
 	Integrity         []byte       `json:"-"`
 	CredentialsActive bool         `json:"credentials_active,omitempty"`

--- a/storage/postgres/keystore_test.go
+++ b/storage/postgres/keystore_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Secured Storage", func() {
 		mock.ExpectQuery(`SELECT CURRENT_DATABASE()`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("mock"))
 		mock.ExpectQuery(`SELECT COUNT(1)*`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("1"))
 		mock.ExpectExec("SELECT pg_advisory_lock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20210107104000,false"))
+		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20210218104000,false"))
 		mock.ExpectExec("SELECT pg_advisory_unlock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 		options := storage.DefaultSettings()
 		options.EncryptionKey = string(envEncryptionKey)

--- a/storage/postgres/locker_test.go
+++ b/storage/postgres/locker_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Storage Locker", func() {
 		mock.ExpectQuery(`SELECT CURRENT_DATABASE()`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("mock"))
 		mock.ExpectQuery(`SELECT COUNT(1)*`).WillReturnRows(sqlmock.NewRows([]string{"mock"}).FromCSVString("1"))
 		mock.ExpectExec("SELECT pg_advisory_lock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
-		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20210107104000,false"))
+		mock.ExpectQuery(`SELECT version, dirty FROM "schema_migrations" LIMIT 1`).WillReturnRows(sqlmock.NewRows([]string{"version", "dirty"}).FromCSVString("20210218104000,false"))
 		mock.ExpectExec("SELECT pg_advisory_unlock*").WithArgs(sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
 
 		options := storage.DefaultSettings()

--- a/storage/postgres/migrations/20210218104000_platform_suspended.down.sql
+++ b/storage/postgres/migrations/20210218104000_platform_suspended.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE platforms DROP COLUMN IF EXISTS suspended;
+
+
+
+

--- a/storage/postgres/migrations/20210218104000_platform_suspended.up.sql
+++ b/storage/postgres/migrations/20210218104000_platform_suspended.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE platforms ADD COLUMN IF NOT EXISTS suspended BOOLEAN NOT NULL DEFAULT '0';
+
+
+
+

--- a/storage/postgres/platform.go
+++ b/storage/postgres/platform.go
@@ -39,6 +39,7 @@ type Platform struct {
 	OldPassword       string         `db:"old_password"`
 	Integrity         []byte         `db:"integrity"`
 	Active            bool           `db:"active"`
+	Suspended         bool           `db:"suspended"`
 	CredentialsActive bool           `db:"credentials_active"`
 	LastActive        time.Time      `db:"last_active"`
 	Technical         bool           `db:"technical"`
@@ -62,6 +63,7 @@ func (p *Platform) FromObject(object types.Object) (storage.Entity, error) {
 		Name:              platform.Name,
 		Description:       toNullString(platform.Description),
 		Active:            platform.Active,
+		Suspended:         platform.Suspended,
 		CredentialsActive: platform.CredentialsActive,
 		Technical:         platform.Technical,
 		Version:           toNullString(platform.Version),
@@ -101,6 +103,7 @@ func (p *Platform) ToObject() (types.Object, error) {
 		Name:              p.Name,
 		Description:       p.Description.String,
 		Active:            p.Active,
+		Suspended:         p.Suspended,
 		CredentialsActive: p.CredentialsActive,
 		LastActive:        p.LastActive,
 		Technical:         p.Technical,

--- a/test/osb_and_plugin_test/plugin_test/platform_suspended_plugin_test.go
+++ b/test/osb_and_plugin_test/plugin_test/platform_suspended_plugin_test.go
@@ -1,0 +1,122 @@
+package plugin_test
+
+import (
+	"context"
+	"github.com/Peripli/service-manager/pkg/query"
+	"github.com/Peripli/service-manager/pkg/types"
+	"github.com/Peripli/service-manager/storage"
+	"github.com/Peripli/service-manager/test/common"
+	"github.com/gofrs/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+)
+
+var _ = Describe("Platform Suspension OSB plugin", func() {
+	var (
+		ctx       *common.TestContext
+		planID    string
+		serviceID string
+		brokerID  string
+		osbURL    string
+	)
+
+	BeforeEach(func() {
+		ctx = common.NewTestContextBuilderWithSecurity().Build()
+		UUID, err := uuid.NewV4()
+		Expect(err).ToNot(HaveOccurred())
+		planID = UUID.String()
+		plan1 := common.GenerateTestPlanWithID(planID)
+		UUID, err = uuid.NewV4()
+		Expect(err).ToNot(HaveOccurred())
+		serviceID = UUID.String()
+		service1 := common.GenerateTestServiceWithPlansWithID(serviceID, plan1)
+		catalog := common.NewEmptySBCatalog()
+		catalog.AddService(service1)
+
+		brokerID, _, _ = ctx.RegisterBrokerWithCatalog(catalog).GetBrokerAsParams()
+		common.CreateVisibilitiesForAllBrokerPlans(ctx.SMWithOAuth, brokerID)
+		osbURL = "/v1/osb/" + brokerID
+
+		ctx.SMWithBasic.PUT(osbURL+"/v2/service_instances/12345").
+			WithHeader("Content-Type", "application/json").
+			WithJSON(object{"service_id": serviceID, "plan_id": planID}).
+			Expect().Status(http.StatusCreated)
+
+		testPlatformID := ctx.TestPlatform.GetID()
+
+		err = ctx.SMRepository.InTransaction(context.TODO(), func(ctx context.Context, storage storage.Repository) error {
+			var updatedPlatform types.Object
+			byID := query.ByField(query.EqualsOperator, "id", testPlatformID)
+			platformFromStorage, err := storage.Get(ctx, types.PlatformType, byID)
+			Expect(err).ToNot(HaveOccurred())
+
+			platformFromStorage.(*types.Platform).Suspended = true
+			if updatedPlatform, err = storage.Update(ctx, platformFromStorage, types.LabelChanges{}); err != nil {
+				return err
+			}
+			Expect(updatedPlatform.(*types.Platform).Suspended).To(Equal(true))
+			return nil
+		})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if ctx != nil {
+			ctx.Cleanup()
+		}
+	})
+
+	When("Platform Suspended", func() {
+
+		It("should not allow provision request", func() {
+			res := ctx.SMWithBasic.PUT(osbURL+"/v2/service_instances/12345").
+				WithHeader("Content-Type", "application/json").
+				WithJSON(object{"service_id": serviceID, "plan_id": planID}).
+				Expect().Status(http.StatusBadRequest).JSON().Object()
+			res.Value("description").Equal("platform suspended")
+		})
+
+		It("should not allow update request", func() {
+			res := ctx.SMWithBasic.PATCH(osbURL+"/v2/service_instances/12345").
+				WithHeader("Content-Type", "application/json").
+				WithJSON(object{"service_id": serviceID, "plan_id": planID, "parameters": "{\"key\":\"val\"}"}).
+				Expect().Status(http.StatusBadRequest).JSON().Object()
+			res.Value("description").Equal("platform suspended")
+		})
+
+		It("should not allow deprovision request", func() {
+			res := ctx.SMWithBasic.DELETE(osbURL + "/v2/service_instances/12345").
+				Expect().Status(http.StatusBadRequest).JSON().Object()
+			res.Value("description").Equal("platform suspended")
+		})
+
+		It("should allow fetch instance", func() {
+			ctx.SMWithBasic.GET(osbURL + "/v2/service_instances/12345").
+				Expect().Status(http.StatusOK)
+		})
+
+		It("should not allow bind request", func() {
+			res := ctx.SMWithBasic.PUT(osbURL + "/v2/service_instances/12345/service_bindings/5678").
+				WithJSON(object{"service_id": serviceID, "plan_id": planID}).
+				Expect().Status(http.StatusBadRequest).JSON().Object()
+			res.Value("description").Equal("platform suspended")
+		})
+
+		It("should not allow unbind request", func() {
+			res := ctx.SMWithBasic.DELETE(osbURL + "/v2/service_instances/12345/service_bindings/5678").
+				Expect().Status(http.StatusBadRequest).JSON().Object()
+			res.Value("description").Equal("platform suspended")
+		})
+
+		It("should allow fetch binding request", func() {
+			ctx.SMWithBasic.GET(osbURL + "/v2/service_instances/12345/service_bindings/5678").
+				Expect().Status(http.StatusOK)
+		})
+
+		It("should allow get catalog request", func() {
+			ctx.SMWithBasic.GET(osbURL + "/v2/catalog").
+				Expect().Status(http.StatusOK)
+		})
+	})
+})


### PR DESCRIPTION
Allow suspend platform by adding new boolean column to platform table,
Following OSB operations will be forbidden when the platform is suspended:
- Provision
- Deprovision
- Update
- Bind
- Unbind