### PR TITLE
send only only one registered certificate when broker is registered wi…

### DIFF
--- a/pkg/client/broker_transport.go
+++ b/pkg/client/broker_transport.go
@@ -25,7 +25,7 @@ import (
 func GetTransportWithTLS(tlsConfig *tls.Config, logger *logrus.Entry) *http.Transport {
 	transport := http.Transport{}
 	httpclient.ConfigureTransport(&transport)
-	transport.TLSClientConfig.Certificates = append(transport.TLSClientConfig.Certificates, tlsConfig.Certificates...)
+	transport.TLSClientConfig.Certificates = tlsConfig.Certificates
 	logger.Infof("adding certificates to tls connection, added %d certificate/s", len(transport.TLSClientConfig.Certificates))
 	//prevents keeping idle connections when accessing to different broker hosts
 	transport.DisableKeepAlives = true

--- a/storage/interceptors/smaap_service_instance_interceptor.go
+++ b/storage/interceptors/smaap_service_instance_interceptor.go
@@ -741,7 +741,6 @@ func preparePrerequisites(ctx context.Context, repository storage.Repository, os
 	}
 
 	if tlsConfig != nil {
-		tlsConfig.Certificates = append(tlsConfig.Certificates, httpclient.GetHttpClientGlobalSettings().TLSCertificates...)
 		osbClientConfig.TLSConfig = tlsConfig
 	} else if len(httpclient.GetHttpClientGlobalSettings().TLSCertificates) > 0 {
 		var defaultTLSConfig tls.Config

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -650,7 +650,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							})
 							Context("broker with its own tls configuration", func() {
 								It("sends request to a broker that supports only service manager certificate, should fail", func() {
-									//check if only one certificate is sends, otherwise the connection would fail
+									//check if only one certificate is sent, otherwise the connection would'nt fail
 									ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerRequestWithTLSToWrongBrokerServer).
 										Expect().
 										Status(http.StatusBadGateway)

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -91,6 +91,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				postBrokerRequestWithTLSandBasic                       Object
 				expectedBrokerResponseTLS                              Object
 				expectedBrokerServerWithServiceManagerMtlsAndBasicAuth Object
+				postBrokerRequestWithTLSToWrongBrokerServer			   Object
 				postBrokerRequestWithTLSNoCert                         Object
 				labels                                                 Object
 				postBrokerServerMtls                                   Object
@@ -195,6 +196,19 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						"basic": Object{
 							"username": brokerServerWithSMCertficate.Username,
 							"password": brokerServerWithSMCertficate.Password,
+						},
+					},
+				}
+
+
+				postBrokerRequestWithTLSToWrongBrokerServer = Object{
+					"name":        "wrong-broker-tls",
+					"broker_url":  brokerServerWithSMCertficate.URL(),
+					"description": brokerDescription,
+					"credentials": Object{
+						"tls": Object{
+							"client_certificate": tls_settings.ClientCertificate,
+							"client_key":         tls_settings.ClientKey,
 						},
 					},
 				}
@@ -633,6 +647,14 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 								})
 
+							})
+							Context("broker with its own tls configuration", func() {
+								It("sends request to a broker that supports  only service manager certificate", func() {
+									//check if only one certificate is sends, otherwise the connection would fail
+									ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerRequestWithTLSToWrongBrokerServer).
+										Expect().
+										Status(http.StatusBadGateway)
+								})
 							})
 							Context("broker client certificate and basic auth are configured", func() {
 								It("should succeed", func() {

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -649,7 +649,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 							})
 							Context("broker with its own tls configuration", func() {
-								It("sends request to a broker that supports  only service manager certificate", func() {
+								It("sends request to a broker that supports only service manager certificate, should fail", func() {
 									//check if only one certificate is sends, otherwise the connection would fail
 									ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerRequestWithTLSToWrongBrokerServer).
 										Expect().

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -91,7 +91,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				postBrokerRequestWithTLSandBasic                       Object
 				expectedBrokerResponseTLS                              Object
 				expectedBrokerServerWithServiceManagerMtlsAndBasicAuth Object
-				postBrokerRequestWithTLSToWrongBrokerServer			   Object
+				postBrokerRequestWithTLSToWrongBrokerServer            Object
 				postBrokerRequestWithTLSNoCert                         Object
 				labels                                                 Object
 				postBrokerServerMtls                                   Object
@@ -199,7 +199,6 @@ var _ = test.DescribeTestsFor(test.TestCase{
 						},
 					},
 				}
-
 
 				postBrokerRequestWithTLSToWrongBrokerServer = Object{
 					"name":        "wrong-broker-tls",


### PR DESCRIPTION
Reference to bug: https://jtrack.wdf.sap.corp/browse/NGPBUG-155102
in case the broker is registered with tls, send only the registered certificate, don't send the default service manager certificate.
Now it sends both, and haproxy gets confused