### PR TITLE
Fearure  orm support for subqueries

### DIFF
--- a/pkg/query/operators.go
+++ b/pkg/query/operators.go
@@ -32,7 +32,8 @@ const (
 	// LessThanOrEqualOperator takes two operands and tests if the left is lesser than or equal the right
 	LessThanOrEqualOperator leOperator = "le"
 	// InOperator takes two operands and tests if the left is contained in the right
-	InOperator inOperator = "in"
+	InOperator         inOperator         = "in"
+	InSubqueryOperator inSubqueryOperator = "inSubquery"
 	// NotInOperator takes two operands and tests if the left is not contained in the right
 	NotInOperator notInOperator = "notin"
 	// NotExistsSubquery receives a sub-query as single left-operand and checks the sub-query for rows existence. If there're no rows then it will return TRUE, otherwise FALSE.
@@ -170,6 +171,24 @@ func (containsOperator) IsNullable() bool {
 }
 
 func (containsOperator) IsNumeric() bool {
+	return false
+}
+
+type inSubqueryOperator string
+
+func (o inSubqueryOperator) String() string {
+	return string(o)
+}
+
+func (inSubqueryOperator) Type() OperatorType {
+	return UnivariateOperator
+}
+
+func (inSubqueryOperator) IsNullable() bool {
+	return false
+}
+
+func (inSubqueryOperator) IsNumeric() bool {
 	return false
 }
 

--- a/pkg/query/selection.go
+++ b/pkg/query/selection.go
@@ -48,6 +48,8 @@ const (
 	ResultQuery CriterionType = "resultQuery"
 	// ExistQuery denotes that the query should test for the existence of any record in a given sub-query
 	ExistQuery CriterionType = "existQuery"
+	// InQuery denotes that the query
+	Subquery CriterionType = "subQuery"
 )
 
 // OperatorType represents the type of the query operator
@@ -86,7 +88,7 @@ var (
 		InOperator, NotInOperator, EqualsOrNilOperator, ContainsOperator,
 	}
 	// CriteriaTypes returns the supported query criteria types
-	CriteriaTypes = []CriterionType{FieldQuery, LabelQuery, ExistQuery}
+	CriteriaTypes = []CriterionType{FieldQuery, LabelQuery, ExistQuery, Subquery}
 )
 
 // Operator is a query operator
@@ -124,6 +126,10 @@ func ByNotExists(subQuery string) Criterion {
 
 func ByExists(subQuery string) Criterion {
 	return NewCriterion("", ExistsSubquery, []string{subQuery}, ExistQuery)
+}
+
+func BySubquery(operator Operator, leftOp string, subQuery string) Criterion {
+	return NewCriterion(leftOp, operator, []string{subQuery}, Subquery)
 }
 
 // ByLabel constructs a new criterion for label querying
@@ -188,7 +194,7 @@ func (c Criterion) Validate() error {
 		return &util.UnsupportedQueryError{Message: fmt.Sprintf("separator %s is not allowed in %s with left operand \"%s\".", Separator, c.Type, c.LeftOp)}
 	}
 	for _, op := range c.RightOp {
-		if strings.ContainsRune(op, '\n') && c.Type != ExistQuery {
+		if strings.ContainsRune(op, '\n') && c.Type != ExistQuery && c.Type != Subquery {
 			return &util.UnsupportedQueryError{Message: fmt.Sprintf("%s with key \"%s\" has value \"%s\" contaning forbidden new line character", c.Type, c.LeftOp, op)}
 		}
 	}

--- a/pkg/query/selection_test.go
+++ b/pkg/query/selection_test.go
@@ -124,106 +124,142 @@ new line`))
 
 	Describe("Parse query", func() {
 		for _, queryType := range CriteriaTypes {
-			Context("With no query", func() {
-				It("Should return empty criteria", func() {
-					criteria, err := Parse(queryType, "")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(len(criteria)).To(Equal(0))
+			Describe(string("queryType - "+queryType), func() {
+				queryType := queryType
+				Context("With no query", func() {
+					It("Should return empty criteria", func() {
+						criteria, err := Parse(queryType, "")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(len(criteria)).To(Equal(0))
+					})
 				})
-			})
 
-			Context("With missing query operator", func() {
-				It("Should return an error", func() {
-					criteria, err := Parse(queryType, "leftop_rightop")
-					Expect(err).To(HaveOccurred())
-					Expect(criteria).To(BeNil())
-				})
-			})
-
-			Context("When there is an invalid field query", func() {
-				It("Should return an error", func() {
-					criteria, err := Parse(queryType, "leftop lt 'rightop'")
-					Expect(err).To(HaveOccurred())
-					Expect(criteria).To(BeNil())
-				})
-			})
-
-			Context("When passing multivariate query", func() {
-				It("Should be ok", func() {
-					criteria, err := Parse(queryType, "leftop in ('rightop', 'rightop2')")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(criteria).To(ConsistOf(NewCriterion("leftop", InOperator, []string{"rightop2", "rightop"}, queryType)))
-				})
-			})
-
-			Context("When passing multiple queries", func() {
-				It("Should build criteria", func() {
-					criteria, err := Parse(queryType, "leftop1 in ('rightop','rightop2') and leftop2 eq 'rightop3'")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(criteria).To(ConsistOf(NewCriterion("leftop1", InOperator, []string{"rightop2", "rightop"}, queryType), NewCriterion("leftop2", EqualsOperator, []string{"rightop3"}, queryType)))
-				})
-			})
-
-			Context("Operator is unsupported", func() {
-				It("Should return error", func() {
-					criteria, err := Parse(queryType, "leftop1 @ ('rightop', 'rightop2')")
-					Expect(err).To(HaveOccurred())
-					Expect(criteria).To(BeNil())
-				})
-			})
-
-			Context("Right operand is empty", func() {
-				It("Should be ok", func() {
-					criteria, err := Parse(queryType, "leftop1 in ()")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(criteria).ToNot(BeNil())
-					Expect(criteria).To(ConsistOf(NewCriterion("leftop1", InOperator, []string{""}, queryType)))
-				})
-			})
-			Context("Multivariate operator with right operand without opening brace", func() {
-				It("Should return error", func() {
-					criteria, err := Parse(queryType, "leftop in 'rightop','rightop2')")
-					Expect(err).To(HaveOccurred())
-					Expect(criteria).To(BeNil())
-				})
-			})
-			Context("Multivariate operator with right operand without closing brace", func() {
-				It("Should return error", func() {
-					criteria, err := Parse(queryType, "leftop in ('rightop','rightop2'")
-					Expect(err).To(HaveOccurred())
-					Expect(criteria).To(BeNil())
-				})
-			})
-			Context("Right operand with escaped quote", func() {
-				It("Should be okay", func() {
-					criteria, err := Parse(queryType, "leftop1 eq 'right''op'")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(criteria).ToNot(BeNil())
-					Expect(criteria).To(ConsistOf(NewCriterion("leftop1", EqualsOperator, []string{"right'op"}, queryType)))
-				})
-			})
-			Context("Complex right operand", func() {
-				It("Should be okay", func() {
-					rightOp := "this is a mixed, input example. It contains symbols   words ! -h@ppy p@rs'ng"
-					escaped := strings.Replace(rightOp, "'", "''", -1)
-					criteria, err := Parse(queryType, fmt.Sprintf("leftop1 eq '%s'", escaped))
-					Expect(err).ToNot(HaveOccurred())
-					Expect(criteria).ToNot(BeNil())
-					Expect(criteria).To(ConsistOf(NewCriterion("leftop1", EqualsOperator, []string{rightOp}, queryType)))
-				})
-			})
-
-			Context("Duplicate query key", func() {
-				It("Should return error", func() {
-					//ExistQuery type doesn't support left operands nor it excepts any operators aside from NotExist/Exist operators
-					if queryType != ExistQuery {
-						criteria, err := Parse(queryType, "leftop1 eq 'rightop' and leftop1 eq 'rightop2'")
+				Context("With missing query operator", func() {
+					It("Should return an error", func() {
+						criteria, err := Parse(queryType, "leftop_rightop")
 						Expect(err).To(HaveOccurred())
 						Expect(criteria).To(BeNil())
-					}
+					})
+				})
+
+				Context("When there is an invalid field query", func() {
+					It("Should return an error", func() {
+						criteria, err := Parse(queryType, "leftop lt 'rightop'")
+						Expect(err).To(HaveOccurred())
+						Expect(criteria).To(BeNil())
+					})
+				})
+
+				Context("When passing multivariate query", func() {
+					It("Should be ok", func() {
+						criteria, err := Parse(queryType, "leftop in ('rightop', 'rightop2')")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(criteria).To(ConsistOf(NewCriterion("leftop", InOperator, []string{"rightop2", "rightop"}, queryType)))
+					})
+				})
+
+				Context("When passing multiple queries", func() {
+					It("Should build criteria", func() {
+						criteria, err := Parse(queryType, "leftop1 in ('rightop','rightop2') and leftop2 eq 'rightop3'")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(criteria).To(ConsistOf(NewCriterion("leftop1", InOperator, []string{"rightop2", "rightop"}, queryType), NewCriterion("leftop2", EqualsOperator, []string{"rightop3"}, queryType)))
+					})
+				})
+
+				Context("Operator is unsupported", func() {
+					It("Should return error", func() {
+						criteria, err := Parse(queryType, "leftop1 @ ('rightop', 'rightop2')")
+						Expect(err).To(HaveOccurred())
+						Expect(criteria).To(BeNil())
+					})
+				})
+
+				Context("Right operand is empty", func() {
+					It("Should be ok", func() {
+						criteria, err := Parse(queryType, "leftop1 in ()")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(criteria).ToNot(BeNil())
+						Expect(criteria).To(ConsistOf(NewCriterion("leftop1", InOperator, []string{""}, queryType)))
+					})
+				})
+				Context("Multivariate operator with right operand without opening brace", func() {
+					It("Should return error", func() {
+						criteria, err := Parse(queryType, "leftop in 'rightop','rightop2')")
+						Expect(err).To(HaveOccurred())
+						Expect(criteria).To(BeNil())
+					})
+				})
+				Context("Multivariate operator with right operand without closing brace", func() {
+					It("Should return error", func() {
+						criteria, err := Parse(queryType, "leftop in ('rightop','rightop2'")
+						Expect(err).To(HaveOccurred())
+						Expect(criteria).To(BeNil())
+					})
+				})
+				Context("Right operand with escaped quote", func() {
+					It("Should be okay", func() {
+						criteria, err := Parse(queryType, "leftop1 eq 'right''op'")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(criteria).ToNot(BeNil())
+						Expect(criteria).To(ConsistOf(NewCriterion("leftop1", EqualsOperator, []string{"right'op"}, queryType)))
+					})
+				})
+				Context("Complex right operand", func() {
+					It("Should be okay", func() {
+						rightOp := "this is a mixed, input example. It contains symbols   words ! -h@ppy p@rs'ng"
+						escaped := strings.Replace(rightOp, "'", "''", -1)
+						criteria, err := Parse(queryType, fmt.Sprintf("leftop1 eq '%s'", escaped))
+						Expect(err).ToNot(HaveOccurred())
+						Expect(criteria).ToNot(BeNil())
+						Expect(criteria).To(ConsistOf(NewCriterion("leftop1", EqualsOperator, []string{rightOp}, queryType)))
+					})
+				})
+
+				Context("Duplicate query key", func() {
+					It("Should return error", func() {
+						//ExistQuery type doesn't support left operands nor it excepts any operators aside from NotExist/Exist operators
+						if queryType == LabelQuery {
+							criteria, err := Parse(queryType, "leftop1 eq 'rightop' and leftop1 eq 'rightop2'")
+							Expect(err).To(HaveOccurred())
+							Expect(criteria).To(BeNil())
+						}
+					})
+				})
+
+				Context("When separator is not properly escaped in first query value", func() {
+					It("Should return error", func() {
+						criteria, err := Parse(queryType, "leftop1 eq 'not'escaped' and leftOp2 eq 'rightOp'")
+						Expect(err).To(HaveOccurred())
+						Expect(criteria).To(BeNil())
+					})
+				})
+
+				Context("When separator is not escaped in value", func() {
+					It("Trims the value to the separator", func() {
+						criteria, err := Parse(queryType, "leftop1 eq 'not'escaped'")
+						Expect(err).To(HaveOccurred())
+						Expect(criteria).To(BeNil())
+					})
+				})
+
+				Context("When using equals or operators", func() {
+					It("should build the right ge query", func() {
+						criteria, err := Parse(FieldQuery, "leftop ge -1.35")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(criteria).ToNot(BeNil())
+						expectedQuery := ByField(GreaterThanOrEqualOperator, "leftop", "-1.35")
+						Expect(criteria).To(ConsistOf(expectedQuery))
+					})
+
+					It("should build the right le query", func() {
+						criteria, err := Parse(FieldQuery, "leftop le 3")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(criteria).ToNot(BeNil())
+						expectedQuery := ByField(LessThanOrEqualOperator, "leftop", "3")
+						Expect(criteria).To(ConsistOf(expectedQuery))
+					})
 				})
 			})
-
 			for _, op := range Operators {
 				op := op
 				for _, queryType := range []CriterionType{FieldQuery, LabelQuery} {
@@ -260,41 +296,8 @@ new line`))
 					})
 				}
 			}
-
-			Context("When separator is not properly escaped in first query value", func() {
-				It("Should return error", func() {
-					criteria, err := Parse(queryType, "leftop1 eq 'not'escaped' and leftOp2 eq 'rightOp'")
-					Expect(err).To(HaveOccurred())
-					Expect(criteria).To(BeNil())
-				})
-			})
-
-			Context("When separator is not escaped in value", func() {
-				It("Trims the value to the separator", func() {
-					criteria, err := Parse(queryType, "leftop1 eq 'not'escaped'")
-					Expect(err).To(HaveOccurred())
-					Expect(criteria).To(BeNil())
-				})
-			})
-
-			Context("When using equals or operators", func() {
-				It("should build the right ge query", func() {
-					criteria, err := Parse(FieldQuery, "leftop ge -1.35")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(criteria).ToNot(BeNil())
-					expectedQuery := ByField(GreaterThanOrEqualOperator, "leftop", "-1.35")
-					Expect(criteria).To(ConsistOf(expectedQuery))
-				})
-
-				It("should build the right le query", func() {
-					criteria, err := Parse(FieldQuery, "leftop le 3")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(criteria).ToNot(BeNil())
-					expectedQuery := ByField(LessThanOrEqualOperator, "leftop", "3")
-					Expect(criteria).To(ConsistOf(expectedQuery))
-				})
-			})
 		}
+
 	})
 
 	DescribeTable("Validate Criterion",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,21 @@
+sonar.projectBaseDir=.
+sonar.scm.provider=git
+sonar.sources=.
+sonar.inclusions=**/*.go
+sonar.exclusions=**/*test,**/*Test,**/test/**/*,**/docs/**/*
+sonar.tests=.
+sonar.test.inclusions=**/*test.go,**/*Tests.go,**/mocks/*.go,**/test/**/*
+sonar.test.exclusions=**/vendor/**
+sonar.go.coverage.reportPaths=./cover.out
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+sonar.pullrequest.provider=github
+sonar.dynamicAnalysis=reuseReports
+sonar.cfamily.build-wrapper-output=.
+sonar.language=go
+sonar.coverage.exclusions=**/*test*,**/*Test*,**/test/**/*
+
+sonar.issue.ignore.multicriteria=e1,e2
+sonar.issue.ignore.multicriteria.e1.ruleKey=go:S3776
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.go
+sonar.issue.ignore.multicriteria.e2.ruleKey=go:S1192
+sonar.issue.ignore.multicriteria.e2.resourceKey=**/*.go

--- a/storage/postgres/query_builder.go
+++ b/storage/postgres/query_builder.go
@@ -356,14 +356,20 @@ func (pq *pgQuery) WithCriteria(criteria ...query.Criterion) *pgQuery {
 			})
 		case query.ResultQuery:
 			pq.processResultCriteria(criterion)
-
 		case query.ExistQuery:
 			pq.fieldsWhereClause.children = append(pq.fieldsWhereClause.children, &whereClauseTree{
 				criterion: criterion,
 				dbTags:    pq.entityTags,
 				tableName: pq.entityTableName,
 			})
+		case query.Subquery:
+			pq.fieldsWhereClause.children = append(pq.fieldsWhereClause.children, &whereClauseTree{
+				criterion: criterion,
+				dbTags:    pq.entityTags,
+				tableName: pq.entityTableName,
+			})
 		}
+
 	}
 
 	return pq

--- a/storage/sub_query.go
+++ b/storage/sub_query.go
@@ -6,6 +6,7 @@ type SubQuery int
 
 const (
 	QueryForAllLastOperationsPerResource SubQuery = iota
+	QueryForAllNotLastOperationsPerResource
 	QueryForOperationsWithResource
 	QueryForTenantScopedServiceOfferings
 	QueryForInstanceChildrenByLabel
@@ -40,6 +41,15 @@ var subQueries = map[SubQuery]string{
         GROUP BY resource_id, resource_type) LAST_OPERATIONS ON 
     op.paging_sequence = LAST_OPERATIONS.paging_sequence
     WHERE operations.id = op.id`,
+	QueryForAllNotLastOperationsPerResource: `
+	SELECT op.id 
+	FROM OPERATIONS op
+	LEFT JOIN (
+		SELECT MAX(OPERATIONS.PAGING_SEQUENCE) PAGING_SEQUENCE 
+		FROM OPERATIONS 
+		GROUP BY RESOURCE_ID, RESOURCE_TYPE
+	) max_op ON op.PAGING_SEQUENCE = max_op.PAGING_SEQUENCE
+	WHERE max_op.PAGING_SEQUENCE IS NULL`,
 	QueryForOperationsWithResource: `
     SELECT id
     FROM {{.RESOURCE_TABLE}}

--- a/test/query_test/query_test.go
+++ b/test/query_test/query_test.go
@@ -245,6 +245,16 @@ var _ = Describe("Service Manager Query", func() {
 					Expect(listContains(list, "latestOpForInstance1"))
 					Expect(listContains(list, "latestOpForInstance2"))
 				})
+
+				It("should return only the operations being NOT last operation for their corresponding instances", func() {
+					criteria := []query.Criterion{query.BySubquery(query.InSubqueryOperator, "id", storage.GetSubQuery(storage.QueryForAllNotLastOperationsPerResource))}
+
+					list, err := repository.List(context.Background(), types.OperationType, criteria...)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(list.Len()).To(BeEquivalentTo(2))
+					Expect(listContains(list, "oldestOpForInstance1"))
+					Expect(listContains(list, "oldestOpForInstance2"))
+				})
 			})
 
 		})


### PR DESCRIPTION
## Motivation

SM ORM does not support sub-queries. Adding the functionality in order to solve performance issues with "exists queries"

## Approach

Add new Criterion Type. 

## Pull Request status

* [x] Initial implementation
* [x] Unit tests
* [ ] Integration tests
