### PR TITLE
don't fail validation when service manager default certificate is ava…

### DIFF
--- a/api/filters/checkBrokerCredentials.go
+++ b/api/filters/checkBrokerCredentials.go
@@ -2,6 +2,7 @@ package filters
 
 import (
 	"fmt"
+	"github.com/Peripli/service-manager/pkg/httpclient"
 	"net/http"
 
 	"github.com/Peripli/service-manager/pkg/util"
@@ -39,7 +40,8 @@ func (*CheckBrokerCredentialsFilter) Run(req *web.Request, next web.Handler) (*w
 }
 
 func credentialsMissing(basicFields []gjson.Result, tlsFields []gjson.Result) bool {
-	if (basicFields[0].Exists() && basicFields[1].Exists()) || (tlsFields[0].Exists() && tlsFields[1].Exists()) {
+	httpSettings := httpclient.GetHttpClientGlobalSettings()
+	if (basicFields[0].Exists() && basicFields[1].Exists()) || (tlsFields[0].Exists() && tlsFields[1].Exists()) || len(httpSettings.ServerCertificate) > 0 {
 		return false
 	}
 	return true

--- a/pkg/types/service_broker.go
+++ b/pkg/types/service_broker.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/Peripli/service-manager/pkg/httpclient"
 	"reflect"
 	"strconv"
 	"strings"
@@ -127,7 +128,8 @@ func (e *ServiceBroker) Validate() error {
 	if err := e.Labels.Validate(); err != nil {
 		return err
 	}
-	if e.Credentials == nil {
+	httpSettings := httpclient.GetHttpClientGlobalSettings()
+	if e.Credentials == nil && len(httpSettings.ServerCertificate) == 0 {
 		return errors.New("missing credentials")
 	}
 	return e.Credentials.Validate()


### PR DESCRIPTION
Currently, broker credentials validation fails if there is no basic authentication or broker tls configured. With new feature that uses service manager default certificate(mTLS) when communicating with broker, don't fail. 