### PR TITLE
allow updating reference instance when parameters are not changed.

### DIFF
--- a/api/common/sharing/utils.go
+++ b/api/common/sharing/utils.go
@@ -59,8 +59,12 @@ func IsValidReferenceInstancePatchRequest(req *web.Request, instance *types.Serv
 	if instance.ServicePlanID != newPlanID {
 		return util.HandleInstanceSharingError(util.ErrChangingPlanOfReferenceInstance, instance.ID)
 	}
-	parametersRaw := gjson.GetBytes(req.Body, "parameters").Raw
-	if parametersRaw != "" {
+
+	parameters := gjson.GetBytes(req.Body, "parameters").Map()
+	referencedInstanceID, exists := parameters[instance_sharing.ReferencedInstanceIDKey]
+
+	containsSameReference := exists && referencedInstanceID.String() == instance.ReferencedInstanceID
+	if len(parameters) > 0 && !containsSameReference {
 		return util.HandleInstanceSharingError(util.ErrChangingParametersOfReferenceInstance, instance.ID)
 	}
 	return nil

--- a/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
@@ -4712,6 +4712,38 @@ var _ = DescribeTestsFor(TestCase{
 							object.ValueEqual("labels", expectedLabels)
 
 						})
+						It("succeeds patching with same reference id in the parameters", func() {
+							newName := "renamed"
+							patchRequestBody := Object{
+								"name":             newName,
+								"service_plan_id":  referencePlan.ID,
+								"maintenance_info": "{}",
+								"parameters": map[string]string{
+									instance_sharing.ReferencedInstanceIDKey: sharedInstanceID,
+								},
+							}
+							resp := ctx.SMWithOAuthForTenant.PATCH(web.ServiceInstancesURL+"/"+referenceInstanceID).
+								WithQuery("async", "false").
+								WithJSON(patchRequestBody).
+								Expect().
+								Status(http.StatusOK)
+							referenceInstanceID, _ = VerifyOperationExists(ctx, resp.Header("Location").Raw(), OperationExpectations{
+								Category:          types.UPDATE,
+								State:             types.SUCCEEDED,
+								ResourceType:      types.ServiceInstanceType,
+								Reschedulable:     false,
+								DeletionScheduled: false,
+							})
+							objAfterOp := VerifyResourceExists(ctx.SMWithOAuthForTenant, ResourceExpectations{
+								ID:    referenceInstanceID,
+								Type:  types.ServiceInstanceType,
+								Ready: true,
+							})
+							By("verify reference-instance plan has not changed")
+							objAfterOp.Value("service_plan_id").Equal(referencePlan.ID)
+							By("verify reference-instance-id has not changed")
+							objAfterOp.Value("referenced_instance_id").Equal(sharedInstanceID)
+						})
 						for _, testConfig := range []testConfigStruct{
 							{async: "true", status: http.StatusAccepted},
 							{async: "false", status: http.StatusOK},


### PR DESCRIPTION
## Motivation
Support the K8S polling mechanism for instance sharing.

## Approach

Allow passing parameters on reference-instance patch request as long as the "referenced_instance_id" value has not changed.

## Pull Request status

* [x] Initial implementation
* [x] Refactoring
* [ ] Unit tests
* [x] Integration tests



