### PR TITLE
Revert ignore case for reference provisioning

### DIFF
--- a/api/common/sharing/utils.go
+++ b/api/common/sharing/utils.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Peripli/service-manager/pkg/web"
 	"github.com/Peripli/service-manager/storage"
 	"github.com/tidwall/gjson"
-	"strings"
 )
 
 func ExtractReferencedInstanceID(req *web.Request, repository storage.Repository, body []byte, tenantIdentifier string, getTenantId func() string, smaap bool) (string, error) {
@@ -60,7 +59,6 @@ func IsValidReferenceInstancePatchRequest(req *web.Request, instance *types.Serv
 	if instance.ServicePlanID != newPlanID {
 		return util.HandleInstanceSharingError(util.ErrChangingPlanOfReferenceInstance, instance.ID)
 	}
-
 	parameters := gjson.GetBytes(req.Body, "parameters").Map()
 	referencedInstanceID, exists := parameters[instance_sharing.ReferencedInstanceIDKey]
 
@@ -154,11 +152,11 @@ func filterInstancesBySelectors(ctx context.Context, repository storage.Reposito
 		instance := instances.ItemAt(i).(*types.ServiceInstance)
 
 		selectorVal, exists := parameters[instance_sharing.ReferenceInstanceNameSelectorKey]
-		if exists && len(selectorVal.String()) > 0 && !equalsIgnoreCase(instance.Name, selectorVal.String()) {
+		if exists && len(selectorVal.String()) > 0 && !(instance.Name == selectorVal.String()) {
 			continue
 		}
 
-		if selectorPlan != nil && !equalsIgnoreCase(instance.ServicePlanID, selectorPlan.ID) {
+		if selectorPlan != nil && instance.ServicePlanID != selectorPlan.ID {
 			continue
 		}
 
@@ -193,23 +191,19 @@ func filterInstancesBySelectors(ctx context.Context, repository storage.Reposito
 
 func getSelectorPlan(ctx context.Context, repository storage.Repository, smaap bool, offeringID, selectorValue string) (*types.ServicePlan, error) {
 	var err error
-	namedQuery := storage.QueryForPlanByNameIgnoreCase
-	if !smaap {
-		namedQuery = storage.QueryForPlanByCatalogNameIgnoreCase
+	var key string
+	if smaap {
+		key = "name"
+	} else {
+		key = "catalog_name"
 	}
-
-	queryParams := map[string]interface{}{
-		"name":        selectorValue,
-		"offering_id": offeringID,
-	}
-	objectList, err := repository.QueryForList(ctx, types.ServicePlanType, namedQuery, queryParams)
-	if err != nil || objectList.Len() == 0 {
+	planObject, err := repository.Get(ctx, types.ServicePlanType,
+		query.ByField(query.EqualsOperator, key, selectorValue),
+		query.ByField(query.EqualsOperator, "service_offering_id", offeringID),
+	)
+	if err != nil {
 		return nil, util.HandleInstanceSharingError(util.ErrNoResultsForReferenceSelector, "")
 	}
-	if objectList.Len() > 1 {
-		return nil, util.HandleInstanceSharingError(util.ErrMultipleReferenceSelectorResults, "")
-	}
-	planObject := objectList.ItemAt(0)
 	selectorPlan := planObject.(*types.ServicePlan)
 	return selectorPlan, nil
 }
@@ -246,13 +240,9 @@ func isSameServiceOffering(ctx context.Context, repository storage.Repository, o
 
 func contains(s []string, e string) bool {
 	for _, a := range s {
-		if equalsIgnoreCase(a, e) {
+		if a == e {
 			return true
 		}
 	}
 	return false
-}
-
-func equalsIgnoreCase(a, b string) bool {
-	return strings.EqualFold(a, b)
 }

--- a/api/osb/instance_sharing_plugin.go
+++ b/api/osb/instance_sharing_plugin.go
@@ -263,7 +263,7 @@ func (is *instanceSharingPlugin) handleBinding(req *web.Request, next web.Handle
 
 	instance := serviceInstanceObj.(*types.ServiceInstance)
 
-	// if instance is referecnce, switch the context of the request with the original instance context.
+	// if instance is reference, switch the context of the request with the original instance context.
 	if len(instance.ReferencedInstanceID) > 0 {
 		referencedInstanceObject, err := storage.GetObjectByField(ctx, is.repository, types.ServiceInstanceType, "id", instance.ReferencedInstanceID)
 		if err != nil {

--- a/storage/named_query.go
+++ b/storage/named_query.go
@@ -11,8 +11,6 @@ const (
 	QueryForVisibilityWithPlatformAndPlan
 	QueryForPlanByNameAndOfferingsWithVisibility
 	QueryForSharedInstances
-	QueryForPlanByNameIgnoreCase
-	QueryForPlanByCatalogNameIgnoreCase
 )
 
 var namedQueries = map[NamedQuery]string{
@@ -103,12 +101,6 @@ var namedQueries = map[NamedQuery]string{
 			WHERE service_instance_labels.key = :tenant_identifier AND service_instance_labels.val = :tenant_id AND
 				  service_instance_labels.service_instance_id = service_instances.id
 		  )`,
-	QueryForPlanByNameIgnoreCase: `
-	SELECT * FROM service_plans
-	WHERE service_offering_id = :offering_id AND name ILIKE :name`,
-	QueryForPlanByCatalogNameIgnoreCase: `
-	SELECT * FROM service_plans
-	WHERE service_offering_id = :offering_id AND catalog_name ILIKE :name`,
 }
 
 func GetNamedQuery(query NamedQuery) string {

--- a/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
@@ -4054,14 +4054,12 @@ var _ = DescribeTestsFor(TestCase{
 									It("succeeds to provision by plan name selector", func() {
 										randomUUID, _ := uuid.NewV4()
 										sharedPlan := GetPlanByKey(ctx, "id", sharedInstance.ServicePlanID)
-										// case sensitive test:
-										selectorVal := strings.ToUpper(sharedPlan.Name)
 										requestBody := Object{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
 											"parameters": map[string]string{
-												instance_sharing.ReferencePlanNameSelectorKey: selectorVal,
+												instance_sharing.ReferencePlanNameSelectorKey: sharedPlan.Name,
 											},
 										}
 										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
@@ -4072,14 +4070,12 @@ var _ = DescribeTestsFor(TestCase{
 									})
 									It("succeeds to provision by instance name selector", func() {
 										randomUUID, _ := uuid.NewV4()
-										// case sensitive test:
-										selectorVal := strings.ToUpper(sharedInstance.Name)
 										requestBody := Object{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
 											"parameters": map[string]string{
-												instance_sharing.ReferenceInstanceNameSelectorKey: selectorVal,
+												instance_sharing.ReferenceInstanceNameSelectorKey: sharedInstance.Name,
 											},
 										}
 										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
@@ -4177,15 +4173,13 @@ var _ = DescribeTestsFor(TestCase{
 									})
 									It("succeeds to provision by label selector if the instance has a match with the selector label", func() {
 										randomUUID, _ := uuid.NewV4()
-										// case sensitive test:
-										labelUpper := strings.ToUpper("eu")
 										requestBody := Object{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
 											"parameters": map[string]map[string][]string{
 												instance_sharing.ReferenceLabelSelectorKey: {
-													"origin": {labelUpper, "1"},
+													"origin": {"eu", "1"},
 												},
 											},
 										}


### PR DESCRIPTION
# Revert Ignore Case for Instance Reference Selectors

## Motivation

We do want to be case-sensitive for reference-instance provision by selectors.

## Approach

Revert to the original selector feature without the ignore case named-queries.

## Pull Request status

* [x] Initial implementation
* [x] Refactoring
* [x] Unit tests
* [x] Integration tests
