### PR TITLE
add service manager tenant id to info endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -48,6 +48,7 @@ const osbVersion = "2.14"
 
 // Settings type to be loaded from the environment
 type Settings struct {
+	ServiceManagerTenantId     string   `mapstructure:"service_manager_tenant_id" description:"tenant id of the service manager"`
 	TokenIssuerURL             string   `mapstructure:"token_issuer_url" description:"url of the token issuer which to use for validating tokens"`
 	ClientID                   string   `mapstructure:"client_id" description:"id of the client from which the token must be issued"`
 	TokenBasicAuth             bool     `mapstructure:"token_basic_auth" description:"specifies if client credentials to the authorization server should be sent in the header as basic auth (true) or in the body (false)"`
@@ -138,6 +139,7 @@ func New(ctx context.Context, e env.Environment, options *Options) (*web.API, er
 			&info.Controller{
 				TokenIssuer:    options.APISettings.TokenIssuerURL,
 				TokenBasicAuth: options.APISettings.TokenBasicAuth,
+				ServiceManagerTenantId: options.APISettings.ServiceManagerTenantId,
 			},
 			&osb.Controller{
 				BrokerFetcher: func(ctx context.Context, brokerID string) (*types.ServiceBroker, error) {

--- a/api/api.go
+++ b/api/api.go
@@ -137,8 +137,8 @@ func New(ctx context.Context, e env.Environment, options *Options) (*web.API, er
 			},
 
 			&info.Controller{
-				TokenIssuer:    options.APISettings.TokenIssuerURL,
-				TokenBasicAuth: options.APISettings.TokenBasicAuth,
+				TokenIssuer:            options.APISettings.TokenIssuerURL,
+				TokenBasicAuth:         options.APISettings.TokenBasicAuth,
 				ServiceManagerTenantId: options.APISettings.ServiceManagerTenantId,
 			},
 			&osb.Controller{

--- a/api/info/info_controller.go
+++ b/api/info/info_controller.go
@@ -30,6 +30,7 @@ type Controller struct {
 	// TokenBasicAuth specifies if client credentials should be sent in the header
 	// as basic auth (true) or in the body (false)
 	TokenBasicAuth bool `json:"token_basic_auth"`
+	ServiceManagerTenantId string `json:"service_manager_tenant_id"`
 }
 
 var _ web.Controller = &Controller{}

--- a/api/info/info_controller.go
+++ b/api/info/info_controller.go
@@ -29,7 +29,7 @@ type Controller struct {
 
 	// TokenBasicAuth specifies if client credentials should be sent in the header
 	// as basic auth (true) or in the body (false)
-	TokenBasicAuth bool `json:"token_basic_auth"`
+	TokenBasicAuth         bool   `json:"token_basic_auth"`
 	ServiceManagerTenantId string `json:"service_manager_tenant_id"`
 }
 

--- a/test/info_test/info_test.go
+++ b/test/info_test/info_test.go
@@ -38,9 +38,10 @@ var _ = Describe("Info API", func() {
 		description     string
 		configBasicAuth bool
 		expectBasicAuth bool
+		serviceManagerTenantId string
 	}{
-		{"Returns token_issuer_url and token_basic_auth: true", true, true},
-		{"Returns token_issuer_url and token_basic_auth: false", false, false},
+		{"Returns token_issuer_url and token_basic_auth: true", true, true, ""},
+		{"Returns token_issuer_url and token_basic_auth: false", false, false,"someId"},
 	}
 
 	for _, tc := range cases {
@@ -51,6 +52,7 @@ var _ = Describe("Info API", func() {
 
 			postHook := func(e env.Environment, servers map[string]common.FakeServer) {
 				e.Set("api.token_basic_auth", tc.configBasicAuth)
+				e.Set("api.service_manager_tenant_id",tc.serviceManagerTenantId)
 			}
 			ctx = common.NewTestContextBuilder().WithEnvPostExtensions(postHook).Build()
 
@@ -64,6 +66,7 @@ var _ = Describe("Info API", func() {
 				JSON().Object().Equal(common.Object{
 				"token_issuer_url": ctx.Servers[common.OauthServer].URL(),
 				"token_basic_auth": tc.expectBasicAuth,
+				"service_manager_tenant_id":tc.serviceManagerTenantId,
 			})
 		})
 	}

--- a/test/info_test/info_test.go
+++ b/test/info_test/info_test.go
@@ -35,13 +35,13 @@ func TestInfo(t *testing.T) {
 
 var _ = Describe("Info API", func() {
 	cases := []struct {
-		description     string
-		configBasicAuth bool
-		expectBasicAuth bool
+		description            string
+		configBasicAuth        bool
+		expectBasicAuth        bool
 		serviceManagerTenantId string
 	}{
 		{"Returns token_issuer_url and token_basic_auth: true", true, true, ""},
-		{"Returns token_issuer_url and token_basic_auth: false", false, false,"someId"},
+		{"Returns token_issuer_url and token_basic_auth: false", false, false, "someId"},
 	}
 
 	for _, tc := range cases {
@@ -52,7 +52,7 @@ var _ = Describe("Info API", func() {
 
 			postHook := func(e env.Environment, servers map[string]common.FakeServer) {
 				e.Set("api.token_basic_auth", tc.configBasicAuth)
-				e.Set("api.service_manager_tenant_id",tc.serviceManagerTenantId)
+				e.Set("api.service_manager_tenant_id", tc.serviceManagerTenantId)
 			}
 			ctx = common.NewTestContextBuilder().WithEnvPostExtensions(postHook).Build()
 
@@ -64,9 +64,9 @@ var _ = Describe("Info API", func() {
 				Expect().
 				Status(http.StatusOK).
 				JSON().Object().Equal(common.Object{
-				"token_issuer_url": ctx.Servers[common.OauthServer].URL(),
-				"token_basic_auth": tc.expectBasicAuth,
-				"service_manager_tenant_id":tc.serviceManagerTenantId,
+				"token_issuer_url":          ctx.Servers[common.OauthServer].URL(),
+				"token_basic_auth":          tc.expectBasicAuth,
+				"service_manager_tenant_id": tc.serviceManagerTenantId,
 			})
 		})
 	}


### PR DESCRIPTION
## Motivation

Allow developers to retrieve service manager tenant id for development/ configurations purposes .

## Approach

Add service manager tenant  id to the info endpoint 

## Pull Request status

* [x] Initial implementation
* [ ] Refactoring
* [x] Unit tests
* [x] Integration tests

