### PR TITLE
Reference selectors with label query

### DIFF
--- a/api/common/sharing/utils.go
+++ b/api/common/sharing/utils.go
@@ -40,7 +40,7 @@ func ExtractReferencedInstanceID(req *web.Request, repository storage.Repository
 		selectors := parameters[instance_sharing.SelectorsKey].Map()
 		referencedInstance, err = filterInstancesBySelectors(ctx, repository, referencePlan.ServiceOfferingID, tenantIdentifier, getTenantId(), selectors, smaap)
 		if err != nil {
-			log.C(ctx).Errorf("Failed to filter instances by selectors: %s", err)
+			log.C(ctx).Errorf("Failed to filter instances by selectors: %s", err.Error())
 			return "", err
 		}
 
@@ -140,9 +140,8 @@ func filterInstancesBySelectors(ctx context.Context, repository storage.Reposito
 
 	// Filter by label query:
 	labelsSelector, labelExists := selectors[instance_sharing.ReferenceLabelSelectorKey]
-	labelsSelectorArray := labelsSelector.Array()
-	hasLabelsSelectors := labelExists && len(labelsSelectorArray) > 0 && labelsSelectorArray[0].String() != ""
-	if hasLabelsSelectors {
+	if labelExists && len(labelsSelector.Array()) > 0 && labelsSelector.Array()[0].String() != "" {
+		labelsSelectorArray := labelsSelector.Array()
 		var criteria []query.Criterion
 		for index := 0; index < len(labelsSelectorArray); index++ {
 			queryToParse := labelsSelectorArray[index].String()

--- a/api/common/sharing/utils.go
+++ b/api/common/sharing/utils.go
@@ -228,25 +228,6 @@ func getInstanceByLabelSelector(ctx context.Context, repository storage.Reposito
 	return instancesList.ItemAt(0).(*types.ServiceInstance), nil
 }
 
-func matchLabels(instanceLabels types.Labels, selectorLabels types.Labels) (bool, error) {
-	if instanceLabels == nil {
-		return false, nil
-	}
-	for selectorLabelKey, selectorLabelArray := range selectorLabels {
-		instanceLabelArray, exists := instanceLabels[selectorLabelKey]
-		if exists && len(instanceLabelArray) > 0 {
-			for _, selectorLabelVal := range selectorLabelArray {
-				if !contains(instanceLabelArray, selectorLabelVal) {
-					return false, nil
-				}
-			}
-		} else {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
 func isSameServiceOffering(ctx context.Context, repository storage.Repository, offeringID string, planID string) (bool, error) {
 	count, err := repository.Count(ctx, types.ServicePlanType,
 		query.ByField(query.EqualsOperator, "service_offering_id", offeringID),
@@ -256,13 +237,4 @@ func isSameServiceOffering(ctx context.Context, repository storage.Repository, o
 		return false, util.HandleStorageError(err, types.ServicePlanType.String())
 	}
 	return count > 0, nil
-}
-
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
 }

--- a/api/common/sharing/utils.go
+++ b/api/common/sharing/utils.go
@@ -154,9 +154,6 @@ func filterInstancesBySelectors(ctx context.Context, repository storage.Reposito
 				return nil, err
 			}
 			criteria = append(criteria, parse...)
-			// need to move the query label out as the service plan selector.
-			// need to run a query for service instances with this criteria
-			// if we get single service instance that matches the criteria, we need to check if it is equal to the current instnace
 		}
 		selectorLabeledInstance, err = getInstanceByLabelSelector(ctx, repository, criteria)
 		if err != nil {

--- a/api/common/sharing/utils.go
+++ b/api/common/sharing/utils.go
@@ -137,21 +137,20 @@ func filterInstancesBySelectors(ctx context.Context, repository storage.Reposito
 	var filteredInstances types.ServiceInstances
 
 	var sharedInstances types.ObjectList
-	var allowedPlans types.ObjectList
 
 	// Filter by label query:
 	labelsSelector, labelExists := selectors[instance_sharing.ReferenceLabelSelectorKey]
 	labelsSelectorArray := labelsSelector.Array()
-	withLabelsSelectors := labelExists && len(labelsSelectorArray) > 0 && labelsSelectorArray[0].String() != ""
-	if withLabelsSelectors {
+	hasLabelsSelectors := labelExists && len(labelsSelectorArray) > 0 && labelsSelectorArray[0].String() != ""
+	if hasLabelsSelectors {
 		var criteria []query.Criterion
 		for index := 0; index < len(labelsSelectorArray); index++ {
 			queryToParse := labelsSelectorArray[index].String()
-			parse, err := query.Parse(query.LabelQuery, queryToParse)
+			criterion, err := query.Parse(query.LabelQuery, queryToParse)
 			if err != nil {
 				return nil, err
 			}
-			criteria = append(criteria, parse...)
+			criteria = append(criteria, criterion...)
 		}
 		criteria = append(criteria, query.ByLabel(query.EqualsOperator, tenantIdentifier, tenantValue))
 		criteria = append(criteria, query.ByField(query.EqualsOperator, "shared", "true"))
@@ -159,7 +158,7 @@ func filterInstancesBySelectors(ctx context.Context, repository storage.Reposito
 		if err != nil {
 			return nil, err
 		}
-		allowedPlans, err = getPlansOfServiceOffering(ctx, repository, offeringID)
+		allowedPlans, err := getPlansOfServiceOffering(ctx, repository, offeringID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/instance_sharing/types.go
+++ b/pkg/instance_sharing/types.go
@@ -7,22 +7,22 @@ const (
 	SupportsInstanceSharingKey = "supportsInstanceSharing"
 
 	ReferencedInstanceIDKey         = "referenced_instance_id"
-	ReferencedInstanceIDTitle       = "Reference Instance ID"
+	ReferencedInstanceIDTitle       = "Referenced Instance ID"
 	ReferencedInstanceIDDescription = "Specify the ID of the instance to which you want to create a reference."
 
-	BySelectorsKey         = "referenced_instance_id"
-	BySelectorsTitle       = "Reference Instance ID"
-	BySelectorsDescription = "Specify the ID of the instance to which you want to create a reference."
+	SelectorsKey           = "selectors"
+	BySelectorsTitle       = "Attributes"
+	BySelectorsDescription = "Find the instance to which you want to create a reference by using various search attributes, such as instance name, plan name, or labels."
 
 	ReferenceInstanceNameSelectorKey         = "instance_name_selector"
 	ReferenceInstanceNameSelectorTitle       = "Find by Instance Name"
-	ReferenceInstanceNameSelectorDescription = "You can use the instance name to find the shared instance to which you want to create a reference."
+	ReferenceInstanceNameSelectorDescription = "Specify the instance name of the shared instance to which you want to create a reference."
 
 	ReferencePlanNameSelectorKey         = "plan_name_selector"
 	ReferencePlanNameSelectorTitle       = "Find by Plan Name"
-	ReferencePlanNameSelectorDescription = "You can use the plan name to find the shared instance to which you want to create a reference."
+	ReferencePlanNameSelectorDescription = "Specify the plan name of the shared instance to which you want to create a reference."
 
-	ReferenceLabelSelectorKey         = "instance_labels_selector"
-	ReferenceLabelSelectorTitle       = "instance_labels_selector"
-	ReferenceLabelSelectorDescription = "instance_labels_selector"
+	ReferenceLabelSelectorKey         = "instance_label_selector"
+	ReferenceLabelSelectorTitle       = "Find by Label Query"
+	ReferenceLabelSelectorDescription = "You can use the labels query to find the shared instance to which you want to create a reference. For example: \\\"origin\\\": [\\\"eu\\\"] returns an instance whose origin is in the EU."
 )

--- a/pkg/instance_sharing/types.go
+++ b/pkg/instance_sharing/types.go
@@ -7,22 +7,22 @@ const (
 	SupportsInstanceSharingKey = "supportsInstanceSharing"
 
 	ReferencedInstanceIDKey         = "referenced_instance_id"
-	ReferencedInstanceIDTitle       = "Shared Instance ID "
-	ReferencedInstanceIDDescription = "Specify the ID of the instance to which you want to create a reference."
+	ReferencedInstanceIDTitle       = "Shared Instance ID"
+	ReferencedInstanceIDDescription = "Specify the ID of the instance to which you want to create the reference."
 
 	SelectorsKey           = "selectors"
-	BySelectorsTitle       = "Shared Instance Attributes "
-	BySelectorsDescription = "Find the shared instance to which you want to create a reference by specifying its various attributes, such as instance name, plan name, or labels."
+	BySelectorsTitle       = "Find by"
+	BySelectorsDescription = "You can create a reference to a shared service instance without providing its ID. Use instead various attributes, such as plan, instance name, or labels to find a matching shared instance to which to create the reference."
 
 	ReferenceInstanceNameSelectorKey         = "instance_name_selector"
 	ReferenceInstanceNameSelectorTitle       = "Instance Name"
-	ReferenceInstanceNameSelectorDescription = "Specify the instance name of the shared instance to which you want to create a reference."
+	ReferenceInstanceNameSelectorDescription = "Specify the instance name of the shared instance to which you want to create the reference."
 
 	ReferencePlanNameSelectorKey         = "plan_name_selector"
 	ReferencePlanNameSelectorTitle       = "Plan Name"
-	ReferencePlanNameSelectorDescription = "Specify the plan name of the shared instance to which you want to create a reference."
+	ReferencePlanNameSelectorDescription = "Specify the plan name of the shared instance to which you want to create the reference."
 
 	ReferenceLabelSelectorKey         = "instance_label_selector"
-	ReferenceLabelSelectorTitle       = "Label"
-	ReferenceLabelSelectorDescription = "Specify the labels to find the shared instance to which you want to create a reference. For example: “origin eq ‘eu’” returns an instance whose origin is in the EU. You can add multiple label queries to a single search."
+	ReferenceLabelSelectorTitle       = "Labels"
+	ReferenceLabelSelectorDescription = "Use label query to find the shared instance to which you want to create the reference. For example: “origin eq ‘eu’” returns an instance whose origin is in the EU. You can add multiple label queries to a single search."
 )

--- a/pkg/instance_sharing/types.go
+++ b/pkg/instance_sharing/types.go
@@ -15,14 +15,14 @@ const (
 	BySelectorsDescription = "Find the instance to which you want to create a reference by using various search attributes, such as instance name, plan name, or labels."
 
 	ReferenceInstanceNameSelectorKey         = "instance_name_selector"
-	ReferenceInstanceNameSelectorTitle       = "Find by Instance Name"
+	ReferenceInstanceNameSelectorTitle       = "Instance Name"
 	ReferenceInstanceNameSelectorDescription = "Specify the instance name of the shared instance to which you want to create a reference."
 
 	ReferencePlanNameSelectorKey         = "plan_name_selector"
-	ReferencePlanNameSelectorTitle       = "Find by Plan Name"
+	ReferencePlanNameSelectorTitle       = "Plan Name"
 	ReferencePlanNameSelectorDescription = "Specify the plan name of the shared instance to which you want to create a reference."
 
 	ReferenceLabelSelectorKey         = "instance_label_selector"
-	ReferenceLabelSelectorTitle       = "Find by Label Query"
-	ReferenceLabelSelectorDescription = "You can use the labels query to find the shared instance to which you want to create a reference. For example: \\\"origin\\\": [\\\"eu\\\"] returns an instance whose origin is in the EU."
+	ReferenceLabelSelectorTitle       = "Label"
+	ReferenceLabelSelectorDescription = "Specify the labels to find the shared instance to which you want to create a reference. For example: “origin eq ‘eu’” returns an instance whose origin is in the EU. You can add multiple label queries to a single search."
 )

--- a/pkg/instance_sharing/types.go
+++ b/pkg/instance_sharing/types.go
@@ -7,12 +7,12 @@ const (
 	SupportsInstanceSharingKey = "supportsInstanceSharing"
 
 	ReferencedInstanceIDKey         = "referenced_instance_id"
-	ReferencedInstanceIDTitle       = "Referenced Instance ID"
+	ReferencedInstanceIDTitle       = "Shared Instance ID "
 	ReferencedInstanceIDDescription = "Specify the ID of the instance to which you want to create a reference."
 
 	SelectorsKey           = "selectors"
-	BySelectorsTitle       = "Attributes"
-	BySelectorsDescription = "Find the instance to which you want to create a reference by using various search attributes, such as instance name, plan name, or labels."
+	BySelectorsTitle       = "Shared Instance Attributes "
+	BySelectorsDescription = "Find the shared instance to which you want to create a reference by specifying its various attributes, such as instance name, plan name, or labels."
 
 	ReferenceInstanceNameSelectorKey         = "instance_name_selector"
 	ReferenceInstanceNameSelectorTitle       = "Instance Name"

--- a/pkg/instance_sharing/types.go
+++ b/pkg/instance_sharing/types.go
@@ -10,6 +10,10 @@ const (
 	ReferencedInstanceIDTitle       = "Reference Instance ID"
 	ReferencedInstanceIDDescription = "Specify the ID of the instance to which you want to create a reference."
 
+	BySelectorsKey         = "referenced_instance_id"
+	BySelectorsTitle       = "Reference Instance ID"
+	BySelectorsDescription = "Specify the ID of the instance to which you want to create a reference."
+
 	ReferenceInstanceNameSelectorKey         = "instance_name_selector"
 	ReferenceInstanceNameSelectorTitle       = "Find by Instance Name"
 	ReferenceInstanceNameSelectorDescription = "You can use the instance name to find the shared instance to which you want to create a reference."
@@ -18,5 +22,7 @@ const (
 	ReferencePlanNameSelectorTitle       = "Find by Plan Name"
 	ReferencePlanNameSelectorDescription = "You can use the plan name to find the shared instance to which you want to create a reference."
 
-	ReferenceLabelSelectorKey = "instance_labels_selector"
+	ReferenceLabelSelectorKey         = "instance_labels_selector"
+	ReferenceLabelSelectorTitle       = "instance_labels_selector"
+	ReferenceLabelSelectorDescription = "instance_labels_selector"
 )

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -230,7 +230,6 @@ var (
 	ErrReferencedInstanceNotShared               = errors.New("referenced-instance should be shared first")
 	ErrReferencedInstanceNotFound                = errors.New("referenced-instance not found")
 	ErrMultipleReferenceSelectorResults          = errors.New("multiple selector results")
-	ErrInvalidReferenceSelectors                 = errors.New("invalid selectors")
 	ErrNoResultsForReferenceSelector             = errors.New("no results for reference selector")
 	ErrReferenceWithWrongServiceOffering         = errors.New("referenced-instance not matches the service offering")
 	ErrChangingPlanOfReferenceInstance           = errors.New("changing plan of reference instance")
@@ -289,12 +288,6 @@ func HandleInstanceSharingError(err error, entityName string) error {
 			ErrorType:   "BadRequest",
 			Description: "Failed to create the instance. There are multiple shared instances that match your criteria. Refine your search criteria or specify the instance ID.",
 			StatusCode:  http.StatusNotFound,
-		}
-	case ErrInvalidReferenceSelectors:
-		return &HTTPError{
-			ErrorType:   "BadRequest",
-			Description: "Failed to create the instance. Your search parameters are invalid.",
-			StatusCode:  http.StatusBadRequest,
 		}
 	case ErrNoResultsForReferenceSelector:
 		return &HTTPError{

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -286,13 +286,13 @@ func HandleInstanceSharingError(err error, entityName string) error {
 	case ErrMultipleReferenceSelectorResults:
 		return &HTTPError{
 			ErrorType:   "BadRequest",
-			Description: "Failed to create the instance. There are multiple shared instances that match your criteria. Refine your search criteria or specify the instance ID.",
+			Description: "Failed to create the instance. There are multiple shared instances that match your criteria. Refine your search criteria or specify the shared instance ID.",
 			StatusCode:  http.StatusNotFound,
 		}
 	case ErrNoResultsForReferenceSelector:
 		return &HTTPError{
 			ErrorType:   "NotFound",
-			Description: "Failed to create the instance. Could not find a shared instance that matches your criteria. Refine your search criteria or specify the instance ID.",
+			Description: "Failed to create the instance. Could not find a shared instance that matches your criteria. Refine your search criteria or specify the shared instance ID.",
 			StatusCode:  http.StatusNotFound,
 		}
 	case ErrChangingPlanOfReferenceInstance:

--- a/schemas/predefined_plans.go
+++ b/schemas/predefined_plans.go
@@ -30,7 +30,10 @@ func BuildReferencePlanSchema() string {
           "type": "object",
           "additionalProperties": false,
           "_show_form_view": true,
-		  "_controlsOrder": ["%[3]s", "%[6]s", "%[9]s"],
+          "_controlsOrder": [
+            "%[3]s",
+            "%[6]s"
+          ],
           "properties": {
             "%[3]s": {
               "title": "%[4]s",
@@ -42,18 +45,49 @@ func BuildReferencePlanSchema() string {
             "%[6]s": {
               "title": "%[7]s",
               "description": "%[8]s",
-              "type": "string",
-              "minLength": 0,
-              "maxLength": 100
-            },
-            "%[9]s": {
-              "title": "%[10]s",
-              "description": "%[11]s",
-              "type": "string",
-              "minLength": 0,
-              "maxLength": 100
+              "type": "object",
+              "_controlsOrder": [
+                "%[9]s",
+                "%[12]s",
+                "%[15]s"
+              ],
+              "properties": {
+                "%[9]s": {
+                  "title": "%[10]s",
+                  "description": "%[11]s",
+                  "type": "string",
+                  "minLength": 0,
+                  "maxLength": 100
+                },
+                "%[12]s": {
+                  "title": "%[13]s",
+                  "description": "%[14]s",
+                  "type": "string",
+                  "minLength": 0,
+                  "maxLength": 100
+                },
+                "%[15]s": {
+                  "title": "%[16]s",
+                  "description": "%[17]s",
+                  "type": "array",
+                  "minItems": 0,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
             }
           }
+        }
+      },
+      "update": {
+        "parameters": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "type": "object",
+          "_show_form_view": false,
+          "_controlsOrder": [],
+          "additionalProperties": false,
+          "properties": {}
         }
       }
     }
@@ -64,12 +98,18 @@ func BuildReferencePlanSchema() string {
 		instance_sharing.ReferencedInstanceIDKey,                  // 3
 		instance_sharing.ReferencedInstanceIDTitle,                // 4
 		instance_sharing.ReferencedInstanceIDDescription,          // 5
-		instance_sharing.ReferenceInstanceNameSelectorKey,         // 6
-		instance_sharing.ReferenceInstanceNameSelectorTitle,       // 7
-		instance_sharing.ReferenceInstanceNameSelectorDescription, // 8
-		instance_sharing.ReferencePlanNameSelectorKey,             // 9
-		instance_sharing.ReferencePlanNameSelectorTitle,           // 10
-		instance_sharing.ReferencePlanNameSelectorDescription,     // 11
+		instance_sharing.BySelectorsKey,                           // 6
+		instance_sharing.BySelectorsTitle,                         // 7
+		instance_sharing.BySelectorsDescription,                   // 8
+		instance_sharing.ReferenceInstanceNameSelectorKey,         // 9
+		instance_sharing.ReferenceInstanceNameSelectorTitle,       // 10
+		instance_sharing.ReferenceInstanceNameSelectorDescription, // 11
+		instance_sharing.ReferencePlanNameSelectorKey,             // 12
+		instance_sharing.ReferencePlanNameSelectorTitle,           // 13
+		instance_sharing.ReferencePlanNameSelectorDescription,     // 14
+		instance_sharing.ReferenceLabelSelectorKey,                // 15
+		instance_sharing.ReferenceLabelSelectorTitle,              // 16
+		instance_sharing.ReferenceLabelSelectorDescription,        // 17
 	)
 }
 

--- a/schemas/predefined_plans.go
+++ b/schemas/predefined_plans.go
@@ -98,7 +98,7 @@ func BuildReferencePlanSchema() string {
 		instance_sharing.ReferencedInstanceIDKey,                  // 3
 		instance_sharing.ReferencedInstanceIDTitle,                // 4
 		instance_sharing.ReferencedInstanceIDDescription,          // 5
-		instance_sharing.BySelectorsKey,                           // 6
+		instance_sharing.SelectorsKey,                             // 6
 		instance_sharing.BySelectorsTitle,                         // 7
 		instance_sharing.BySelectorsDescription,                   // 8
 		instance_sharing.ReferenceInstanceNameSelectorKey,         // 9

--- a/test/common/service_instance_sharing.go
+++ b/test/common/service_instance_sharing.go
@@ -78,13 +78,22 @@ func GetPlanByKey(ctx *TestContext, key, value string) *types.ServicePlan {
 
 func CreateReferenceInstance(smExpect *SMExpect, async string, expectedStatusCode int, selectorKey, selectorValue, referencePlanID string) *httpexpect.Response {
 	ID, _ := uuid.NewV4()
+
+	// set parameters:
+	parameters := map[string]interface{}{}
+	if selectorKey == instance_sharing.ReferencedInstanceIDKey {
+		parameters[selectorKey] = selectorValue
+	} else {
+		parameters[instance_sharing.SelectorsKey] = map[string]interface{}{
+			selectorKey: selectorValue,
+		}
+	}
+
 	requestBody := Object{
 		"name":             "reference-instance-" + ID.String(),
 		"service_plan_id":  referencePlanID,
 		"maintenance_info": "{}",
-		"parameters": map[string]string{
-			selectorKey: selectorValue,
-		},
+		"parameters":       parameters,
 	}
 	resp := smExpect.POST(web.ServiceInstancesURL).
 		WithQuery("async", async).

--- a/test/osb_and_plugin_test/osb_test/instance_sharing_test.go
+++ b/test/osb_and_plugin_test/osb_test/instance_sharing_test.go
@@ -223,7 +223,7 @@ var _ = Describe("Instance Sharing", func() {
 
 			})
 		})
-		FContext("provision with selectors", func() {
+		Context("provision with selectors", func() {
 			var resp *httpexpect.Response
 			var sharedInstanceID, referenceInstanceID string
 			BeforeEach(func() {

--- a/test/osb_and_plugin_test/osb_test/instance_sharing_test.go
+++ b/test/osb_and_plugin_test/osb_test/instance_sharing_test.go
@@ -223,7 +223,7 @@ var _ = Describe("Instance Sharing", func() {
 
 			})
 		})
-		Context("provision with selectors", func() {
+		FContext("provision with selectors", func() {
 			var resp *httpexpect.Response
 			var sharedInstanceID, referenceInstanceID string
 			BeforeEach(func() {
@@ -273,7 +273,8 @@ var _ = Describe("Instance Sharing", func() {
 				resp, referenceInstanceID = createReferenceInstance(platform.ID, instance_sharing.ReferencedInstanceIDKey, "*", false)
 			})
 			It("succeeds with label selector", func() {
-				labelSelector := Object{TenantIdentifier: Array{TenantValue}}
+				query := fmt.Sprintf("%s eq '%s'", TenantIdentifier, TenantValue)
+				labelSelector := Array{query}
 				resp, referenceInstanceID = createReferenceInstance(platform.ID, instance_sharing.ReferenceLabelSelectorKey, labelSelector, false)
 			})
 			It("succeeds with combination of selectors", func() {

--- a/test/osb_and_plugin_test/osb_test/instance_sharing_test.go
+++ b/test/osb_and_plugin_test/osb_test/instance_sharing_test.go
@@ -291,8 +291,10 @@ var _ = Describe("Instance Sharing", func() {
 				referenceProvisionBody := buildReferenceProvisionBody(referencePlan.CatalogID, platform.ID)
 				referenceProvisionBody["parameters"] = Object{
 					TenantIdentifier: Array{TenantValue},
-					instance_sharing.ReferenceInstanceNameSelectorKey: sharedInstance.Name,
-					instance_sharing.ReferencePlanNameSelectorKey:     shareablePlan.CatalogName,
+					instance_sharing.SelectorsKey: map[string]interface{}{
+						instance_sharing.ReferenceInstanceNameSelectorKey: sharedInstance.Name,
+						instance_sharing.ReferencePlanNameSelectorKey:     shareablePlan.CatalogName,
+					},
 				}
 				utils.SetAuthContext(ctx.SMWithOAuth).AddPlanVisibilityForPlatform(referencePlan.CatalogID, platform.ID, organizationGUID)
 				resp = ctx.SMWithBasic.PUT(instanceSharingBrokerPath+"/v2/service_instances/"+instanceID).
@@ -346,8 +348,10 @@ var _ = Describe("Instance Sharing", func() {
 					referenceProvisionBody := buildReferenceProvisionBody(referencePlan.CatalogID, platform.ID)
 					referenceProvisionBody["parameters"] = Object{
 						TenantIdentifier: Array{TenantValue},
-						instance_sharing.ReferenceInstanceNameSelectorKey: sharedInstance.Name,
-						instance_sharing.ReferencePlanNameSelectorKey:     shareablePlan.CatalogName,
+						instance_sharing.SelectorsKey: map[string]interface{}{
+							instance_sharing.ReferenceInstanceNameSelectorKey: sharedInstance.Name,
+							instance_sharing.ReferencePlanNameSelectorKey:     shareablePlan.CatalogName,
+						},
 					}
 					utils.SetAuthContext(ctx.SMWithOAuth).AddPlanVisibilityForPlatform(referencePlan.CatalogID, platform.ID, organizationGUID)
 					resp = ctx.SMWithBasic.PUT(instanceSharingBrokerPath+"/v2/service_instances/"+instanceID).
@@ -908,7 +912,15 @@ func createReferenceInstance(platformID, selectorKey string, selectorValue inter
 
 	referencePlan := GetReferencePlanOfExistingPlan(ctx, "catalog_id", shareablePlanCatalogID)
 	referenceProvisionBody := buildReferenceProvisionBody(referencePlan.CatalogID, platformID)
-	referenceProvisionBody["parameters"] = Object{selectorKey: selectorValue}
+	if selectorKey == instance_sharing.ReferencedInstanceIDKey {
+		referenceProvisionBody["parameters"] = Object{selectorKey: selectorValue}
+	} else {
+		referenceProvisionBody["parameters"] = Object{
+			instance_sharing.SelectorsKey: map[string]interface{}{
+				selectorKey: selectorValue,
+			},
+		}
+	}
 	utils.SetAuthContext(ctx.SMWithOAuth).AddPlanVisibilityForPlatform(referencePlan.CatalogID, platformID, organizationGUID)
 	resp := ctx.SMWithBasic.PUT(instanceSharingBrokerPath+"/v2/service_instances/"+instanceID).
 		WithQuery(acceptsIncompleteKey, accepts_incomplete).

--- a/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
@@ -3973,7 +3973,7 @@ var _ = DescribeTestsFor(TestCase{
 								resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrRequestBodyContainsReferencedInstanceID, instance_sharing.ReferencedInstanceIDKey))
 							})
 						})
-						FContext("provision with selectors", func() {
+						Context("provision with selectors", func() {
 							var sharedInstance *types.ServiceInstance
 							BeforeEach(func() {
 								sharedInstance, _ = GetInstanceObjectByID(ctx, sharedInstanceID)

--- a/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
@@ -4159,133 +4159,137 @@ var _ = DescribeTestsFor(TestCase{
 									})
 								})
 								Context("label selector", func() {
-									It("succeeds to provision by label selector if the instance contains the selector labels", func() {
-										randomUUID, _ := uuid.NewV4()
-										requestBody := Object{
-											"name":             "reference-instance-" + randomUUID.String(),
-											"service_plan_id":  referencePlan.ID,
-											"maintenance_info": "{}",
-											"parameters": map[string]interface{}{
-												instance_sharing.SelectorsKey: map[string]interface{}{
-													instance_sharing.ReferenceLabelSelectorKey: Array{
-														"origin eq '1'",
-														fmt.Sprintf("%s eq '%s'", TenantIdentifier, TenantIDValue),
+									Context("positive", func() {
+										It("succeeds to provision by label selector if the instance contains the selector labels", func() {
+											randomUUID, _ := uuid.NewV4()
+											requestBody := Object{
+												"name":             "reference-instance-" + randomUUID.String(),
+												"service_plan_id":  referencePlan.ID,
+												"maintenance_info": "{}",
+												"parameters": map[string]interface{}{
+													instance_sharing.SelectorsKey: map[string]interface{}{
+														instance_sharing.ReferenceLabelSelectorKey: Array{
+															"origin eq '1'",
+															fmt.Sprintf("%s eq '%s'", TenantIdentifier, TenantIDValue),
+														},
 													},
 												},
-											},
-										}
-										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
-											WithQuery("async", false).
-											WithJSON(requestBody).
-											Expect().
-											Status(http.StatusCreated)
+											}
+											resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
+												WithQuery("async", false).
+												WithJSON(requestBody).
+												Expect().
+												Status(http.StatusCreated)
+										})
+										It("succeeds to provision by label selector if the instance has a match with the selector label", func() {
+											randomUUID, _ := uuid.NewV4()
+											requestBody := Object{
+												"name":             "reference-instance-" + randomUUID.String(),
+												"service_plan_id":  referencePlan.ID,
+												"maintenance_info": "{}",
+												"parameters": map[string]interface{}{
+													instance_sharing.SelectorsKey: map[string]interface{}{
+														instance_sharing.ReferenceLabelSelectorKey: Array{
+															"origin eq 'eu'",
+															"origin eq '1'",
+														},
+													},
+												},
+											}
+											resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
+												WithQuery("async", false).
+												WithJSON(requestBody).
+												Expect().
+												Status(http.StatusCreated)
+										})
 									})
-									It("succeeds to provision by label selector if the instance has a match with the selector label", func() {
-										randomUUID, _ := uuid.NewV4()
-										requestBody := Object{
-											"name":             "reference-instance-" + randomUUID.String(),
-											"service_plan_id":  referencePlan.ID,
-											"maintenance_info": "{}",
-											"parameters": map[string]interface{}{
-												instance_sharing.SelectorsKey: map[string]interface{}{
-													instance_sharing.ReferenceLabelSelectorKey: Array{
-														"origin eq 'eu'",
-														"origin eq '1'",
+									Context("negative", func() {
+										It("fails to provision by label selector due to multiple results using the 'in' operator", func() {
+											expectToSucceed = false
+											randomUUID, _ := uuid.NewV4()
+											requestBody := Object{
+												"name":             "reference-instance-" + randomUUID.String(),
+												"service_plan_id":  referencePlan.ID,
+												"maintenance_info": "{}",
+												"parameters": map[string]interface{}{
+													instance_sharing.SelectorsKey: map[string]interface{}{
+														instance_sharing.ReferenceLabelSelectorKey: Array{
+															"origin in ('eu', '1')",
+														},
 													},
 												},
-											},
-										}
-										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
-											WithQuery("async", false).
-											WithJSON(requestBody).
-											Expect().
-											Status(http.StatusCreated)
-									})
-									It("fails to provision by label selector due to multiple results using the 'in' operator", func() {
-										expectToSucceed = false
-										randomUUID, _ := uuid.NewV4()
-										requestBody := Object{
-											"name":             "reference-instance-" + randomUUID.String(),
-											"service_plan_id":  referencePlan.ID,
-											"maintenance_info": "{}",
-											"parameters": map[string]interface{}{
-												instance_sharing.SelectorsKey: map[string]interface{}{
-													instance_sharing.ReferenceLabelSelectorKey: Array{
-														"origin in ('eu', '1')",
+											}
+											resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
+												WithQuery("async", false).
+												WithJSON(requestBody).
+												Expect().
+												Status(http.StatusNotFound)
+										})
+										It("fails to provision by label selector due to an invalid operator", func() {
+											expectToSucceed = false
+											randomUUID, _ := uuid.NewV4()
+											requestBody := Object{
+												"name":             "reference-instance-" + randomUUID.String(),
+												"service_plan_id":  referencePlan.ID,
+												"maintenance_info": "{}",
+												"parameters": map[string]interface{}{
+													instance_sharing.SelectorsKey: map[string]interface{}{
+														instance_sharing.ReferenceLabelSelectorKey: Array{
+															"origin bla ('eu', '1')",
+														},
 													},
 												},
-											},
-										}
-										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
-											WithQuery("async", false).
-											WithJSON(requestBody).
-											Expect().
-											Status(http.StatusNotFound)
-									})
-									It("fails to provision by label selector due to an invalid operator", func() {
-										expectToSucceed = false
-										randomUUID, _ := uuid.NewV4()
-										requestBody := Object{
-											"name":             "reference-instance-" + randomUUID.String(),
-											"service_plan_id":  referencePlan.ID,
-											"maintenance_info": "{}",
-											"parameters": map[string]interface{}{
-												instance_sharing.SelectorsKey: map[string]interface{}{
-													instance_sharing.ReferenceLabelSelectorKey: Array{
-														"origin bla ('eu', '1')",
+											}
+											resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
+												WithQuery("async", false).
+												WithJSON(requestBody).
+												Expect().
+												Status(http.StatusBadRequest)
+										})
+										It("fails to provision by label selector due to invalid input type", func() {
+											expectToSucceed = false
+											randomUUID, _ := uuid.NewV4()
+											requestBody := Object{
+												"name":             "reference-instance-" + randomUUID.String(),
+												"service_plan_id":  referencePlan.ID,
+												"maintenance_info": "{}",
+												"parameters": map[string]interface{}{
+													instance_sharing.SelectorsKey: map[string]map[string][]string{
+														instance_sharing.ReferenceLabelSelectorKey: {
+															"origin": {"eu", "1"},
+														},
 													},
 												},
-											},
-										}
-										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
-											WithQuery("async", false).
-											WithJSON(requestBody).
-											Expect().
-											Status(http.StatusBadRequest)
-									})
-									It("fails to provision by label selector due to invalid input type", func() {
-										expectToSucceed = false
-										randomUUID, _ := uuid.NewV4()
-										requestBody := Object{
-											"name":             "reference-instance-" + randomUUID.String(),
-											"service_plan_id":  referencePlan.ID,
-											"maintenance_info": "{}",
-											"parameters": map[string]interface{}{
-												instance_sharing.SelectorsKey: map[string]map[string][]string{
-													instance_sharing.ReferenceLabelSelectorKey: {
-														"origin": {"eu", "1"},
+											}
+											resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
+												WithQuery("async", false).
+												WithJSON(requestBody).
+												Expect().
+												Status(http.StatusBadRequest)
+										})
+										It("fails to provision if one of label value does not match", func() {
+											expectToSucceed = false
+											randomUUID, _ := uuid.NewV4()
+											requestBody := Object{
+												"name":             "reference-instance-" + randomUUID.String(),
+												"service_plan_id":  referencePlan.ID,
+												"maintenance_info": "{}",
+												"parameters": map[string]interface{}{
+													instance_sharing.SelectorsKey: map[string]interface{}{
+														instance_sharing.ReferenceLabelSelectorKey: Array{
+															fmt.Sprintf("%s eq '%s'", TenantIdentifier, TenantIDValue),
+															"origin eq '11'",
+														},
 													},
 												},
-											},
-										}
-										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
-											WithQuery("async", false).
-											WithJSON(requestBody).
-											Expect().
-											Status(http.StatusBadRequest)
-									})
-									It("fails to provision if one of label value does not match", func() {
-										expectToSucceed = false
-										randomUUID, _ := uuid.NewV4()
-										requestBody := Object{
-											"name":             "reference-instance-" + randomUUID.String(),
-											"service_plan_id":  referencePlan.ID,
-											"maintenance_info": "{}",
-											"parameters": map[string]interface{}{
-												instance_sharing.SelectorsKey: map[string]interface{}{
-													instance_sharing.ReferenceLabelSelectorKey: Array{
-														fmt.Sprintf("%s eq '%s'", TenantIdentifier, TenantIDValue),
-														"origin eq '11'",
-													},
-												},
-											},
-										}
-										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
-											WithQuery("async", false).
-											WithJSON(requestBody).
-											Expect().
-											Status(http.StatusNotFound)
-										resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrNoResultsForReferenceSelector, ""))
+											}
+											resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
+												WithQuery("async", false).
+												WithJSON(requestBody).
+												Expect().
+												Status(http.StatusNotFound)
+											resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrNoResultsForReferenceSelector, ""))
+										})
 									})
 								})
 							})

--- a/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
@@ -4222,9 +4222,27 @@ var _ = DescribeTestsFor(TestCase{
 												Expect().
 												Status(http.StatusCreated)
 										})
+										It("succeeds to provision by label selector with label selector as string", func() {
+											randomUUID, _ := uuid.NewV4()
+											requestBody := Object{
+												"name":             "reference-instance-" + randomUUID.String(),
+												"service_plan_id":  referencePlan.ID,
+												"maintenance_info": "{}",
+												"parameters": map[string]interface{}{
+													instance_sharing.SelectorsKey: map[string]interface{}{
+														instance_sharing.ReferenceLabelSelectorKey: "origin eq '1'",
+													},
+												},
+											}
+											resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
+												WithQuery("async", false).
+												WithJSON(requestBody).
+												Expect().
+												Status(http.StatusCreated)
+										})
 									})
 									Context("negative", func() {
-										It("fails to provision by label selector due to multiple results using the 'in' operator", func() {
+										It("fails to provision due to multiple results using the 'in' operator", func() {
 											expectToSucceed = false
 											randomUUID, _ := uuid.NewV4()
 											requestBody := Object{
@@ -4245,7 +4263,7 @@ var _ = DescribeTestsFor(TestCase{
 												Expect().
 												Status(http.StatusNotFound)
 										})
-										It("fails to provision by label selector due to an invalid operator", func() {
+										It("fails to provision due to an invalid operator", func() {
 											expectToSucceed = false
 											randomUUID, _ := uuid.NewV4()
 											requestBody := Object{
@@ -4266,7 +4284,7 @@ var _ = DescribeTestsFor(TestCase{
 												Expect().
 												Status(http.StatusBadRequest)
 										})
-										It("fails to provision by label selector due to invalid input type", func() {
+										It("fails to provision due to invalid input type", func() {
 											expectToSucceed = false
 											randomUUID, _ := uuid.NewV4()
 											requestBody := Object{

--- a/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
+++ b/test/service_instance_and_binding_test/service_instance_test/service_instance_test.go
@@ -4058,8 +4058,10 @@ var _ = DescribeTestsFor(TestCase{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters": map[string]string{
-												instance_sharing.ReferencePlanNameSelectorKey: sharedPlan.Name,
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]string{
+													instance_sharing.ReferencePlanNameSelectorKey: sharedPlan.Name,
+												},
 											},
 										}
 										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
@@ -4074,8 +4076,10 @@ var _ = DescribeTestsFor(TestCase{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters": map[string]string{
-												instance_sharing.ReferenceInstanceNameSelectorKey: sharedInstance.Name,
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]string{
+													instance_sharing.ReferenceInstanceNameSelectorKey: sharedInstance.Name,
+												},
 											},
 										}
 										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
@@ -4087,17 +4091,18 @@ var _ = DescribeTestsFor(TestCase{
 									It("succeeds to provision by instance name selector with other empty selectors", func() {
 										randomUUID, _ := uuid.NewV4()
 
-										parameters := make(map[string]interface{})
-										parameters[instance_sharing.ReferenceInstanceNameSelectorKey] = sharedInstance.Name
-										parameters[instance_sharing.ReferencePlanNameSelectorKey] = ""
-										parameters[instance_sharing.ReferencedInstanceIDKey] = ""
-										parameters[instance_sharing.ReferenceLabelSelectorKey] = Object{}
-
 										requestBody := Object{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters":       parameters,
+											"parameters": map[string]interface{}{
+												instance_sharing.ReferencedInstanceIDKey: "",
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceInstanceNameSelectorKey: sharedInstance.Name,
+													instance_sharing.ReferencePlanNameSelectorKey:     "",
+													instance_sharing.ReferenceLabelSelectorKey:        Array{},
+												},
+											},
 										}
 										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
 											WithQuery("async", false).
@@ -4105,21 +4110,22 @@ var _ = DescribeTestsFor(TestCase{
 											Expect().
 											Status(http.StatusCreated)
 									})
-									It("succeeds to provision by plan name selector with other empty selectors", func() {
+									It("succeeds to provision by plan name selector while the other selectors are empty", func() {
 										randomUUID, _ := uuid.NewV4()
 										sharedPlan := GetPlanByKey(ctx, "id", sharedInstance.ServicePlanID)
-
-										parameters := make(map[string]interface{})
-										parameters[instance_sharing.ReferenceInstanceNameSelectorKey] = ""
-										parameters[instance_sharing.ReferencePlanNameSelectorKey] = sharedPlan.Name
-										parameters[instance_sharing.ReferencedInstanceIDKey] = ""
-										parameters[instance_sharing.ReferenceLabelSelectorKey] = Object{}
 
 										requestBody := Object{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters":       parameters,
+											"parameters": map[string]interface{}{
+												instance_sharing.ReferencedInstanceIDKey: "",
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceInstanceNameSelectorKey: "",
+													instance_sharing.ReferencePlanNameSelectorKey:     sharedPlan.Name,
+													instance_sharing.ReferenceLabelSelectorKey:        Array{},
+												},
+											},
 										}
 										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
 											WithQuery("async", false).
@@ -4133,18 +4139,18 @@ var _ = DescribeTestsFor(TestCase{
 										randomUUID, _ := uuid.NewV4()
 										sharedPlan := GetPlanByKey(ctx, "id", sharedInstance.ServicePlanID)
 
-										parameters := make(map[string]interface{})
-										parameters[instance_sharing.ReferenceInstanceNameSelectorKey] = sharedInstance.Name
-										parameters[instance_sharing.ReferencePlanNameSelectorKey] = sharedPlan.Name
-										parameters[instance_sharing.ReferencedInstanceIDKey] = ""
-										parameters[instance_sharing.ReferenceLabelSelectorKey] = Object{}
-
 										requestBody := Object{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters":       parameters,
-										}
+											"parameters": map[string]interface{}{
+												instance_sharing.ReferencedInstanceIDKey: "",
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceInstanceNameSelectorKey: sharedInstance.Name,
+													instance_sharing.ReferencePlanNameSelectorKey:     sharedPlan.Name,
+													instance_sharing.ReferenceLabelSelectorKey:        Array{},
+												},
+											}}
 										resp = ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
 											WithQuery("async", false).
 											WithJSON(requestBody).
@@ -4159,10 +4165,12 @@ var _ = DescribeTestsFor(TestCase{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters": map[string]Array{
-												instance_sharing.ReferenceLabelSelectorKey: {
-													"origin eq '1'",
-													fmt.Sprintf("%s eq '%s'", TenantIdentifier, TenantIDValue),
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceLabelSelectorKey: Array{
+														"origin eq '1'",
+														fmt.Sprintf("%s eq '%s'", TenantIdentifier, TenantIDValue),
+													},
 												},
 											},
 										}
@@ -4178,10 +4186,12 @@ var _ = DescribeTestsFor(TestCase{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters": map[string]Array{
-												instance_sharing.ReferenceLabelSelectorKey: {
-													"origin eq 'eu'",
-													"origin eq '1'",
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceLabelSelectorKey: Array{
+														"origin eq 'eu'",
+														"origin eq '1'",
+													},
 												},
 											},
 										}
@@ -4198,9 +4208,11 @@ var _ = DescribeTestsFor(TestCase{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters": map[string]Array{
-												instance_sharing.ReferenceLabelSelectorKey: {
-													"origin in ('eu', '1')",
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceLabelSelectorKey: Array{
+														"origin in ('eu', '1')",
+													},
 												},
 											},
 										}
@@ -4217,9 +4229,11 @@ var _ = DescribeTestsFor(TestCase{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters": map[string]Array{
-												instance_sharing.ReferenceLabelSelectorKey: {
-													"origin bla ('eu', '1')",
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceLabelSelectorKey: Array{
+														"origin bla ('eu', '1')",
+													},
 												},
 											},
 										}
@@ -4236,9 +4250,11 @@ var _ = DescribeTestsFor(TestCase{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters": map[string]map[string][]string{
-												instance_sharing.ReferenceLabelSelectorKey: {
-													"origin": {"eu", "1"},
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]map[string][]string{
+													instance_sharing.ReferenceLabelSelectorKey: {
+														"origin": {"eu", "1"},
+													},
 												},
 											},
 										}
@@ -4255,10 +4271,12 @@ var _ = DescribeTestsFor(TestCase{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters": map[string]Array{
-												instance_sharing.ReferenceLabelSelectorKey: {
-													fmt.Sprintf("%s eq '%s'", TenantIdentifier, TenantIDValue),
-													"origin eq '11'",
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceLabelSelectorKey: Array{
+														fmt.Sprintf("%s eq '%s'", TenantIdentifier, TenantIDValue),
+														"origin eq '11'",
+													},
 												},
 											},
 										}
@@ -4304,10 +4322,12 @@ var _ = DescribeTestsFor(TestCase{
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
 											"parameters": map[string]interface{}{
-												instance_sharing.ReferenceLabelSelectorKey: Array{
-													fmt.Sprintf("%s eq '%s'", TenantIdentifier, randomUUID.String()),
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceLabelSelectorKey: Array{
+														fmt.Sprintf("%s eq '%s'", TenantIdentifier, randomUUID.String()),
+													},
+													"some-selector": Object{},
 												},
-												"some-selector": Object{},
 											},
 										}
 										resp := ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
@@ -4320,17 +4340,18 @@ var _ = DescribeTestsFor(TestCase{
 									It("fails to provision due to empty selectors values", func() {
 										randomUUID, _ := uuid.NewV4()
 
-										parameters := make(map[string]interface{})
-										parameters[instance_sharing.ReferencedInstanceIDKey] = ""
-										parameters[instance_sharing.ReferenceInstanceNameSelectorKey] = ""
-										parameters[instance_sharing.ReferencePlanNameSelectorKey] = ""
-										parameters[instance_sharing.ReferenceLabelSelectorKey] = Object{}
-
 										requestBody := Object{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters":       parameters,
+											"parameters": map[string]interface{}{
+												instance_sharing.ReferencedInstanceIDKey: "",
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceInstanceNameSelectorKey: "",
+													instance_sharing.ReferencePlanNameSelectorKey:     "",
+													instance_sharing.ReferenceLabelSelectorKey:        Array{},
+												},
+											},
 										}
 
 										resp := ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
@@ -4338,14 +4359,16 @@ var _ = DescribeTestsFor(TestCase{
 											WithJSON(requestBody).
 											Expect().
 											Status(http.StatusBadRequest)
-										resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrInvalidReferenceSelectors, ""))
+										resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrMissingOrInvalidReferenceParameter, ""))
 									})
 									It("fails to provision due to invalid label input type (empty string)", func() {
 										parameters := make(map[string]interface{})
 										parameters[instance_sharing.ReferencedInstanceIDKey] = ""
-										parameters[instance_sharing.ReferenceInstanceNameSelectorKey] = ""
-										parameters[instance_sharing.ReferencePlanNameSelectorKey] = ""
-										parameters[instance_sharing.ReferenceLabelSelectorKey] = ""
+										parameters[instance_sharing.SelectorsKey] = map[string]interface{}{
+											instance_sharing.ReferenceInstanceNameSelectorKey: "",
+											instance_sharing.ReferencePlanNameSelectorKey:     "",
+											instance_sharing.ReferenceLabelSelectorKey:        "",
+										}
 										requestBody["parameters"] = parameters
 
 										resp := ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
@@ -4353,14 +4376,16 @@ var _ = DescribeTestsFor(TestCase{
 											WithJSON(requestBody).
 											Expect().
 											Status(http.StatusBadRequest)
-										resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrInvalidReferenceSelectors, ""))
+										resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrMissingOrInvalidReferenceParameter, ""))
 									})
 									It("fails to provision due to empty result (labelQuery as string instead of array)", func() {
 										parameters := make(map[string]interface{})
 										parameters[instance_sharing.ReferencedInstanceIDKey] = ""
-										parameters[instance_sharing.ReferenceInstanceNameSelectorKey] = ""
-										parameters[instance_sharing.ReferencePlanNameSelectorKey] = ""
-										parameters[instance_sharing.ReferenceLabelSelectorKey] = "origin eq 'eu'"
+										parameters[instance_sharing.SelectorsKey] = map[string]interface{}{
+											instance_sharing.ReferenceInstanceNameSelectorKey: "",
+											instance_sharing.ReferencePlanNameSelectorKey:     "",
+											instance_sharing.ReferenceLabelSelectorKey:        "origin eq 'eu'",
+										}
 										requestBody["parameters"] = parameters
 
 										resp := ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
@@ -4370,12 +4395,15 @@ var _ = DescribeTestsFor(TestCase{
 											Status(http.StatusNotFound)
 										resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrNoResultsForReferenceSelector, ""))
 									})
-									It("fails to provision due to invalid id input type", func() {
+									It("fails to provision due to invalid id input type (instance id)", func() {
 										parameters := make(map[string]interface{})
 										parameters[instance_sharing.ReferencedInstanceIDKey] = Object{}
-										parameters[instance_sharing.ReferenceInstanceNameSelectorKey] = ""
-										parameters[instance_sharing.ReferencePlanNameSelectorKey] = ""
-										parameters[instance_sharing.ReferenceLabelSelectorKey] = ""
+										parameters[instance_sharing.SelectorsKey] = map[string]interface{}{
+											instance_sharing.ReferenceInstanceNameSelectorKey: "",
+											instance_sharing.ReferencePlanNameSelectorKey:     "",
+											instance_sharing.ReferenceLabelSelectorKey:        "",
+										}
+										requestBody["parameters"] = parameters
 
 										resp := ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
 											WithQuery("async", false).
@@ -4384,12 +4412,15 @@ var _ = DescribeTestsFor(TestCase{
 											Status(http.StatusBadRequest)
 										resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrMissingOrInvalidReferenceParameter, instance_sharing.ReferencedInstanceIDKey))
 									})
-									It("fails to provision due to invalid name input type", func() {
+									It("fails to provision due to invalid name input type (instance name)", func() {
 										parameters := make(map[string]interface{})
 										parameters[instance_sharing.ReferencedInstanceIDKey] = ""
-										parameters[instance_sharing.ReferenceInstanceNameSelectorKey] = Object{}
-										parameters[instance_sharing.ReferencePlanNameSelectorKey] = ""
-										parameters[instance_sharing.ReferenceLabelSelectorKey] = ""
+										parameters[instance_sharing.SelectorsKey] = map[string]interface{}{
+											instance_sharing.ReferenceInstanceNameSelectorKey: Object{},
+											instance_sharing.ReferencePlanNameSelectorKey:     "",
+											instance_sharing.ReferenceLabelSelectorKey:        "",
+										}
+										requestBody["parameters"] = parameters
 
 										resp := ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
 											WithQuery("async", false).
@@ -4397,6 +4428,23 @@ var _ = DescribeTestsFor(TestCase{
 											Expect().
 											Status(http.StatusBadRequest)
 										resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrMissingOrInvalidReferenceParameter, instance_sharing.ReferencedInstanceIDKey))
+									})
+									It("fails to provision due to a combination of instance id and selectors", func() {
+										parameters := make(map[string]interface{})
+										parameters[instance_sharing.ReferencedInstanceIDKey] = sharedInstanceID
+										parameters[instance_sharing.SelectorsKey] = map[string]interface{}{
+											instance_sharing.ReferenceInstanceNameSelectorKey: sharedInstance.Name,
+											instance_sharing.ReferencePlanNameSelectorKey:     "",
+											instance_sharing.ReferenceLabelSelectorKey:        "",
+										}
+										requestBody["parameters"] = parameters
+
+										resp := ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
+											WithQuery("async", false).
+											WithJSON(requestBody).
+											Expect().
+											Status(http.StatusBadRequest)
+										resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrInvalidReferenceSelectors, instance_sharing.ReferencedInstanceIDKey))
 									})
 								})
 								When("the selectors have more than one result", func() {
@@ -4429,8 +4477,10 @@ var _ = DescribeTestsFor(TestCase{
 											"name":             "reference-instance-" + ID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters": map[string]string{
-												instance_sharing.ReferencePlanNameSelectorKey: anotherSharedPlan.Name,
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferencePlanNameSelectorKey: anotherSharedPlan.Name,
+												},
 											},
 										}
 										resp := ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
@@ -4454,8 +4504,10 @@ var _ = DescribeTestsFor(TestCase{
 											"name":             "reference-instance-" + ID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters": map[string]string{
-												instance_sharing.ReferenceInstanceNameSelectorKey: anotherSharedInstance.Name,
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceInstanceNameSelectorKey: anotherSharedInstance.Name,
+												},
 											},
 										}
 										resp := ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
@@ -4480,8 +4532,10 @@ var _ = DescribeTestsFor(TestCase{
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
 											"parameters": map[string]interface{}{
-												instance_sharing.ReferenceLabelSelectorKey: Array{
-													fmt.Sprintf("%s eq '%s'", TenantIdentifier, TenantIDValue),
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceLabelSelectorKey: Array{
+														fmt.Sprintf("%s eq '%s'", TenantIdentifier, TenantIDValue),
+													},
 												},
 											},
 										}
@@ -4518,8 +4572,10 @@ var _ = DescribeTestsFor(TestCase{
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
 											"parameters": map[string]interface{}{
-												instance_sharing.ReferenceLabelSelectorKey: Array{
-													fmt.Sprintf("%s eq '%s'", TenantIdentifier, randomUUID.String()),
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceLabelSelectorKey: Array{
+														fmt.Sprintf("%s eq '%s'", TenantIdentifier, randomUUID.String()),
+													},
 												},
 											},
 										}
@@ -4565,17 +4621,19 @@ var _ = DescribeTestsFor(TestCase{
 										resp := CreateReferenceInstance(ctx.SMWithOAuthForTenant, "false", http.StatusNotFound, instance_sharing.ReferencedInstanceIDKey, "*", referencePlan.ID)
 										resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrNoResultsForReferenceSelector, ""))
 									})
-									It("should fail to provision with a label selector", func() {
-										parameters := make(map[string]interface{})
-										parameters[instance_sharing.ReferenceLabelSelectorKey] = Array{
-											"origin eq 'eu'",
-										}
+									It("should fail to provision with a label selector (not found)", func() {
 										randomUUID, _ := uuid.NewV4()
 										requestBody := Object{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters":       parameters,
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceLabelSelectorKey: Array{
+														"origin eq 'eu'",
+													},
+												},
+											},
 										}
 										resp := ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
 											WithQuery("async", false).
@@ -4628,17 +4686,19 @@ var _ = DescribeTestsFor(TestCase{
 										resp := CreateReferenceInstance(ctx.SMWithOAuthForTenant, "false", http.StatusNotFound, instance_sharing.ReferenceInstanceNameSelectorKey, instanceName, referencePlan.ID)
 										resp.JSON().Object().Equal(util.HandleInstanceSharingError(util.ErrNoResultsForReferenceSelector, ""))
 									})
-									It("should fail to provision with a label selector", func() {
-										parameters := make(map[string]interface{})
-										parameters[instance_sharing.ReferenceLabelSelectorKey] = Array{
-											"origin eq 'eu'",
-										}
+									It("should fail to provision with a label selector (not found)", func() {
 										randomUUID, _ := uuid.NewV4()
 										requestBody := Object{
 											"name":             "reference-instance-" + randomUUID.String(),
 											"service_plan_id":  referencePlan.ID,
 											"maintenance_info": "{}",
-											"parameters":       parameters,
+											"parameters": map[string]interface{}{
+												instance_sharing.SelectorsKey: map[string]interface{}{
+													instance_sharing.ReferenceLabelSelectorKey: Array{
+														"origin eq 'eu'",
+													},
+												},
+											},
 										}
 										resp := ctx.SMWithOAuthForTenant.POST(web.ServiceInstancesURL).
 											WithQuery("async", false).


### PR DESCRIPTION
# [Instance Sharing] Claim shared service instance by labels

## Motivation

Sharing a service instance between different scopes allows apps in different scopes to share databases, messaging queues, and other types of services. This enables development teams to share resource, while eliminates the use service bindings as keys and user-provided services or other means to maintain credentials of instances which were provisioned in another scope.

## User story

As a developer, I would like to be able to refer to a shared instance without the need to provide the ID of the original instance so that I could apply a robust automated script that can be executed in different landscapes and setups

## Approach

Implemented like the service plan selector
* Retrieve in advance the service instances that match the criteria of the labels.
* Filter the labeled instances comparing to the full list of shared instances.

## Pull Request status

* [x] Initial implementation
* [x] Refactoring
* [x] Unit tests
* [x] Integration tests

