### PR TITLE
oidc add pem format validation

### DIFF
--- a/pkg/auth/oidc/oidc_test.go
+++ b/pkg/auth/oidc/oidc_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Service Manager Auth strategy test", func() {
 					Expect(client).ToNot(BeNil())
 				}
 			},
-			Entry("mTLS with invalid certificate & key",
+			Entry("mTLS with valid certificate & key",
 				&auth.Options{
 					Certificate:   tls_settings.ClientCertificate,
 					Key:           tls_settings.ClientKey,

--- a/pkg/auth/oidc/oidc_test.go
+++ b/pkg/auth/oidc/oidc_test.go
@@ -197,6 +197,14 @@ var _ = Describe("Service Manager Auth strategy test", func() {
 					ClientID:      "client-id",
 				},
 				"no such file or directory"),
+			Entry("mTLS certificate provided with file, key by input string - returns error",
+				&auth.Options{
+					Certificate:   "certificate.pem",
+					Key:           "key",
+					TokenEndpoint: "http://token-endpoint",
+					ClientID:      "client-id",
+				},
+				"both certificate and key must be provided as file or as string"),
 		)
 		DescribeTable("NewClient",
 			func(options *auth.Options, token *auth.Token, expectedErrMsg string, expetedToken *auth.Token) {

--- a/pkg/auth/oidc/oidc_test.go
+++ b/pkg/auth/oidc/oidc_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Service Manager Auth strategy test", func() {
 		}
 
 		DescribeTable("mTLS oidc client",
-			func(options *auth.Options, token *auth.Token, expectedErrMsg string, expetedToken *auth.Token) {
+			func(options *auth.Options, expectedErrMsg string) {
 				client, err := NewClient(options, token)
 
 				if expectedErrMsg != "" {
@@ -180,14 +180,7 @@ var _ = Describe("Service Manager Auth strategy test", func() {
 					TokenEndpoint: "http://token-endpoint",
 					ClientID:      "client-id",
 				},
-				nil,
-				"",
-				nil),
-			Entry("mTLS Valid token - reuses the token", &auth.Options{
-				Certificate: tls_settings.ClientCertificate,
-				Key:         tls_settings.ClientKey,
-				ClientID:    "client-id",
-			}, newToken(-1*time.Hour), "", token),
+				""),
 			Entry("mTLS invalid certificate - returns error",
 				&auth.Options{
 					Certificate:   "certificate",
@@ -195,9 +188,7 @@ var _ = Describe("Service Manager Auth strategy test", func() {
 					TokenEndpoint: "http://token-endpoint",
 					ClientID:      "client-id",
 				},
-				newToken(-1*time.Hour),
-				"tls: failed to find any PEM data in certificate input",
-				nil),
+				"tls: failed to find any PEM data in certificate input"),
 			Entry("mTLS invalid certificate file - returns error",
 				&auth.Options{
 					Certificate:   "certificate.pem",
@@ -205,9 +196,7 @@ var _ = Describe("Service Manager Auth strategy test", func() {
 					TokenEndpoint: "http://token-endpoint",
 					ClientID:      "client-id",
 				},
-				newToken(-1*time.Hour),
-				"no such file or directory",
-				nil),
+				"no such file or directory"),
 		)
 		DescribeTable("NewClient",
 			func(options *auth.Options, token *auth.Token, expectedErrMsg string, expetedToken *auth.Token) {

--- a/pkg/auth/util/util.go
+++ b/pkg/auth/util/util.go
@@ -29,31 +29,44 @@ import (
 
 // BuildHTTPClient builds custom http client with configured ssl validation / mtls
 func BuildHTTPClient(options *auth.Options) (*http.Client, error) {
+	if options.MtlsEnabled() {
+		return newMtlsClient(options)
+	} else {
+		return newClient(options)
+	}
+}
+
+func newClient(options *auth.Options) (*http.Client, error) {
+	client := getClient()
+	if options.SSLDisabled {
+		client.Transport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	return client, nil
+}
+
+func newMtlsClient(options *auth.Options) (*http.Client, error) {
 	var err error
 	var cert tls.Certificate
+
 	client := getClient()
 
-	if options.MtlsEnabled() {
-		certBytes := []byte(options.Certificate)
-		keyBytes := []byte(options.Key)
-		if pemFile(certBytes) && pemFile(keyBytes) {
-			cert, err = tls.LoadX509KeyPair(options.Certificate, options.Key)
-		} else {
-			cert, err = tls.X509KeyPair(certBytes, keyBytes)
-		}
-		if err != nil {
-			return nil, err
-		}
+	certBytes := []byte(options.Certificate)
+	keyBytes := []byte(options.Key)
 
-		client.Transport.(*http.Transport).TLSClientConfig = &tls.Config{
-			Certificates: []tls.Certificate{cert},
-		}
-
-		return client, nil
+	if pemFile(certBytes) != pemFile(keyBytes) {
+		return nil, fmt.Errorf("both certificate and key must be provided as file or as string")
+	}
+	if pemFile(certBytes) && pemFile(keyBytes) {
+		cert, err = tls.LoadX509KeyPair(options.Certificate, options.Key)
 	} else {
-		if options.SSLDisabled {
-			client.Transport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-		}
+		cert, err = tls.X509KeyPair(certBytes, keyBytes)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	client.Transport.(*http.Transport).TLSClientConfig = &tls.Config{
+		Certificates: []tls.Certificate{cert},
 	}
 
 	return client, nil

--- a/pkg/auth/util/util.go
+++ b/pkg/auth/util/util.go
@@ -63,8 +63,7 @@ func BuildHTTPClient(options *auth.Options) (*http.Client, error) {
 func pemFormat(data []byte) bool {
 	pemStart := []byte("\n-----BEGIN ")
 	pemEnd := []byte("\n-----END ")
-	pemEndOfLine := []byte("-----")
-	if bytes.HasPrefix(data, pemStart[1:]) && bytes.Contains(data, pemEnd) && bytes.HasSuffix(data, pemEndOfLine) {
+	if bytes.HasPrefix(data, pemStart[1:]) && bytes.Contains(data, pemEnd) {
 		return true
 	}
 	return false

--- a/pkg/auth/util/util.go
+++ b/pkg/auth/util/util.go
@@ -36,11 +36,10 @@ func BuildHTTPClient(options *auth.Options) (*http.Client, error) {
 	if options.MtlsEnabled() {
 		certBytes := []byte(options.Certificate)
 		keyBytes := []byte(options.Key)
-		if pemFormat(certBytes) && pemFormat(keyBytes) {
-			cert, err = tls.X509KeyPair(certBytes, keyBytes)
-		} else {
-			// attempt load cert & key pair from file:
+		if pemFile(certBytes) && pemFile(keyBytes) {
 			cert, err = tls.LoadX509KeyPair(options.Certificate, options.Key)
+		} else {
+			cert, err = tls.X509KeyPair(certBytes, keyBytes)
 		}
 		if err != nil {
 			return nil, err
@@ -60,10 +59,9 @@ func BuildHTTPClient(options *auth.Options) (*http.Client, error) {
 	return client, nil
 }
 
-func pemFormat(data []byte) bool {
-	pemStart := []byte("\n-----BEGIN ")
-	pemEnd := []byte("\n-----END ")
-	if bytes.HasPrefix(data, pemStart[1:]) && bytes.Contains(data, pemEnd) {
+func pemFile(data []byte) bool {
+	fileType := []byte(".pem")
+	if bytes.HasSuffix(data, fileType) {
 		return true
 	}
 	return false

--- a/pkg/auth/util/util.go
+++ b/pkg/auth/util/util.go
@@ -74,10 +74,7 @@ func newMtlsClient(options *auth.Options) (*http.Client, error) {
 
 func pemFile(data []byte) bool {
 	fileType := []byte(".pem")
-	if bytes.HasSuffix(data, fileType) {
-		return true
-	}
-	return false
+	return bytes.HasSuffix(data, fileType)
 }
 
 func ConvertBackSlashN(originalValue string) string {


### PR DESCRIPTION
# Accept pem file or pem value for oidc client
## Motivation

Allow setting an OIDC client via file or string

## Approach

Checks if the certificate & key input has `.pem` suffix -> read file.
else -> read input's value.
