### PR TITLE
install go meta linter with gomod off

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ prepare: prepare-counterfeiter build-gen-binary
 ifeq ($(shell which gometalinter),)
 	@echo "Installing gometalinter ...";\
 		cd $(GOPATH)/src;\
-		@GO111MODULE=off go get -u github.com/alecthomas/gometalinter;\
+		GO111MODULE=off go get -u github.com/alecthomas/gometalinter;\
 		cd $(GOPATH)/src/github.com/alecthomas/gometalinter;\
 		go install;\
 		gometalinter -i -u

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ prepare: prepare-counterfeiter build-gen-binary
 ifeq ($(shell which gometalinter),)
 	@echo "Installing gometalinter ...";\
 		cd $(GOPATH)/src;\
-		go get -u github.com/alecthomas/gometalinter;\
+		@GO111MODULE=off go get -u github.com/alecthomas/gometalinter;\
 		cd $(GOPATH)/src/github.com/alecthomas/gometalinter;\
 		go install;\
 		gometalinter -i -u

--- a/Makefile
+++ b/Makefile
@@ -80,13 +80,12 @@ prepare-counterfeiter:
 ## Installs some tools (gometalinter, cover, goveralls)
 prepare: prepare-counterfeiter build-gen-binary
 ifeq ($(shell which gometalinter),)
-	@export GO111MODULE=off
 	@echo "Installing gometalinter ...";\
 		cd $(GOPATH)/src;\
-		go get -u github.com/alecthomas/gometalinter;\
-		cd $(GOPATH)/src/github.com/alecthomas/gometalinter;\
-		go install;\
-		gometalinter -i -u
+		GO111MODULE=off go get -u github.com/alecthomas/gometalinter;\
+		GO111MODULE=off cd $(GOPATH)/src/github.com/alecthomas/gometalinter;\
+		GO111MODULE=off go install;\
+		GO111MODULE=off gometalinter -i -u
 	@export GO111MODULE=on
 endif
 ifeq ($(shell which cover),)

--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,14 @@ prepare-counterfeiter:
 ## Installs some tools (gometalinter, cover, goveralls)
 prepare: prepare-counterfeiter build-gen-binary
 ifeq ($(shell which gometalinter),)
+	@export GO111MODULE=off
 	@echo "Installing gometalinter ...";\
 		cd $(GOPATH)/src;\
-		GO111MODULE=off go get -u github.com/alecthomas/gometalinter;\
+		go get -u github.com/alecthomas/gometalinter;\
 		cd $(GOPATH)/src/github.com/alecthomas/gometalinter;\
 		go install;\
 		gometalinter -i -u
+	@export GO111MODULE=on
 endif
 ifeq ($(shell which cover),)
 	@echo "Installing cover tool..."

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ ifeq ($(shell which gometalinter),)
 		GO111MODULE=off cd $(GOPATH)/src/github.com/alecthomas/gometalinter;\
 		GO111MODULE=off go install;\
 		GO111MODULE=off gometalinter -i -u
-	@export GO111MODULE=on
 endif
 ifeq ($(shell which cover),)
 	@echo "Installing cover tool..."


### PR DESCRIPTION
As gometalinter does not work with go modules, its binary can only be installed now if we set the GO111MODULE flag to off.

