### PR TITLE
don't allow update broker credentials on resync job

### DIFF
--- a/api/credentials_controller.go
+++ b/api/credentials_controller.go
@@ -118,7 +118,7 @@ func (c *credentialsController) setCredentials(r *web.Request) (*web.Response, e
 		return nil, util.HandleStorageError(err, types.BrokerPlatformCredentialType.String())
 	}
 
-	if body.NotificationID == "" {
+	if body.NotificationID == "" && objFromDB.(*types.BrokerPlatformCredential).Active {
 		log.C(ctx).Error("Notification id not provided and broker platform credentials already exists...")
 		return nil, &util.HTTPError{
 			ErrorType:   "CredentialsError",

--- a/api/credentials_controller.go
+++ b/api/credentials_controller.go
@@ -118,7 +118,7 @@ func (c *credentialsController) setCredentials(r *web.Request) (*web.Response, e
 		return nil, util.HandleStorageError(err, types.BrokerPlatformCredentialType.String())
 	}
 
-	if body.NotificationID == "" && platform.Type != types.K8sPlatformType { // K8S clusters are less restrictive in terms of broker management, we need to allow credential rotation even if it's triggered by full resync
+	if body.NotificationID == "" {
 		log.C(ctx).Error("Notification id not provided and broker platform credentials already exists...")
 		return nil, &util.HTTPError{
 			ErrorType:   "CredentialsError",

--- a/test/osb_and_plugin_test/osb_test/catalog_test.go
+++ b/test/osb_and_plugin_test/osb_test/catalog_test.go
@@ -469,12 +469,10 @@ var _ = Describe("Catalog", func() {
 					k8sOSBClient.GET(osbURL + "/v2/catalog").
 						Expect().Status(http.StatusOK).JSON().Object().ContainsKey("services")
 
-					newUsername, newPassword = test.RegisterBrokerPlatformCredentials(k8sPlatformClient, prefixedBrokerID)
+					newUsername, newPassword = test.RegisterBrokerPlatformCredentialsExpect(k8sPlatformClient, prefixedBrokerID, http.StatusConflict)
 					k8sOSBClient.SetBasicCredentials(ctx, newUsername, newPassword)
+					assertCredentialsNotChanged(oldSMWithBasic, k8sOSBClient)
 
-					By("rotation of K8S credentials broker platform credentials should work")
-					k8sOSBClient.GET(osbURL + "/v2/catalog").
-						Expect().Status(http.StatusOK).JSON().Object().ContainsKey("services")
 				})
 			})
 		})

--- a/test/osb_and_plugin_test/osb_test/catalog_test.go
+++ b/test/osb_and_plugin_test/osb_test/catalog_test.go
@@ -378,7 +378,7 @@ var _ = Describe("Catalog", func() {
 								query.OrderResultBy("created_at", query.DescOrder))
 							Expect(err).ToNot(HaveOccurred())
 
-							newUsername, newPassword := test.RegisterBrokerPlatformCredentialsWithNotificationID(SMWithBasicPlatform, prefixedBrokerID, notifications.ItemAt(0).GetID())
+							newUsername, newPassword := test.RegisterBrokerPlatformCredentialsWithNotificationIDNoActivateExpect(SMWithBasicPlatform, prefixedBrokerID, notifications.ItemAt(0).GetID(), http.StatusOK)
 							ctx.SMWithBasic.SetBasicCredentials(ctx, newUsername, newPassword)
 
 							By("new credentials not yet used")

--- a/test/test.go
+++ b/test/test.go
@@ -309,8 +309,12 @@ func RegisterBrokerPlatformCredentialsWithNotificationIDExpect(SMBasicPlatform *
 		"notification_id": notificationID,
 	}
 
-	SMBasicPlatform.Request(http.MethodPut, web.BrokerPlatformCredentialsURL).
-		WithJSON(payload).Expect().Status(expectedStatusCode)
+	res := SMBasicPlatform.Request(http.MethodPut, web.BrokerPlatformCredentialsURL).
+		WithJSON(payload).Expect().Status(expectedStatusCode).JSON().Object()
 
+	if expectedStatusCode == http.StatusOK {
+		SMBasicPlatform.Request(http.MethodPut, fmt.Sprintf("%s/%s/activate", web.BrokerPlatformCredentialsURL, res.Value("id").String().Raw())).
+			WithJSON(common.Object{}).Expect().Status(http.StatusOK)
+	}
 	return username, password
 }


### PR DESCRIPTION
don't allow update broker credentials on resync job
it's not really needed credentials will be rotated only on active broker update
