### PR TITLE
Fix last operation query (compare single objects instead of lists)

### DIFF
--- a/operations/scheduler.go
+++ b/operations/scheduler.go
@@ -215,15 +215,16 @@ func (s *Scheduler) getResourceLastOperation(ctx context.Context, operation *typ
 	byResourceID := query.ByField(query.EqualsOperator, "resource_id", operation.ResourceID)
 	byResourceType := query.ByField(query.EqualsOperator, "resource_type", string(operation.ResourceType))
 	orderDesc := query.OrderResultBy("paging_sequence", query.DescOrder)
-	lastOperationObj, err := s.repository.Get(ctx, types.OperationType, byResourceID, byResourceType, orderDesc)
+	limit := query.LimitResultBy(1)
+	operationsForResourceID, err := s.repository.List(ctx, types.OperationType, byResourceID, byResourceType, orderDesc, limit)
 	if err != nil {
-		if err == util.ErrNotFoundInStorage {
-			log.C(ctx).Debugf("Could not find last operation for resource with id %s and type %s in SMDB. Ignoring missing operation", operation.ResourceID, operation.ResourceType)
-			return nil, false, false, nil
-		}
 		return nil, false, false, util.HandleStorageError(err, types.OperationType.String())
 	}
-	lastOperation := lastOperationObj.(*types.Operation)
+	if operationsForResourceID.Len() == 0 {
+		log.C(ctx).Debugf("Could not find last operation for resource with id %s and type %s in SMDB. Ignoring missing operation", operation.ResourceID, operation.ResourceType)
+		return nil, false, false, nil
+	}
+	lastOperation := operationsForResourceID.ItemAt(0).(*types.Operation)
 	log.C(ctx).Infof("Last operation for resource with id %s of type %s is %+v", lastOperation.ResourceID, lastOperation.ResourceType, lastOperation)
 
 	currentOperationExists := false

--- a/operations/scheduler.go
+++ b/operations/scheduler.go
@@ -226,17 +226,17 @@ func (s *Scheduler) getResourceLastOperation(ctx context.Context, operation *typ
 	lastOperation := lastOperationObj.(*types.Operation)
 	log.C(ctx).Infof("Last operation for resource with id %s of type %s is %+v", lastOperation.ResourceID, lastOperation.ResourceType, lastOperation)
 
-	currentOpExists := false
+	currentOperationExists := false
 	if checkForExistingOperation {
 		byID := query.ByField(query.EqualsOperator, "id", operation.GetID())
 		existingOperationsByID, err := s.repository.List(ctx, types.OperationType, byID)
 		if err != nil {
 			return nil, false, false, util.HandleStorageError(err, types.OperationType.String())
 		}
-		currentOpExists = existingOperationsByID.Len() > 0
+		currentOperationExists = existingOperationsByID.Len() > 0
 	}
 
-	return lastOperation, true, currentOpExists, nil
+	return lastOperation, true, currentOperationExists, nil
 }
 
 func (s *Scheduler) checkForConcurrentOperations(ctx context.Context, operation *types.Operation, lastOperation *types.Operation) error {


### PR DESCRIPTION
FIX: Use an existing named_query to retrieve the resource's last operation instead of loading a full operation list.
Check for existing operation only when is needed.