### PR TITLE
adding sm_provided_credentials field that indicates that broker shoul…

### DIFF
--- a/api/filters/checkBrokerCredentials.go
+++ b/api/filters/checkBrokerCredentials.go
@@ -43,7 +43,7 @@ func (*CheckBrokerCredentialsFilter) Run(req *web.Request, next web.Handler) (*w
 
 func credentialsMissing(smBrokerCredentials gjson.Result, basicFields []gjson.Result, tlsFields []gjson.Result) error {
 	httpSettings := httpclient.GetHttpClientGlobalSettings()
-	if smBrokerCredentials.Exists() && smBrokerCredentials.Bool()  && len(httpSettings.ServerCertificate) == 0 {
+	if smBrokerCredentials.Exists() && smBrokerCredentials.Bool() && len(httpSettings.ServerCertificate) == 0 {
 		return errors.New("no sm provided credentials available, provide another type of credentials")
 	}
 	if (smBrokerCredentials.Exists() && smBrokerCredentials.Bool() || basicFields[0].Exists() && basicFields[1].Exists()) || (tlsFields[0].Exists() && tlsFields[1].Exists()) {

--- a/api/filters/checkBrokerCredentials.go
+++ b/api/filters/checkBrokerCredentials.go
@@ -27,7 +27,7 @@ func (*CheckBrokerCredentialsFilter) Name() string {
 
 func (*CheckBrokerCredentialsFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
 	brokerUrl := gjson.GetBytes(req.Body, "broker_url")
-	smBrokerCredentials := gjson.GetBytes(req.Body, "sm_provided_credentials")
+	smBrokerCredentials := gjson.GetBytes(req.Body, "sm_provided_tls_credentials")
 	basicFields := gjson.GetManyBytes(req.Body, fmt.Sprintf(basicCredentialsPath, "username"), fmt.Sprintf(basicCredentialsPath, "password"))
 	tlsFields := gjson.GetManyBytes(req.Body, fmt.Sprintf(tlsCredentialsPath, "client_certificate"), fmt.Sprintf(tlsCredentialsPath, "client_key"))
 	err := credentialsMissing(smBrokerCredentials, basicFields, tlsFields)

--- a/api/filters/checkBrokerCredentials.go
+++ b/api/filters/checkBrokerCredentials.go
@@ -43,13 +43,13 @@ func (*CheckBrokerCredentialsFilter) Run(req *web.Request, next web.Handler) (*w
 
 func credentialsMissing(smBrokerCredentials gjson.Result, basicFields []gjson.Result, tlsFields []gjson.Result) error {
 	httpSettings := httpclient.GetHttpClientGlobalSettings()
-	if smBrokerCredentials.Exists() && smBrokerCredentials.Bool() == true && len(httpSettings.ServerCertificate) == 0 {
-		return errors.New("No SM provided credentials available, provide another type of credentials")
+	if smBrokerCredentials.Exists() && smBrokerCredentials.Bool()  && len(httpSettings.ServerCertificate) == 0 {
+		return errors.New("no sm provided credentials available, provide another type of credentials")
 	}
-	if (smBrokerCredentials.Exists() == true && smBrokerCredentials.Bool() == true || basicFields[0].Exists() && basicFields[1].Exists()) || (tlsFields[0].Exists() && tlsFields[1].Exists()) {
+	if (smBrokerCredentials.Exists() && smBrokerCredentials.Bool() || basicFields[0].Exists() && basicFields[1].Exists()) || (tlsFields[0].Exists() && tlsFields[1].Exists()) {
 		return nil
 	}
-	return errors.New("Updating a URL of a broker requires its credentials")
+	return errors.New("updating a url of a broker requires its credentials")
 }
 
 func (*CheckBrokerCredentialsFilter) FilterMatchers() []web.FilterMatcher {

--- a/api/filters/checkBrokerCredentials.go
+++ b/api/filters/checkBrokerCredentials.go
@@ -46,7 +46,10 @@ func credentialsMissing(smBrokerCredentials gjson.Result, basicFields []gjson.Re
 	if smBrokerCredentials.Exists() && smBrokerCredentials.Bool() && len(httpSettings.ServerCertificate) == 0 {
 		return errors.New("no sm provided credentials available, provide another type of credentials")
 	}
-	if (smBrokerCredentials.Exists() && smBrokerCredentials.Bool() || basicFields[0].Exists() && basicFields[1].Exists()) || (tlsFields[0].Exists() && tlsFields[1].Exists()) {
+	smProvided := smBrokerCredentials.Exists() && smBrokerCredentials.Bool()
+	basic := basicFields[0].Exists() && basicFields[1].Exists()
+	tls := tlsFields[0].Exists() && tlsFields[1].Exists()
+	if tls || basic || smProvided {
 		return nil
 	}
 	return errors.New("updating a url of a broker requires its credentials")

--- a/api/filters/checkBrokerCredentials.go
+++ b/api/filters/checkBrokerCredentials.go
@@ -27,11 +27,11 @@ func (*CheckBrokerCredentialsFilter) Name() string {
 
 func (*CheckBrokerCredentialsFilter) Run(req *web.Request, next web.Handler) (*web.Response, error) {
 	brokerUrl := gjson.GetBytes(req.Body, "broker_url")
-	smBrokerCredentials:= gjson.GetBytes(req.Body,  "sm_provided_credentials")
+	smBrokerCredentials := gjson.GetBytes(req.Body, "sm_provided_credentials")
 	basicFields := gjson.GetManyBytes(req.Body, fmt.Sprintf(basicCredentialsPath, "username"), fmt.Sprintf(basicCredentialsPath, "password"))
 	tlsFields := gjson.GetManyBytes(req.Body, fmt.Sprintf(tlsCredentialsPath, "client_certificate"), fmt.Sprintf(tlsCredentialsPath, "client_key"))
-    err:=credentialsMissing(smBrokerCredentials,basicFields, tlsFields)
-	if brokerUrl.Exists() && err!=nil {
+	err := credentialsMissing(smBrokerCredentials, basicFields, tlsFields)
+	if brokerUrl.Exists() && err != nil {
 		return nil, &util.HTTPError{
 			ErrorType:   "BadRequest",
 			Description: err.Error(),
@@ -46,7 +46,7 @@ func credentialsMissing(smBrokerCredentials gjson.Result, basicFields []gjson.Re
 	if smBrokerCredentials.Exists() && smBrokerCredentials.Bool() == true && len(httpSettings.ServerCertificate) == 0 {
 		return errors.New("No SM provided credentials available, provide another type of credentials")
 	}
-	if ( smBrokerCredentials.Exists() == true && smBrokerCredentials.Bool() == true ||  basicFields[0].Exists() && basicFields[1].Exists()) || (tlsFields[0].Exists() && tlsFields[1].Exists()) {
+	if (smBrokerCredentials.Exists() == true && smBrokerCredentials.Bool() == true || basicFields[0].Exists() && basicFields[1].Exists()) || (tlsFields[0].Exists() && tlsFields[1].Exists()) {
 		return nil
 	}
 	return errors.New("Updating a URL of a broker requires its credentials")

--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -201,14 +201,14 @@ func buildProxy(targetBrokerURL *url.URL, logger *logrus.Entry, broker *types.Se
 		logger.Infof("Forwarded OSB request to service broker %s at %s", broker.Name, request.URL)
 	}
 
-	tlsConfig, err := broker.GetTLSConfig()
+	tlsConfig, err := broker.GetTLSConfig(logger.Context)
 	if err != nil {
 		return nil, err
 	}
 
 	if tlsConfig != nil {
 		logger.Infof("configuring broker tls for %s", broker.Name)
-		proxy.Transport = client.GetTransportWithTLS(tlsConfig, logger)
+		proxy.Transport = client.GetTransportWithTLS(tlsConfig)
 	}
 	proxy.ModifyResponse = func(response *http.Response) error {
 		logger.Infof("Service broker %s replied with status %d", broker.Name, response.StatusCode)

--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/Peripli/service-manager/pkg/httpclient"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -210,11 +209,6 @@ func buildProxy(targetBrokerURL *url.URL, logger *logrus.Entry, broker *types.Se
 	if tlsConfig != nil {
 		logger.Infof("configuring broker tls for %s", broker.Name)
 		proxy.Transport = client.GetTransportWithTLS(tlsConfig, logger)
-	} else {
-		proxy.Transport = http.DefaultTransport.(*http.Transport)
-		logger.Infof("using default tls configuration for broker %s, has client cert? %d",
-			broker.Name,
-			len(httpclient.GetHttpClientGlobalSettings().TLSCertificates))
 	}
 	proxy.ModifyResponse = func(response *http.Response) error {
 		logger.Infof("Service broker %s replied with status %d", broker.Name, response.StatusCode)

--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -201,7 +201,7 @@ func buildProxy(targetBrokerURL *url.URL, logger *logrus.Entry, broker *types.Se
 		logger.Infof("Forwarded OSB request to service broker %s at %s", broker.Name, request.URL)
 	}
 
-	tlsConfig, err := broker.GetTLSConfig(logger.Context)
+	tlsConfig, err := broker.GetTLSConfig(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/api/osb/osb_controller.go
+++ b/api/osb/osb_controller.go
@@ -201,14 +201,14 @@ func buildProxy(targetBrokerURL *url.URL, logger *logrus.Entry, broker *types.Se
 		logger.Infof("Forwarded OSB request to service broker %s at %s", broker.Name, request.URL)
 	}
 
-	tlsConfig, err := broker.GetTLSConfig(context.Background())
+	tlsConfig, err := broker.GetTLSConfig(logger)
 	if err != nil {
 		return nil, err
 	}
 
 	if tlsConfig != nil {
 		logger.Infof("configuring broker tls for %s", broker.Name)
-		proxy.Transport = client.GetTransportWithTLS(tlsConfig)
+		proxy.Transport = client.GetTransportWithTLS(tlsConfig, logger)
 	}
 	proxy.ModifyResponse = func(response *http.Response) error {
 		logger.Infof("Service broker %s replied with status %d", broker.Name, response.StatusCode)

--- a/api/osb/osb_controller_test.go
+++ b/api/osb/osb_controller_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/test/tls_settings"
 
-	"context"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -54,8 +53,7 @@ var _ = Describe("OSB Controller test", func() {
 	})
 
 	Describe("test osb create proxy", func() {
-		ctx:=context.Background()
-		logger := logrus.WithContext(ctx)
+		logger := logrus.NewEntry(logrus.New())
 		targetBrokerURL, err := url.Parse("http://example.com/proxy/")
 		if err != nil {
 			log.Fatal(err)

--- a/api/osb/osb_controller_test.go
+++ b/api/osb/osb_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/test/tls_settings"
 
+	"context"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -53,7 +54,8 @@ var _ = Describe("OSB Controller test", func() {
 	})
 
 	Describe("test osb create proxy", func() {
-		logger := logrus.NewEntry(logrus.New())
+		ctx:=context.Background()
+		logger := logrus.WithContext(ctx)
 		targetBrokerURL, err := url.Parse("http://example.com/proxy/")
 		if err != nil {
 			log.Fatal(err)

--- a/api/osb/utils.go
+++ b/api/osb/utils.go
@@ -14,7 +14,7 @@ import (
 func Get(doRequestWithClient util.DoRequestWithClientFunc, brokerAPIVersion string, ctx context.Context, broker *types.ServiceBroker, url string, resourceType string) ([]byte, error) {
 
 	log.C(ctx).Debugf("attempting to fetch %s from URL %s and broker with name %s", resourceType, url, broker.Name)
-	brokerClient, err := client.NewBrokerClient(broker, doRequestWithClient)
+	brokerClient, err := client.NewBrokerClient(broker, doRequestWithClient,ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/api/osb/utils.go
+++ b/api/osb/utils.go
@@ -14,7 +14,7 @@ import (
 func Get(doRequestWithClient util.DoRequestWithClientFunc, brokerAPIVersion string, ctx context.Context, broker *types.ServiceBroker, url string, resourceType string) ([]byte, error) {
 
 	log.C(ctx).Debugf("attempting to fetch %s from URL %s and broker with name %s", resourceType, url, broker.Name)
-	brokerClient, err := client.NewBrokerClient(broker, doRequestWithClient,ctx)
+	brokerClient, err := client.NewBrokerClient(broker, doRequestWithClient, ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/broker_client.go
+++ b/pkg/client/broker_client.go
@@ -32,7 +32,7 @@ type BrokerClient struct {
 	requestHandlerDecorated util.DoRequestFunc
 }
 
-func NewBrokerClient(broker *types.ServiceBroker, requestHandler util.DoRequestWithClientFunc,  ctx context.Context) (*BrokerClient, error) {
+func NewBrokerClient(broker *types.ServiceBroker, requestHandler util.DoRequestWithClientFunc, ctx context.Context) (*BrokerClient, error) {
 	tlsConfig, err := broker.GetTLSConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get client for broker %s: %v", broker.Name, err)

--- a/pkg/client/broker_client.go
+++ b/pkg/client/broker_client.go
@@ -32,8 +32,8 @@ type BrokerClient struct {
 	requestHandlerDecorated util.DoRequestFunc
 }
 
-func NewBrokerClient(broker *types.ServiceBroker, requestHandler util.DoRequestWithClientFunc) (*BrokerClient, error) {
-	tlsConfig, err := broker.GetTLSConfig()
+func NewBrokerClient(broker *types.ServiceBroker, requestHandler util.DoRequestWithClientFunc,  ctx context.Context) (*BrokerClient, error) {
+	tlsConfig, err := broker.GetTLSConfig(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get client for broker %s: %v", broker.Name, err)
 	}
@@ -66,7 +66,7 @@ func (bc *BrokerClient) authAndTlsDecorator(requestHandler util.DoRequestWithCli
 		if bc.tlsConfig != nil {
 			client = &http.Client{}
 			logger.Infof("configuring broker tls for %s", bc.broker.Name)
-			client.Transport = GetTransportWithTLS(bc.tlsConfig, logger)
+			client.Transport = GetTransportWithTLS(bc.tlsConfig)
 			return requestHandler(req, client)
 		}
 

--- a/pkg/client/broker_client.go
+++ b/pkg/client/broker_client.go
@@ -33,7 +33,7 @@ type BrokerClient struct {
 }
 
 func NewBrokerClient(broker *types.ServiceBroker, requestHandler util.DoRequestWithClientFunc, ctx context.Context) (*BrokerClient, error) {
-	tlsConfig, err := broker.GetTLSConfig(ctx)
+	tlsConfig, err := broker.GetTLSConfig(log.C(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("unable to get client for broker %s: %v", broker.Name, err)
 	}
@@ -66,7 +66,7 @@ func (bc *BrokerClient) authAndTlsDecorator(requestHandler util.DoRequestWithCli
 		if bc.tlsConfig != nil {
 			client = &http.Client{}
 			logger.Infof("configuring broker tls for %s", bc.broker.Name)
-			client.Transport = GetTransportWithTLS(bc.tlsConfig)
+			client.Transport = GetTransportWithTLS(bc.tlsConfig, logger)
 			return requestHandler(req, client)
 		}
 

--- a/pkg/client/broker_client.go
+++ b/pkg/client/broker_client.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/Peripli/service-manager/pkg/httpclient"
 	"github.com/Peripli/service-manager/pkg/log"
 	"github.com/Peripli/service-manager/pkg/types"
 	"github.com/Peripli/service-manager/pkg/util"
@@ -70,10 +69,6 @@ func (bc *BrokerClient) authAndTlsDecorator(requestHandler util.DoRequestWithCli
 			client.Transport = GetTransportWithTLS(bc.tlsConfig, logger)
 			return requestHandler(req, client)
 		}
-
-		logger.Infof("using default tls configuration for broker %s, has client cert? %d",
-			bc.broker.Name,
-			len(httpclient.GetHttpClientGlobalSettings().TLSCertificates))
 
 		return requestHandler(req, client)
 	}

--- a/pkg/client/broker_transport.go
+++ b/pkg/client/broker_transport.go
@@ -17,23 +17,14 @@ package client
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"github.com/Peripli/service-manager/pkg/httpclient"
-	"github.com/sirupsen/logrus"
 	"net/http"
 )
 
-func GetTransportWithTLS(tlsConfig *tls.Config, logger *logrus.Entry) *http.Transport {
+func GetTransportWithTLS(tlsConfig *tls.Config) *http.Transport {
 	transport := http.Transport{}
 	httpclient.ConfigureTransport(&transport)
 	transport.TLSClientConfig.Certificates = tlsConfig.Certificates
-	if len(tlsConfig.Certificates) > 0 {
-		cert, err := x509.ParseCertificate(tlsConfig.Certificates[0].Certificate[0])
-		if err == nil {
-			logger.Infof("sending certificate with the subject %+v,", cert.Subject.ToRDNSequence())
-		}
-	}
-
 	//prevents keeping idle connections when accessing to different broker hosts
 	transport.DisableKeepAlives = true
 	return &transport

--- a/pkg/client/broker_transport.go
+++ b/pkg/client/broker_transport.go
@@ -18,13 +18,15 @@ package client
 import (
 	"crypto/tls"
 	"github.com/Peripli/service-manager/pkg/httpclient"
+	"github.com/sirupsen/logrus"
 	"net/http"
 )
 
-func GetTransportWithTLS(tlsConfig *tls.Config) *http.Transport {
+func GetTransportWithTLS(tlsConfig *tls.Config, logger *logrus.Entry) *http.Transport {
 	transport := http.Transport{}
 	httpclient.ConfigureTransport(&transport)
 	transport.TLSClientConfig.Certificates = tlsConfig.Certificates
+	logger.Infof("configured mtls transport for the broker")
 	//prevents keeping idle connections when accessing to different broker hosts
 	transport.DisableKeepAlives = true
 	return &transport

--- a/pkg/client/broker_transport.go
+++ b/pkg/client/broker_transport.go
@@ -17,6 +17,7 @@ package client
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"github.com/Peripli/service-manager/pkg/httpclient"
 	"github.com/sirupsen/logrus"
 	"net/http"
@@ -26,7 +27,13 @@ func GetTransportWithTLS(tlsConfig *tls.Config, logger *logrus.Entry) *http.Tran
 	transport := http.Transport{}
 	httpclient.ConfigureTransport(&transport)
 	transport.TLSClientConfig.Certificates = tlsConfig.Certificates
-	logger.Infof("adding certificates to tls connection, added %d certificate/s", len(transport.TLSClientConfig.Certificates))
+	if len(tlsConfig.Certificates)>0 {
+		cert, err := x509.ParseCertificate(tlsConfig.Certificates[0].Certificate[0])
+		if err == nil {
+			logger.Infof("sending certificate with the subject %+v,", cert.Subject.ToRDNSequence())
+		}
+	}
+
 	//prevents keeping idle connections when accessing to different broker hosts
 	transport.DisableKeepAlives = true
 	return &transport

--- a/pkg/client/broker_transport.go
+++ b/pkg/client/broker_transport.go
@@ -27,7 +27,7 @@ func GetTransportWithTLS(tlsConfig *tls.Config, logger *logrus.Entry) *http.Tran
 	transport := http.Transport{}
 	httpclient.ConfigureTransport(&transport)
 	transport.TLSClientConfig.Certificates = tlsConfig.Certificates
-	if len(tlsConfig.Certificates)>0 {
+	if len(tlsConfig.Certificates) > 0 {
 		cert, err := x509.ParseCertificate(tlsConfig.Certificates[0].Certificate[0])
 		if err == nil {
 			logger.Infof("sending certificate with the subject %+v,", cert.Subject.ToRDNSequence())

--- a/pkg/types/credentials.go
+++ b/pkg/types/credentials.go
@@ -50,6 +50,7 @@ func (c *Credentials) MarshalJSON() ([]byte, error) {
 	if toMarshal.Basic == nil || toMarshal.Basic.Username == "" || toMarshal.Basic.Password == "" {
 		toMarshal.Basic = nil
 	}
+
 	if toMarshal.TLS == nil || toMarshal.TLS.Certificate == "" || toMarshal.TLS.Key == "" {
 		toMarshal.TLS = nil
 	}

--- a/pkg/types/credentials.go
+++ b/pkg/types/credentials.go
@@ -60,7 +60,7 @@ func (c *Credentials) MarshalJSON() ([]byte, error) {
 // Validate implements InputValidator and verifies all mandatory fields are populated
 func (c *Credentials) Validate() error {
 	if !c.TLSExists() && !c.BasicExists() && !c.SMProvidedTLSCredentials {
-		return errors.New("missing broker credentials: SM provided, basic or tls credentials are required")
+		return errors.New("missing broker credentials: SM provided mtls , basic or tls credentials are required")
 	}
 	if c.BasicExists() {
 		err := c.validateBasic()

--- a/pkg/types/credentials.go
+++ b/pkg/types/credentials.go
@@ -60,11 +60,11 @@ func (c *Credentials) MarshalJSON() ([]byte, error) {
 
 // Validate implements InputValidator and verifies all mandatory fields are populated
 func (c *Credentials) Validate() error {
-	httpSettings:= httpclient.GetHttpClientGlobalSettings()
-	isMTLSEnabled:=len(httpSettings.ServerCertificate) > 0
-	isBasicMissingCredentials :=c.Basic != nil && (c.Basic.Username =="" ||  c.Basic.Password == "")
-	isTLSMissingCredentials :=c.TLS != nil && (c.TLS.Certificate=="" || c.TLS.Key=="")
-	if c.TLS == nil && c.Basic == nil && c.SMProvidedCredentials == false{
+	httpSettings := httpclient.GetHttpClientGlobalSettings()
+	isMTLSEnabled := len(httpSettings.ServerCertificate) > 0
+	isBasicMissingCredentials := c.Basic != nil && (c.Basic.Username == "" || c.Basic.Password == "")
+	isTLSMissingCredentials := c.TLS != nil && (c.TLS.Certificate == "" || c.TLS.Key == "")
+	if c.TLS == nil && c.Basic == nil && c.SMProvidedCredentials == false {
 		return errors.New("missing broker credentials: SM provided, basic or tls credentials are required")
 	}
 	if c.SMProvidedCredentials == false && c.TLS == nil && isBasicMissingCredentials {
@@ -78,15 +78,15 @@ func (c *Credentials) Validate() error {
 	if c.SMProvidedCredentials == false && c.Basic == nil && isTLSMissingCredentials {
 		return errors.New("tls public certificate and key should be provided")
 	}
-	if c.TLS!=nil && !isTLSMissingCredentials && c.SMProvidedCredentials == true {
+	if c.TLS != nil && !isTLSMissingCredentials && c.SMProvidedCredentials == true {
 		return errors.New("only one of the options could be set, SM provided credentials or tls")
 	}
-	if c.SMProvidedCredentials && !isMTLSEnabled{
+	if c.SMProvidedCredentials && !isMTLSEnabled {
 		return errors.New("SM provided credentials are not supported in this region, set another type of credentials")
 	}
-	if c.TLS != nil && c.TLS.Certificate!="" &&  c.TLS.Key!="" {
+	if c.TLS != nil && c.TLS.Certificate != "" && c.TLS.Key != "" {
 		_, err := tls.X509KeyPair([]byte(c.TLS.Certificate), []byte(c.TLS.Key))
-		if err!=nil{
+		if err != nil {
 			return errors.New("invalidate TLS configuration: " + err.Error())
 		}
 	}

--- a/pkg/types/credentials.go
+++ b/pkg/types/credentials.go
@@ -67,7 +67,7 @@ func (c *Credentials) Validate() error {
 	if c.TLS == nil && c.Basic == nil && c.SMProvidedCredentials == false {
 		return errors.New("missing broker credentials: SM provided, basic or tls credentials are required")
 	}
-	if c.SMProvidedCredentials == false && c.TLS == nil && isBasicMissingCredentials {
+	if !c.SMProvidedCredentials && c.TLS == nil && isBasicMissingCredentials {
 		if c.Basic.Username == "" {
 			return errors.New("missing broker username")
 		}
@@ -75,10 +75,10 @@ func (c *Credentials) Validate() error {
 			return errors.New("missing broker password")
 		}
 	}
-	if c.SMProvidedCredentials == false && c.Basic == nil && isTLSMissingCredentials {
+	if !c.SMProvidedCredentials && c.Basic == nil && isTLSMissingCredentials {
 		return errors.New("tls public certificate and key should be provided")
 	}
-	if c.TLS != nil && !isTLSMissingCredentials && c.SMProvidedCredentials == true {
+	if c.TLS != nil && !isTLSMissingCredentials && c.SMProvidedCredentials {
 		return errors.New("only one of the options could be set, SM provided credentials or tls")
 	}
 	if c.SMProvidedCredentials && !isMTLSEnabled {

--- a/pkg/types/credentials.go
+++ b/pkg/types/credentials.go
@@ -40,7 +40,7 @@ type TLS struct {
 type Credentials struct {
 	Basic                 *Basic `json:"basic,omitempty"`
 	TLS                   *TLS   `json:"tls,omitempty"`
-	SMProvidedCredentials bool   `json:"sm_provided_credentials,omitempty"`
+	SMProvidedCredentials bool   `json:"sm_provided_tls_credentials,omitempty"`
 	Integrity             []byte `json:"-"`
 }
 

--- a/pkg/types/credentials.go
+++ b/pkg/types/credentials.go
@@ -38,10 +38,10 @@ type TLS struct {
 
 // Credentials credentials
 type Credentials struct {
-	Basic                 *Basic `json:"basic,omitempty"`
-	TLS                   *TLS   `json:"tls,omitempty"`
-	SMProvidedCredentials bool   `json:"sm_provided_tls_credentials,omitempty"`
-	Integrity             []byte `json:"-"`
+	Basic                    *Basic `json:"basic,omitempty"`
+	TLS                      *TLS   `json:"tls,omitempty"`
+	SMProvidedTLSCredentials bool   `json:"sm_provided_tls_credentials,omitempty"`
+	Integrity                []byte `json:"-"`
 }
 
 func (c *Credentials) MarshalJSON() ([]byte, error) {
@@ -64,10 +64,10 @@ func (c *Credentials) Validate() error {
 	isMTLSEnabled := len(httpSettings.ServerCertificate) > 0
 	isBasicMissingCredentials := c.Basic != nil && (c.Basic.Username == "" || c.Basic.Password == "")
 	isTLSMissingCredentials := c.TLS != nil && (c.TLS.Certificate == "" || c.TLS.Key == "")
-	if c.TLS == nil && c.Basic == nil && !c.SMProvidedCredentials {
+	if c.TLS == nil && c.Basic == nil && !c.SMProvidedTLSCredentials {
 		return errors.New("missing broker credentials: SM provided, basic or tls credentials are required")
 	}
-	if !c.SMProvidedCredentials && c.TLS == nil && isBasicMissingCredentials {
+	if !c.SMProvidedTLSCredentials && c.TLS == nil && isBasicMissingCredentials {
 		if c.Basic.Username == "" {
 			return errors.New("missing broker username")
 		}
@@ -75,13 +75,13 @@ func (c *Credentials) Validate() error {
 			return errors.New("missing broker password")
 		}
 	}
-	if !c.SMProvidedCredentials && c.Basic == nil && isTLSMissingCredentials {
+	if !c.SMProvidedTLSCredentials && c.Basic == nil && isTLSMissingCredentials {
 		return errors.New("tls public certificate and key should be provided")
 	}
-	if c.TLS != nil && !isTLSMissingCredentials && c.SMProvidedCredentials {
+	if c.TLS != nil && !isTLSMissingCredentials && c.SMProvidedTLSCredentials {
 		return errors.New("only one of the options could be set, SM provided credentials or tls")
 	}
-	if c.SMProvidedCredentials && !isMTLSEnabled {
+	if c.SMProvidedTLSCredentials && !isMTLSEnabled {
 		return errors.New("SM provided credentials are not supported in this region, set another type of credentials")
 	}
 	if c.TLS != nil && c.TLS.Certificate != "" && c.TLS.Key != "" {

--- a/pkg/types/credentials.go
+++ b/pkg/types/credentials.go
@@ -64,7 +64,7 @@ func (c *Credentials) Validate() error {
 	isMTLSEnabled := len(httpSettings.ServerCertificate) > 0
 	isBasicMissingCredentials := c.Basic != nil && (c.Basic.Username == "" || c.Basic.Password == "")
 	isTLSMissingCredentials := c.TLS != nil && (c.TLS.Certificate == "" || c.TLS.Key == "")
-	if c.TLS == nil && c.Basic == nil && c.SMProvidedCredentials == false {
+	if c.TLS == nil && c.Basic == nil && !c.SMProvidedCredentials {
 		return errors.New("missing broker credentials: SM provided, basic or tls credentials are required")
 	}
 	if !c.SMProvidedCredentials && c.TLS == nil && isBasicMissingCredentials {

--- a/pkg/types/credentials.go
+++ b/pkg/types/credentials.go
@@ -50,7 +50,6 @@ func (c *Credentials) MarshalJSON() ([]byte, error) {
 	if toMarshal.Basic == nil || toMarshal.Basic.Username == "" || toMarshal.Basic.Password == "" {
 		toMarshal.Basic = nil
 	}
-
 	if toMarshal.TLS == nil || toMarshal.TLS.Certificate == "" || toMarshal.TLS.Key == "" {
 		toMarshal.TLS = nil
 	}

--- a/pkg/types/service_broker.go
+++ b/pkg/types/service_broker.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/Peripli/service-manager/pkg/httpclient"
 	"reflect"
 	"strconv"
 	"strings"
@@ -45,13 +46,16 @@ type ServiceBroker struct {
 }
 
 func (e *ServiceBroker) GetTLSConfig() (*tls.Config, error) {
+	var tlsConfig tls.Config
 	if e.Credentials.TLS != nil && e.Credentials.TLS.Certificate != "" && e.Credentials.TLS.Key != "" {
-		var tlsConfig tls.Config
 		cert, err := tls.X509KeyPair([]byte(e.Credentials.TLS.Certificate), []byte(e.Credentials.TLS.Key))
 		if err != nil {
 			return nil, err
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
+		return &tlsConfig, nil
+	}else if e.Credentials.SMProvidedCredentials == true {
+		tlsConfig.Certificates = httpclient.GetHttpClientGlobalSettings().TLSCertificates
 		return &tlsConfig, nil
 	}
 

--- a/pkg/types/service_broker.go
+++ b/pkg/types/service_broker.go
@@ -24,10 +24,10 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Peripli/service-manager/pkg/httpclient"
+	"github.com/Peripli/service-manager/pkg/log"
 	"reflect"
 	"strconv"
 	"strings"
-	"github.com/Peripli/service-manager/pkg/log"
 )
 
 const maxNameLength = 255
@@ -46,7 +46,7 @@ type ServiceBroker struct {
 	Services    []*ServiceOffering `json:"-"`
 }
 
-func (e *ServiceBroker) GetTLSConfig( ctx context.Context) (*tls.Config, error) {
+func (e *ServiceBroker) GetTLSConfig(ctx context.Context) (*tls.Config, error) {
 	var tlsConfig tls.Config
 	logger := log.C(ctx)
 	if e.Credentials.TLS != nil && e.Credentials.TLS.Certificate != "" && e.Credentials.TLS.Key != "" {

--- a/pkg/types/service_broker.go
+++ b/pkg/types/service_broker.go
@@ -54,7 +54,7 @@ func (e *ServiceBroker) GetTLSConfig() (*tls.Config, error) {
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
 		return &tlsConfig, nil
-	}else if e.Credentials.SMProvidedCredentials == true {
+	} else if e.Credentials.SMProvidedCredentials == true {
 		tlsConfig.Certificates = httpclient.GetHttpClientGlobalSettings().TLSCertificates
 		return &tlsConfig, nil
 	}

--- a/pkg/types/service_broker.go
+++ b/pkg/types/service_broker.go
@@ -54,7 +54,7 @@ func (e *ServiceBroker) GetTLSConfig() (*tls.Config, error) {
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
 		return &tlsConfig, nil
-	} else if e.Credentials.SMProvidedCredentials {
+	} else if e.Credentials.SMProvidedTLSCredentials {
 		tlsConfig.Certificates = httpclient.GetHttpClientGlobalSettings().TLSCertificates
 		return &tlsConfig, nil
 	}

--- a/pkg/types/service_broker.go
+++ b/pkg/types/service_broker.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"github.com/Peripli/service-manager/pkg/log"
 )
 
 const maxNameLength = 255
@@ -45,17 +46,20 @@ type ServiceBroker struct {
 	Services    []*ServiceOffering `json:"-"`
 }
 
-func (e *ServiceBroker) GetTLSConfig() (*tls.Config, error) {
+func (e *ServiceBroker) GetTLSConfig( ctx context.Context) (*tls.Config, error) {
 	var tlsConfig tls.Config
+	logger := log.C(ctx)
 	if e.Credentials.TLS != nil && e.Credentials.TLS.Certificate != "" && e.Credentials.TLS.Key != "" {
 		cert, err := tls.X509KeyPair([]byte(e.Credentials.TLS.Certificate), []byte(e.Credentials.TLS.Key))
 		if err != nil {
 			return nil, err
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
+		logger.Infof("using mtls custom broker certificate  for the broker with name %s", e.Name)
 		return &tlsConfig, nil
 	} else if e.Credentials.SMProvidedTLSCredentials {
 		tlsConfig.Certificates = httpclient.GetHttpClientGlobalSettings().TLSCertificates
+		logger.Infof("using sm provided mtls certificate for the broker with name %s", e.Name)
 		return &tlsConfig, nil
 	}
 

--- a/pkg/types/service_broker.go
+++ b/pkg/types/service_broker.go
@@ -54,7 +54,7 @@ func (e *ServiceBroker) GetTLSConfig() (*tls.Config, error) {
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
 		return &tlsConfig, nil
-	} else if e.Credentials.SMProvidedCredentials == true {
+	} else if e.Credentials.SMProvidedCredentials {
 		tlsConfig.Certificates = httpclient.GetHttpClientGlobalSettings().TLSCertificates
 		return &tlsConfig, nil
 	}

--- a/pkg/types/service_broker.go
+++ b/pkg/types/service_broker.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/Peripli/service-manager/pkg/httpclient"
-	"github.com/Peripli/service-manager/pkg/log"
+	"github.com/sirupsen/logrus"
 	"reflect"
 	"strconv"
 	"strings"
@@ -46,9 +46,8 @@ type ServiceBroker struct {
 	Services    []*ServiceOffering `json:"-"`
 }
 
-func (e *ServiceBroker) GetTLSConfig(ctx context.Context) (*tls.Config, error) {
+func (e *ServiceBroker) GetTLSConfig(logger *logrus.Entry) (*tls.Config, error) {
 	var tlsConfig tls.Config
-	logger := log.C(ctx)
 	if e.Credentials.TLS != nil && e.Credentials.TLS.Certificate != "" && e.Credentials.TLS.Key != "" {
 		cert, err := tls.X509KeyPair([]byte(e.Credentials.TLS.Certificate), []byte(e.Credentials.TLS.Key))
 		if err != nil {

--- a/storage/interceptors/smaap_service_instance_interceptor.go
+++ b/storage/interceptors/smaap_service_instance_interceptor.go
@@ -724,7 +724,7 @@ func preparePrerequisites(ctx context.Context, repository storage.Repository, os
 	}
 	broker := brokerObject.(*types.ServiceBroker)
 
-	tlsConfig, err := broker.GetTLSConfig(ctx)
+	tlsConfig, err := broker.GetTLSConfig(log.C(ctx))
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/storage/interceptors/smaap_service_instance_interceptor.go
+++ b/storage/interceptors/smaap_service_instance_interceptor.go
@@ -18,10 +18,8 @@ package interceptors
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/Peripli/service-manager/pkg/httpclient"
 	"github.com/tidwall/gjson"
 	"math"
 	"net"
@@ -749,12 +747,7 @@ func preparePrerequisites(ctx context.Context, repository storage.Repository, os
 
 	if tlsConfig != nil {
 		osbClientConfig.TLSConfig = tlsConfig
-	} else if len(httpclient.GetHttpClientGlobalSettings().TLSCertificates) > 0 {
-		var defaultTLSConfig tls.Config
-		defaultTLSConfig.Certificates = httpclient.GetHttpClientGlobalSettings().TLSCertificates
-		osbClientConfig.TLSConfig = &defaultTLSConfig
 	}
-
 	osbClient, err := osbClientFunc(osbClientConfig)
 	if err != nil {
 		return nil, nil, nil, nil, err

--- a/storage/interceptors/smaap_service_instance_interceptor.go
+++ b/storage/interceptors/smaap_service_instance_interceptor.go
@@ -724,7 +724,7 @@ func preparePrerequisites(ctx context.Context, repository storage.Repository, os
 	}
 	broker := brokerObject.(*types.ServiceBroker)
 
-	tlsConfig, err := broker.GetTLSConfig()
+	tlsConfig, err := broker.GetTLSConfig(ctx)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/storage/postgres/broker.go
+++ b/storage/postgres/broker.go
@@ -39,7 +39,7 @@ type Broker struct {
 	TlsClientKey         string             `db:"tls_client_key"`
 	TlsClientCertificate string             `db:"tls_client_certificate"`
 	Catalog              sqlxtypes.JSONText `db:"catalog"`
-
+	SMProvidedCredentials bool              `db:"sm_provided_credentials"`
 	Services []*ServiceOffering `db:"-"`
 }
 
@@ -82,6 +82,7 @@ func (e *Broker) ToObject() (types.Object, error) {
 			Basic:     basic,
 			TLS:       tls,
 			Integrity: e.Integrity,
+			SMProvidedCredentials: e.SMProvidedCredentials,
 		},
 		Catalog:  getJSONRawMessage(e.Catalog),
 		Services: services,
@@ -120,6 +121,7 @@ func (*Broker) FromObject(object types.Object) (storage.Entity, error) {
 	}
 	if broker.Credentials != nil {
 		b.Integrity = broker.Credentials.Integrity
+		b.SMProvidedCredentials=broker.Credentials.SMProvidedCredentials
 
 		if broker.Credentials.Basic != nil {
 			b.Username = broker.Credentials.Basic.Username
@@ -130,6 +132,7 @@ func (*Broker) FromObject(object types.Object) (storage.Entity, error) {
 			b.TlsClientCertificate = broker.Credentials.TLS.Certificate
 			b.TlsClientKey = broker.Credentials.TLS.Key
 		}
+
 	}
 	return b, nil
 }

--- a/storage/postgres/broker.go
+++ b/storage/postgres/broker.go
@@ -30,17 +30,17 @@ import (
 //go:generate smgen storage broker github.com/Peripli/service-manager/pkg/types:ServiceBroker
 type Broker struct {
 	BaseEntity
-	Name                 string             `db:"name"`
-	Description          sql.NullString     `db:"description"`
-	BrokerURL            string             `db:"broker_url"`
-	Username             string             `db:"username"`
-	Password             string             `db:"password"`
-	Integrity            []byte             `db:"integrity"`
-	TlsClientKey         string             `db:"tls_client_key"`
-	TlsClientCertificate string             `db:"tls_client_certificate"`
-	Catalog              sqlxtypes.JSONText `db:"catalog"`
-	SMProvidedCredentials bool              `db:"sm_provided_credentials"`
-	Services []*ServiceOffering `db:"-"`
+	Name                  string             `db:"name"`
+	Description           sql.NullString     `db:"description"`
+	BrokerURL             string             `db:"broker_url"`
+	Username              string             `db:"username"`
+	Password              string             `db:"password"`
+	Integrity             []byte             `db:"integrity"`
+	TlsClientKey          string             `db:"tls_client_key"`
+	TlsClientCertificate  string             `db:"tls_client_certificate"`
+	Catalog               sqlxtypes.JSONText `db:"catalog"`
+	SMProvidedCredentials bool               `db:"sm_provided_credentials"`
+	Services              []*ServiceOffering `db:"-"`
 }
 
 func (e *Broker) ToObject() (types.Object, error) {
@@ -79,9 +79,9 @@ func (e *Broker) ToObject() (types.Object, error) {
 		Description: e.Description.String,
 		BrokerURL:   e.BrokerURL,
 		Credentials: &types.Credentials{
-			Basic:     basic,
-			TLS:       tls,
-			Integrity: e.Integrity,
+			Basic:                 basic,
+			TLS:                   tls,
+			Integrity:             e.Integrity,
 			SMProvidedCredentials: e.SMProvidedCredentials,
 		},
 		Catalog:  getJSONRawMessage(e.Catalog),
@@ -121,7 +121,7 @@ func (*Broker) FromObject(object types.Object) (storage.Entity, error) {
 	}
 	if broker.Credentials != nil {
 		b.Integrity = broker.Credentials.Integrity
-		b.SMProvidedCredentials=broker.Credentials.SMProvidedCredentials
+		b.SMProvidedCredentials = broker.Credentials.SMProvidedCredentials
 
 		if broker.Credentials.Basic != nil {
 			b.Username = broker.Credentials.Basic.Username

--- a/storage/postgres/broker.go
+++ b/storage/postgres/broker.go
@@ -39,7 +39,7 @@ type Broker struct {
 	TlsClientKey          string             `db:"tls_client_key"`
 	TlsClientCertificate  string             `db:"tls_client_certificate"`
 	Catalog               sqlxtypes.JSONText `db:"catalog"`
-	SMProvidedCredentials bool               `db:"sm_provided_credentials"`
+	SMProvidedCredentials bool               `db:"sm_provided_tls_credentials"`
 	Services              []*ServiceOffering `db:"-"`
 }
 

--- a/storage/postgres/broker.go
+++ b/storage/postgres/broker.go
@@ -79,10 +79,10 @@ func (e *Broker) ToObject() (types.Object, error) {
 		Description: e.Description.String,
 		BrokerURL:   e.BrokerURL,
 		Credentials: &types.Credentials{
-			Basic:                 basic,
-			TLS:                   tls,
-			Integrity:             e.Integrity,
-			SMProvidedCredentials: e.SMProvidedCredentials,
+			Basic:                    basic,
+			TLS:                      tls,
+			Integrity:                e.Integrity,
+			SMProvidedTLSCredentials: e.SMProvidedCredentials,
 		},
 		Catalog:  getJSONRawMessage(e.Catalog),
 		Services: services,
@@ -121,7 +121,7 @@ func (*Broker) FromObject(object types.Object) (storage.Entity, error) {
 	}
 	if broker.Credentials != nil {
 		b.Integrity = broker.Credentials.Integrity
-		b.SMProvidedCredentials = broker.Credentials.SMProvidedCredentials
+		b.SMProvidedCredentials = broker.Credentials.SMProvidedTLSCredentials
 
 		if broker.Credentials.Basic != nil {
 			b.Username = broker.Credentials.Basic.Username

--- a/storage/postgres/constant.go
+++ b/storage/postgres/constant.go
@@ -2,4 +2,4 @@ package postgres
 
 // todo: get automatically from folder
 // change this line with the latest version of the migrations:
-const latestMigrationVersion = "20210420120000"
+const latestMigrationVersion = "20210808120000"

--- a/storage/postgres/migrations/20210808120000_sm_provided_credentials.down.sql
+++ b/storage/postgres/migrations/20210808120000_sm_provided_credentials.down.sql
@@ -1,3 +1,1 @@
-BEGIN;
 ALTER TABLE brokers DROP COLUMN sm_provided_credentials;
-COMMIT;

--- a/storage/postgres/migrations/20210808120000_sm_provided_credentials.down.sql
+++ b/storage/postgres/migrations/20210808120000_sm_provided_credentials.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE brokers DROP COLUMN sm_provided_credentials;
+ALTER TABLE brokers DROP COLUMN sm_provided_tls_credentials;

--- a/storage/postgres/migrations/20210808120000_sm_provided_credentials.down.sql
+++ b/storage/postgres/migrations/20210808120000_sm_provided_credentials.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+ALTER TABLE brokers DROP COLUMN sm_provided_credentials;
+COMMIT;

--- a/storage/postgres/migrations/20210808120000_sm_provided_credentials.up.sql
+++ b/storage/postgres/migrations/20210808120000_sm_provided_credentials.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE brokers
+ADD COLUMN IF NOT EXISTS sm_provided_credentials BOOLEAN NOT NULL DEFAULT '0';
+
+COMMIT;

--- a/storage/postgres/migrations/20210808120000_sm_provided_credentials.up.sql
+++ b/storage/postgres/migrations/20210808120000_sm_provided_credentials.up.sql
@@ -1,2 +1,2 @@
 ALTER TABLE brokers
-ADD COLUMN IF NOT EXISTS sm_provided_credentials BOOLEAN NOT NULL DEFAULT '0';
+ADD COLUMN IF NOT EXISTS sm_provided_tls_credentials BOOLEAN NOT NULL DEFAULT '0';

--- a/storage/postgres/migrations/20210808120000_sm_provided_credentials.up.sql
+++ b/storage/postgres/migrations/20210808120000_sm_provided_credentials.up.sql
@@ -1,6 +1,2 @@
-BEGIN;
-
 ALTER TABLE brokers
 ADD COLUMN IF NOT EXISTS sm_provided_credentials BOOLEAN NOT NULL DEFAULT '0';
-
-COMMIT;

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -1344,13 +1344,13 @@ var _ = test.DescribeTestsFor(test.TestCase{
 
 								})
 							})
-							Context("empty all credentials" , func() {
+							Context("empty all credentials", func() {
 								It("should fail", func() {
 									updatedBrokerJSON := Object{
 										"name":        "updated_name",
 										"description": "updated_description",
 										"credentials": Object{
-											"sm_provided_credentials":false,
+											"sm_provided_credentials": false,
 											"basic": Object{
 												"username": "",
 												"password": "",

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -1360,7 +1360,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 									reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithMTLS).WithJSON(updatedBrokerJSON).
 										Expect()
 									reply.Status(http.StatusBadRequest)
-									reply.Body().Contains("missing broker username")
+									reply.Body().Contains("missing broker credentials: SM provided mtls , basic or tls credentials are required")
 									assertInvocationCount(brokerServerWithSMCertficate.CatalogEndpointRequests, 0)
 
 								})

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -1325,12 +1325,32 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								httpclient.Configure()
 							})
 
-							Context("no credentials provided", func() {
+							Context("empty  basic credentials, provided credentials still exist", func() {
 								It("should fail", func() {
 									updatedBrokerJSON := Object{
 										"name":        "updated_name",
 										"description": "updated_description",
 										"credentials": Object{
+											"basic": Object{
+												"username": "",
+												"password": "",
+											},
+										},
+									}
+									reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithMTLS).WithJSON(updatedBrokerJSON).
+										Expect()
+									reply.Status(http.StatusOK)
+									assertInvocationCount(brokerServerWithSMCertficate.CatalogEndpointRequests, 1)
+
+								})
+							})
+							Context("empty all credentials" , func() {
+								It("should fail", func() {
+									updatedBrokerJSON := Object{
+										"name":        "updated_name",
+										"description": "updated_description",
+										"credentials": Object{
+											"sm_provided_credentials":false,
 											"basic": Object{
 												"username": "",
 												"password": "",

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -628,7 +628,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 									res := ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerBasicServerMtls).
 										Expect().
 										Status(http.StatusCreated).JSON().Object()
-									expectedResponse:=Object{
+									expectedResponse := Object{
 										"name":        postBrokerBasicServerMtls["name"],
 										"broker_url":  brokerServerWithSMCertficate.URL(),
 										"description": postBrokerBasicServerMtls["description"],
@@ -643,12 +643,12 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							})
 							When("mtls with basic", func() {
 								It("should  succeed", func() {
-									req:= CopyObject(postBrokerBasicServerMtls)
-									req["credentials"].(Object)["basic"]=Object{
+									req := CopyObject(postBrokerBasicServerMtls)
+									req["credentials"].(Object)["basic"] = Object{
 										"username": brokerServerWithSMCertficate.Username,
 										"password": brokerServerWithSMCertficate.Password,
 									}
-									res:=ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(req).
+									res := ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(req).
 										Expect().Status(http.StatusCreated).JSON().Object()
 									res.ContainsMap(expectedBrokerServerWithServiceManagerMtlsAndBasicAuth)
 									assertInvocationCount(brokerServerWithSMCertficate.CatalogEndpointRequests, 1)
@@ -1249,10 +1249,10 @@ var _ = test.DescribeTestsFor(test.TestCase{
 										"client_certificate": tls_settings.ClientCertificate,
 										"client_key":         tls_settings.ClientKey,
 									},
-									"sm_provided_credentials" : true,
+									"sm_provided_credentials": true,
 								},
 							}
-							reply:=ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithTLS).WithJSON(updatedCredentials).
+							reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithTLS).WithJSON(updatedCredentials).
 								Expect()
 							reply.Status(http.StatusBadRequest)
 							reply.Body().Contains("only one of the options could be set, SM provided credentials or tls")
@@ -1264,12 +1264,12 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								"credentials": Object{
 									"tls": Object{
 										"client_certificate": "",
-										"client_key":        "",
+										"client_key":         "",
 									},
-									"sm_provided_credentials" : true,
+									"sm_provided_credentials": true,
 								},
 							}
-							reply:=ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithTLS).WithJSON(updatedCredentials).
+							reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithTLS).WithJSON(updatedCredentials).
 								Expect()
 							reply.Status(http.StatusBadRequest)
 							reply.Body().Contains("SM provided credentials are not supported in this region")
@@ -1355,7 +1355,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 												"username": "",
 												"password": "",
 											},
-											"sm_provided_credentials":true,
+											"sm_provided_credentials": true,
 										},
 									}
 									reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithMTLS).WithJSON(updatedBrokerJSON).
@@ -1381,7 +1381,6 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							"credentials": Object{
 								"basic": Object{
 									"username": brokerServer.Username,
-
 								},
 							},
 						}

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -1378,6 +1378,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 											"sm_provided_tls_credentials": true,
 										},
 									}
+
 									reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithMTLS).WithJSON(updatedBrokerJSON).
 										Expect()
 									reply.Status(http.StatusOK)

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -180,7 +180,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 					"broker_url":  brokerServerWithSMCertficate.URL(),
 					"description": brokerDescription,
 					"credentials": Object{
-						"sm_provided_credentials": true,
+						"sm_provided_tls_credentials": true,
 					},
 					"labels": labels,
 				}
@@ -190,7 +190,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 					"broker_url":  brokerServerWithSMCertficate.URL(),
 					"description": brokerDescription,
 					"credentials": Object{
-						"sm_provided_credentials": true,
+						"sm_provided_tls_credentials": true,
 						"basic": Object{
 							"username": brokerServerWithSMCertficate.Username,
 							"password": brokerServerWithSMCertficate.Password,
@@ -633,7 +633,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 										"broker_url":  brokerServerWithSMCertficate.URL(),
 										"description": postBrokerBasicServerMtls["description"],
 										"credentials": Object{
-											"sm_provided_credentials": true,
+											"sm_provided_tls_credentials": true,
 										},
 									}
 									res.ContainsMap(expectedResponse)
@@ -1249,7 +1249,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 										"client_certificate": tls_settings.ClientCertificate,
 										"client_key":         tls_settings.ClientKey,
 									},
-									"sm_provided_credentials": true,
+									"sm_provided_tls_credentials": true,
 								},
 							}
 							reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithTLS).WithJSON(updatedCredentials).
@@ -1266,7 +1266,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 										"client_certificate": "",
 										"client_key":         "",
 									},
-									"sm_provided_credentials": true,
+									"sm_provided_tls_credentials": true,
 								},
 							}
 							reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithTLS).WithJSON(updatedCredentials).
@@ -1350,7 +1350,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 										"name":        "updated_name",
 										"description": "updated_description",
 										"credentials": Object{
-											"sm_provided_credentials": false,
+											"sm_provided_tls_credentials": false,
 											"basic": Object{
 												"username": "",
 												"password": "",
@@ -1375,7 +1375,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 												"username": "",
 												"password": "",
 											},
-											"sm_provided_credentials": true,
+											"sm_provided_tls_credentials": true,
 										},
 									}
 									reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithMTLS).WithJSON(updatedBrokerJSON).

--- a/test/broker_test/broker_test.go
+++ b/test/broker_test/broker_test.go
@@ -94,7 +94,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 				postBrokerRequestWithTLSToWrongBrokerServer            Object
 				postBrokerRequestWithTLSNoCert                         Object
 				labels                                                 Object
-				postBrokerServerMtls                                   Object
+				postBrokerBasicServerMtls                              Object
 				postBrokerRequestWithLabels                            labeledBroker
 
 				repository storage.Repository
@@ -175,15 +175,12 @@ var _ = test.DescribeTestsFor(test.TestCase{
 					"labels": labels,
 				}
 
-				postBrokerServerMtls = Object{
+				postBrokerBasicServerMtls = Object{
 					"name":        brokerServerWithServiceManagerMtlsName,
 					"broker_url":  brokerServerWithSMCertficate.URL(),
 					"description": brokerDescription,
 					"credentials": Object{
-						"basic": Object{
-							"username": brokerServerWithSMCertficate.Username,
-							"password": brokerServerWithSMCertficate.Password,
-						},
+						"sm_provided_credentials": true,
 					},
 					"labels": labels,
 				}
@@ -193,6 +190,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 					"broker_url":  brokerServerWithSMCertficate.URL(),
 					"description": brokerDescription,
 					"credentials": Object{
+						"sm_provided_credentials": true,
 						"basic": Object{
 							"username": brokerServerWithSMCertficate.Username,
 							"password": brokerServerWithSMCertficate.Password,
@@ -625,24 +623,45 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								settings.ServerCertificateKey = tls_settings.ServerManagerCertificateKey
 
 							})
-							When("basic auth is configured", func() {
+							When("sm provided credentials requested", func() {
 								It("ok", func() {
-									res := ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerServerMtls).
+									res := ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerBasicServerMtls).
 										Expect().
 										Status(http.StatusCreated).JSON().Object()
-									res.ContainsMap(expectedBrokerServerWithServiceManagerMtlsAndBasicAuth)
+									expectedResponse:=Object{
+										"name":        postBrokerBasicServerMtls["name"],
+										"broker_url":  brokerServerWithSMCertficate.URL(),
+										"description": postBrokerBasicServerMtls["description"],
+										"credentials": Object{
+											"sm_provided_credentials": true,
+										},
+									}
+									res.ContainsMap(expectedResponse)
 									res.NotContainsKey("tls")
 									assertInvocationCount(brokerServerWithSMCertficate.CatalogEndpointRequests, 1)
 								})
 							})
+							When("mtls with basic", func() {
+								It("should  succeed", func() {
+									req:= CopyObject(postBrokerBasicServerMtls)
+									req["credentials"].(Object)["basic"]=Object{
+										"username": brokerServerWithSMCertficate.Username,
+										"password": brokerServerWithSMCertficate.Password,
+									}
+									res:=ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(req).
+										Expect().Status(http.StatusCreated).JSON().Object()
+									res.ContainsMap(expectedBrokerServerWithServiceManagerMtlsAndBasicAuth)
+									assertInvocationCount(brokerServerWithSMCertficate.CatalogEndpointRequests, 1)
+								})
+							})
 
-							When("basic auth is not configured", func() {
+							When("no credentials are provided", func() {
 								It("should fail", func() {
-									req := CopyObject(postBrokerServerMtls)
+									req := CopyObject(postBrokerBasicServerMtls)
 									delete(req, "credentials")
 									ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(req).
 										Expect().
-										Status(http.StatusBadRequest).JSON().Object()
+										Status(http.StatusBadRequest)
 
 								})
 
@@ -676,7 +695,7 @@ var _ = test.DescribeTestsFor(test.TestCase{
 							})
 
 							It("returns error", func() {
-								ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerServerMtls).
+								ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerBasicServerMtls).
 									Expect().
 									Status(http.StatusBadGateway).Body()
 
@@ -1222,9 +1241,160 @@ var _ = test.DescribeTestsFor(test.TestCase{
 								Status(http.StatusOK)
 							assertInvocationCount(brokerServerWithBrokerCertificate.CatalogEndpointRequests, 1)
 						})
+
+						It("when tls credentials and sm provided credential", func() {
+							updatedCredentials := Object{
+								"credentials": Object{
+									"tls": Object{
+										"client_certificate": tls_settings.ClientCertificate,
+										"client_key":         tls_settings.ClientKey,
+									},
+									"sm_provided_credentials" : true,
+								},
+							}
+							reply:=ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithTLS).WithJSON(updatedCredentials).
+								Expect()
+							reply.Status(http.StatusBadRequest)
+							reply.Body().Contains("only one of the options could be set, SM provided credentials or tls")
+							assertInvocationCount(brokerServerWithBrokerCertificate.CatalogEndpointRequests, 0)
+						})
+
+						It("when emptying tls custom credentials but sm default tls is not available", func() {
+							updatedCredentials := Object{
+								"credentials": Object{
+									"tls": Object{
+										"client_certificate": "",
+										"client_key":        "",
+									},
+									"sm_provided_credentials" : true,
+								},
+							}
+							reply:=ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithTLS).WithJSON(updatedCredentials).
+								Expect()
+							reply.Status(http.StatusBadRequest)
+							reply.Body().Contains("SM provided credentials are not supported in this region")
+							assertInvocationCount(brokerServerWithBrokerCertificate.CatalogEndpointRequests, 0)
+						})
+
+						It("when tls is used ", func() {
+							updatedCredentials := Object{
+								"credentials": Object{
+									"tls": Object{
+										"client_certificate": tls_settings.ClientCertificate,
+										"client_key":         tls_settings.ClientKey,
+									},
+								},
+							}
+							ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithTLS).WithJSON(updatedCredentials).
+								Expect().
+								Status(http.StatusOK)
+							assertInvocationCount(brokerServerWithBrokerCertificate.CatalogEndpointRequests, 1)
+						})
+						Context("default mTLS", func() {
+							var settings *httpclient.Settings
+							var brokerIDWithMTLS string
+							BeforeEach(func() {
+								settings = ctx.Config.HTTPClient
+								settings.SkipSSLValidation = false
+								settings.RootCACertificates = []string{tls_settings.BrokerRootCertificate}
+								settings.ServerCertificate = tls_settings.ServerManagerCertificate
+								settings.ServerCertificateKey = tls_settings.ServerManagerCertificateKey
+								httpclient.SetHTTPClientGlobalSettings(settings)
+								httpclient.Configure()
+								http.DefaultTransport.(*http.Transport).TLSClientConfig.ServerName = "localhost"
+
+								replyWithMTLS := ctx.SMWithOAuth.POST(web.ServiceBrokersURL).WithJSON(postBrokerBasicServerMtls).
+									Expect().
+									Status(http.StatusCreated).
+									JSON().Object()
+
+								brokerIDWithMTLS = replyWithMTLS.Value("id").String().Raw()
+								assertInvocationCount(brokerServerWithSMCertficate.CatalogEndpointRequests, 1)
+								brokerServer.ResetCallHistory()
+								brokerServerWithSMCertficate.ResetCallHistory()
+
+							})
+							AfterEach(func() {
+								http.DefaultTransport.(*http.Transport).TLSClientConfig = nil
+								settings.TLSCertificates = []tls.Certificate{}
+								settings.ServerCertificate = ""
+								settings.ServerCertificateKey = ""
+								settings.SkipSSLValidation = true
+								settings.RootCACertificates = []string{}
+								httpclient.SetHTTPClientGlobalSettings(settings)
+								httpclient.Configure()
+							})
+
+							Context("no credentials provided", func() {
+								It("should fail", func() {
+									updatedBrokerJSON := Object{
+										"name":        "updated_name",
+										"description": "updated_description",
+										"credentials": Object{
+											"basic": Object{
+												"username": "",
+												"password": "",
+											},
+										},
+									}
+									reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithMTLS).WithJSON(updatedBrokerJSON).
+										Expect()
+									reply.Status(http.StatusBadRequest)
+									reply.Body().Contains("missing broker username")
+									assertInvocationCount(brokerServerWithSMCertficate.CatalogEndpointRequests, 0)
+
+								})
+							})
+							Context("use sm default credentials", func() {
+								It("should succeed", func() {
+									updatedBrokerJSON := Object{
+										"name":        "updated_name",
+										"description": "updated_description",
+										"credentials": Object{
+											"basic": Object{
+												"username": "",
+												"password": "",
+											},
+											"sm_provided_credentials":true,
+										},
+									}
+									reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerIDWithMTLS).WithJSON(updatedBrokerJSON).
+										Expect()
+									reply.Status(http.StatusOK)
+									assertInvocationCount(brokerServerWithSMCertficate.CatalogEndpointRequests, 1)
+									byID := query.ByField(query.EqualsOperator, "id", brokerIDWithMTLS)
+									dbObj, err := repository.Get(context.TODO(), types.ServiceBrokerType, byID)
+									Expect(err).ToNot(HaveOccurred())
+									brokerFromDB := dbObj.(*types.ServiceBroker)
+									Expect(brokerFromDB.Credentials.Basic.Username).To(BeEmpty())
+
+								})
+
+							})
+						})
 					})
 
-					It("returns 200", func() {
+					It("only username is updated, should fail", func() {
+						brokerServer.Username = "updatedUsername"
+						brokerServer.Password = "updatedPassword"
+						updatedCredentials := Object{
+							"credentials": Object{
+								"basic": Object{
+									"username": brokerServer.Username,
+
+								},
+							},
+						}
+						reply := ctx.SMWithOAuth.PATCH(web.ServiceBrokersURL + "/" + brokerID).
+							WithJSON(updatedCredentials).
+							Expect()
+						reply.Status(http.StatusBadRequest)
+						reply.Body().Contains("401 Unauthorized")
+						assertInvocationCount(brokerServer.CatalogEndpointRequests, 0)
+
+					})
+
+					It("valid basic auth returns 200", func() {
 						brokerServer.Username = "updatedUsername"
 						brokerServer.Password = "updatedPassword"
 						updatedCredentials := Object{


### PR DESCRIPTION
When a broker is registered, at least one of the  authentication options should be chosen:
* basic 
* custom TLS
*  sm provided  tls credentials 
Basic could be set with custom TLS or SM-provided tls  credentials. Setting SM provided  tls credentials together with broker customer tls is not allowed. 

If SM-provided credentials are chosen, each connection made to the broker will be TLS with SM client certificate. 
